### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/leonardodipace/semola/security/code-scanning/1](https://github.com/leonardodipace/semola/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions:` block that grants only the minimal required scopes for the `GITHUB_TOKEN`. For this workflow, the jobs only need to read repository contents (for `actions/checkout`) and do not interact with issues, pull requests, or other writable resources, so `contents: read` is sufficient.

The best fix with no functional change is to add a top-level `permissions:` block applying to all jobs. This should be placed near the top of `.github/workflows/ci.yml`, after the `name:` and before the `on:` block, to clearly scope it to the entire workflow. No additional imports or external dependencies are needed; this is purely a YAML configuration change.

Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between lines 2 and 3 in the provided snippet (i.e., after `name: CI` and its blank line, before `on:`). This ensures both `lint` and `test` jobs run with a read-only `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
