### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/leonardodipace/semola/security/code-scanning/2](https://github.com/leonardodipace/semola/security/code-scanning/2)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions used by this workflow. Since the jobs only check out code, install dependencies, lint, and run tests, they only need read access to repository contents.

The best minimal fix is to add a workflow-level `permissions` block near the top of `.github/workflows/ci.yml`, just under the `name: CI` line, setting `contents: read`. This will apply to all jobs (`lint` and `test`) because they do not define their own `permissions`. No other functionality needs to change, and no additional methods or imports are needed.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

between the existing `name: CI` line and the `on:` block. This ensures the `GITHUB_TOKEN` has only read access to repository contents for this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
