### PR TITLE
Add CI workflow for automated linting and testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run lint
+        run: bun run check
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run tests
+        run: bun test


### PR DESCRIPTION
## Summary

Added GitHub Actions CI workflow to automate code quality checks on pull requests and pushes to main.

## Changes

- Created `.github/workflows/ci.yml` with two parallel jobs:
  - **Lint**: Runs `bun run check` (Biome + TypeScript type checking)
  - **Test**: Runs `bun test`

## Workflow Triggers

- Push to `main` branch
- Pull requests targeting `main`

## Benefits

- Automated code quality enforcement
- Faster feedback on PRs with parallel job execution
- Catches lint and test failures before merge
- Complements existing publish workflow

## Testing

The workflow will run automatically on this PR.
