### PR TITLE
Replace predicate functions with helper functions in Policy module

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,23 +156,29 @@ cleanup.start();
 ### Check Permissions
 
 ```typescript
-import { Policy } from "semola/policy";
+import { Policy, eq, has } from "semola/policy";
 
-type User = { id: number; role: string };
+type User = { id: number; role: string; permissions: string[] };
 
 const policy = new Policy<User>();
 
-// Allow admins to edit any resource
+// Allow admins full access
 policy.allow({
   action: ["create", "update", "delete"],
-  conditions: { role: "admin" },
+  conditions: { role: eq("admin") },
   reason: "Admins have full access",
 });
 
-// Check if user can edit
-const user: User = { id: 1, role: "admin" };
+// Allow users with a specific permission
+policy.allow({
+  action: "read",
+  conditions: { permissions: has("posts:read") },
+});
+
+// Check if user can perform an action
+const user: User = { id: 1, role: "admin", permissions: [] };
 const result = policy.can("update", user);
-console.log(result.allowed); // true or false
+console.log(result.allowed); // true
 ```
 
 ### Internationalize Your App

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -5,7 +5,7 @@ A type-safe policy-based authorization system for defining and enforcing access 
 ## Import
 
 ```typescript
-import { Policy } from "semola/policy";
+import { Policy, eq, gt, startsWith, has, and } from "semola/policy";
 ```
 
 ## API
@@ -44,11 +44,11 @@ policy.allow({
   action: ["create", "update"],
 });
 
-// Allow with a predicate function
+// Allow with a helper function
 policy.allow({
   action: "read",
   conditions: {
-    title: (v) => v.startsWith("Public"),
+    title: startsWith("Public"),
   },
 });
 ```
@@ -102,7 +102,7 @@ policy.can("delete");
 type Action = "read" | "create" | "update" | "delete" | (string & {});
 
 type Conditions<T> = {
-  [K in keyof T]?: T[K] | ((value: T[K]) => boolean);
+  [K in keyof T]?: T[K] | ConditionHelper<T[K]>;
 };
 
 type CanResult = {
@@ -116,12 +116,95 @@ type CanResult = {
 - **Type-safe conditions**: Conditions are validated against the entity type
 - **Flexible actions**: Built-in CRUD actions plus custom string actions
 - **Array actions**: Register multiple actions in a single `allow` or `forbid` call
-- **Predicate conditions**: Use functions for dynamic condition matching
+- **Helper functions**: Rich set of typed helpers for comparisons, strings, arrays, and null checks
+- **Composable logic**: Combine helpers with `and`, `or`, `not` for complex conditions
+- **Adapter-ready**: Each helper carries `operator` and `value` metadata for serialization
 - **Multiple conditions**: Rules can match multiple object properties (AND logic)
 - **Allow/Forbid semantics**: Explicit permission and denial rules
 - **Human-readable reasons**: Optional explanations for authorization decisions
 - **No match defaults to deny**: Conservative security model
 - **Zero dependencies**: Pure TypeScript implementation
+
+## Helpers
+
+Helper functions express conditions beyond simple equality. Each helper is type-safe and carries metadata (`operator`, `value`) for use in adapters.
+
+### Comparison
+
+| Helper       | Description           |
+| ------------ | --------------------- |
+| `eq(value)`  | Equal to              |
+| `neq(value)` | Not equal to          |
+| `gt(value)`  | Greater than          |
+| `gte(value)` | Greater than or equal |
+| `lt(value)`  | Less than             |
+| `lte(value)` | Less than or equal    |
+
+### Logic
+
+| Helper            | Description                    |
+| ----------------- | ------------------------------ |
+| `not(helper)`     | Negates a helper               |
+| `and(...helpers)` | All helpers must match         |
+| `or(...helpers)`  | At least one helper must match |
+
+### String
+
+| Helper                | Description               |
+| --------------------- | ------------------------- |
+| `startsWith(prefix)`  | String starts with prefix |
+| `endsWith(suffix)`    | String ends with suffix   |
+| `includes(substring)` | String contains substring |
+| `matches(pattern)`    | String matches a regex    |
+
+### Array
+
+| Helper          | Description                                       |
+| --------------- | ------------------------------------------------- |
+| `has(item)`     | Array contains item (or all items if array given) |
+| `hasAny(items)` | Array contains at least one item                  |
+| `hasLength(n)`  | Length equals `n`, or `{ min?, max? }` range      |
+| `isEmpty()`     | Array or string is empty                          |
+
+### Null / Undefined
+
+| Helper        | Description                        |
+| ------------- | ---------------------------------- |
+| `isDefined()` | Value is not `null` or `undefined` |
+| `isNullish()` | Value is `null` or `undefined`     |
+
+```typescript
+import { Policy, eq, gt, startsWith, has, and, not } from "semola/policy";
+
+type Post = {
+  id: number;
+  title: string;
+  authorId: number;
+  status: "draft" | "published";
+  tags: string[];
+};
+
+const policy = new Policy<Post>();
+
+// Exact value match
+policy.allow({ action: "read", conditions: { status: "published" } });
+
+// Helper conditions
+policy.allow({
+  action: "read",
+  conditions: { title: startsWith("Public") },
+});
+
+policy.allow({
+  action: "update",
+  conditions: { authorId: gt(0), status: not(eq("published")) },
+});
+
+policy.allow({
+  action: "read",
+  conditions: { tags: has("featured") },
+});
+```
 
 ## Usage Example
 

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -35,7 +35,7 @@ policy.allow({
   action: "read",
   reason: "Public posts are visible to everyone",
   conditions: {
-    status: "published",
+    status: eq("published"),
   },
 });
 
@@ -63,7 +63,7 @@ policy.forbid({
   action: "update",
   reason: "Published posts cannot be modified",
   conditions: {
-    status: "published",
+    status: eq("published"),
   },
 });
 
@@ -102,7 +102,7 @@ policy.can("delete");
 type Action = "read" | "create" | "update" | "delete" | (string & {});
 
 type Conditions<T> = {
-  [K in keyof T]?: T[K] | ConditionHelper<T[K]>;
+  [K in keyof T]?: ConditionHelper<T[K]>;
 };
 
 type CanResult = {
@@ -186,8 +186,7 @@ type Post = {
 
 const policy = new Policy<Post>();
 
-// Exact value match
-policy.allow({ action: "read", conditions: { status: "published" } });
+policy.allow({ action: "read", conditions: { status: eq("published") } });
 
 // Helper conditions
 policy.allow({
@@ -209,7 +208,7 @@ policy.allow({
 ## Usage Example
 
 ```typescript
-import { Policy } from "semola/policy";
+import { Policy, eq } from "semola/policy";
 
 type Post = {
   id: number;
@@ -225,7 +224,7 @@ policy.allow({
   action: "read",
   reason: "Published posts are publicly accessible",
   conditions: {
-    status: "published",
+    status: eq("published"),
   },
 });
 
@@ -233,7 +232,7 @@ policy.allow({
   action: "update",
   reason: "Draft posts can be edited",
   conditions: {
-    status: "draft",
+    status: eq("draft"),
   },
 });
 
@@ -241,7 +240,7 @@ policy.forbid({
   action: "delete",
   reason: "Published posts cannot be deleted",
   conditions: {
-    status: "published",
+    status: eq("published"),
   },
 });
 

--- a/src/lib/policy/helpers.test.ts
+++ b/src/lib/policy/helpers.test.ts
@@ -291,6 +291,14 @@ describe("hasAny", () => {
     expect(hasAny<string>([]).fn(["tech"])).toBe(false);
   });
 
+  test("returns true when single item is in array", () => {
+    expect(hasAny("tech").fn(["tech", "business"])).toBe(true);
+  });
+
+  test("returns false when single item is not in array", () => {
+    expect(hasAny("finance").fn(["tech", "business"])).toBe(false);
+  });
+
   test("carries correct metadata", () => {
     const items = ["a", "b"];
 

--- a/src/lib/policy/helpers.test.ts
+++ b/src/lib/policy/helpers.test.ts
@@ -1,0 +1,555 @@
+import { describe, expect, test } from "bun:test";
+import {
+  and,
+  endsWith,
+  eq,
+  gt,
+  gte,
+  has,
+  hasAny,
+  hasLength,
+  includes,
+  isDefined,
+  isEmpty,
+  isNullish,
+  lt,
+  lte,
+  matches,
+  neq,
+  not,
+  or,
+  startsWith,
+} from "./helpers.js";
+import { Policy } from "./index.js";
+
+describe("eq", () => {
+  test("returns true when value strictly equals condition", () => {
+    expect(eq("draft").fn("draft")).toBe(true);
+  });
+
+  test("returns false when value does not equal condition", () => {
+    expect(eq("draft").fn("published")).toBe(false);
+  });
+
+  test("carries correct metadata", () => {
+    const helper = eq(42);
+
+    expect(helper.__isConditionHelper).toBe(true);
+    expect(helper.operator).toBe("eq");
+    expect(helper.value).toBe(42);
+  });
+});
+
+describe("neq", () => {
+  test("returns true when value differs", () => {
+    expect(neq("draft").fn("published")).toBe(true);
+  });
+
+  test("returns false when value equals condition", () => {
+    expect(neq("draft").fn("draft")).toBe(false);
+  });
+
+  test("carries correct metadata", () => {
+    expect(neq(1).operator).toBe("neq");
+  });
+});
+
+describe("gt", () => {
+  test("returns true when actual is greater", () => {
+    expect(gt(5).fn(10)).toBe(true);
+  });
+
+  test("returns false when actual equals condition", () => {
+    expect(gt(5).fn(5)).toBe(false);
+  });
+
+  test("returns false when actual is less", () => {
+    expect(gt(5).fn(3)).toBe(false);
+  });
+
+  test("works with Date values", () => {
+    const past = new Date("2020-01-01");
+    const future = new Date("2030-01-01");
+
+    expect(gt(past).fn(future)).toBe(true);
+    expect(gt(future).fn(past)).toBe(false);
+  });
+
+  test("carries correct metadata", () => {
+    expect(gt(5).operator).toBe("gt");
+    expect(gt(5).value).toBe(5);
+  });
+});
+
+describe("gte", () => {
+  test("returns true when actual is greater", () => {
+    expect(gte(5).fn(10)).toBe(true);
+  });
+
+  test("returns true when actual equals condition", () => {
+    expect(gte(5).fn(5)).toBe(true);
+  });
+
+  test("returns false when actual is less", () => {
+    expect(gte(5).fn(3)).toBe(false);
+  });
+
+  test("carries correct metadata", () => {
+    expect(gte(5).operator).toBe("gte");
+  });
+});
+
+describe("lt", () => {
+  test("returns true when actual is less", () => {
+    expect(lt(10).fn(5)).toBe(true);
+  });
+
+  test("returns false when actual equals condition", () => {
+    expect(lt(5).fn(5)).toBe(false);
+  });
+
+  test("carries correct metadata", () => {
+    expect(lt(1).operator).toBe("lt");
+  });
+});
+
+describe("lte", () => {
+  test("returns true when actual is less", () => {
+    expect(lte(10).fn(5)).toBe(true);
+  });
+
+  test("returns true when actual equals condition", () => {
+    expect(lte(5).fn(5)).toBe(true);
+  });
+
+  test("carries correct metadata", () => {
+    expect(lte(1).operator).toBe("lte");
+  });
+});
+
+describe("not", () => {
+  test("negates a true result to false", () => {
+    expect(not(eq("draft")).fn("draft")).toBe(false);
+  });
+
+  test("negates a false result to true", () => {
+    expect(not(eq("draft")).fn("published")).toBe(true);
+  });
+
+  test("carries correct metadata", () => {
+    const inner = eq("draft");
+    const helper = not(inner);
+
+    expect(helper.operator).toBe("not");
+    expect(helper.value).toBe(inner);
+  });
+
+  test("double negation", () => {
+    expect(not(not(eq("draft"))).fn("draft")).toBe(true);
+    expect(not(not(eq("draft"))).fn("published")).toBe(false);
+  });
+});
+
+describe("and", () => {
+  test("returns true when all helpers match", () => {
+    expect(and(gt(0), lt(10)).fn(5)).toBe(true);
+  });
+
+  test("returns false when any helper does not match", () => {
+    expect(and(gt(0), lt(10)).fn(10)).toBe(false);
+  });
+
+  test("carries correct metadata", () => {
+    const a = gt(0);
+    const b = lt(10);
+    const helper = and(a, b);
+
+    expect(helper.operator).toBe("and");
+    expect(helper.value).toEqual([a, b]);
+  });
+});
+
+describe("or", () => {
+  test("returns true when at least one helper matches", () => {
+    expect(or(eq("draft"), eq("review")).fn("draft")).toBe(true);
+    expect(or(eq("draft"), eq("review")).fn("review")).toBe(true);
+  });
+
+  test("returns false when no helper matches", () => {
+    expect(or(eq("draft"), eq("review")).fn("published")).toBe(false);
+  });
+
+  test("carries correct metadata", () => {
+    const a = eq("draft");
+    const b = eq("review");
+    const helper = or(a, b);
+
+    expect(helper.operator).toBe("or");
+    expect(helper.value).toEqual([a, b]);
+  });
+});
+
+describe("startsWith", () => {
+  test("returns true when string starts with prefix", () => {
+    expect(startsWith("Hello").fn("Hello World")).toBe(true);
+  });
+
+  test("returns false when string does not start with prefix", () => {
+    expect(startsWith("World").fn("Hello World")).toBe(false);
+  });
+
+  test("carries correct metadata", () => {
+    expect(startsWith("Hi").operator).toBe("startsWith");
+    expect(startsWith("Hi").value).toBe("Hi");
+  });
+});
+
+describe("endsWith", () => {
+  test("returns true when string ends with suffix", () => {
+    expect(endsWith("World").fn("Hello World")).toBe(true);
+  });
+
+  test("returns false when string does not end with suffix", () => {
+    expect(endsWith("Hello").fn("Hello World")).toBe(false);
+  });
+
+  test("carries correct metadata", () => {
+    expect(endsWith("!").operator).toBe("endsWith");
+  });
+});
+
+describe("includes", () => {
+  test("returns true when string contains substring", () => {
+    expect(includes("lo W").fn("Hello World")).toBe(true);
+  });
+
+  test("returns false when string does not contain substring", () => {
+    expect(includes("xyz").fn("Hello World")).toBe(false);
+  });
+
+  test("carries correct metadata", () => {
+    expect(includes("test").operator).toBe("includes");
+    expect(includes("test").value).toBe("test");
+  });
+});
+
+describe("matches", () => {
+  test("returns true when string matches pattern", () => {
+    expect(matches(/^Hello/).fn("Hello World")).toBe(true);
+  });
+
+  test("returns false when string does not match pattern", () => {
+    expect(matches(/^World/).fn("Hello World")).toBe(false);
+  });
+
+  test("carries correct metadata", () => {
+    const pattern = /test/i;
+
+    expect(matches(pattern).operator).toBe("matches");
+    expect(matches(pattern).value).toBe(pattern);
+  });
+});
+
+describe("has", () => {
+  test("returns true when array includes a single value", () => {
+    expect(has("tech").fn(["tech", "business"])).toBe(true);
+  });
+
+  test("returns false when array does not include a single value", () => {
+    expect(has("tech").fn(["business"])).toBe(false);
+  });
+
+  test("returns true when array includes all condition values", () => {
+    expect(has(["tech", "business"]).fn(["tech", "business", "finance"])).toBe(
+      true,
+    );
+  });
+
+  test("returns false when array is missing some condition values", () => {
+    expect(has(["tech", "finance"]).fn(["tech", "business"])).toBe(false);
+  });
+
+  test("returns true when condition array is empty", () => {
+    expect(has<string>([]).fn(["tech"])).toBe(true);
+  });
+
+  test("carries correct metadata", () => {
+    expect(has("tech").operator).toBe("has");
+    expect(has("tech").value).toBe("tech");
+  });
+});
+
+describe("hasAny", () => {
+  test("returns true when array contains at least one of the values", () => {
+    expect(hasAny(["tech", "finance"]).fn(["tech", "business"])).toBe(true);
+  });
+
+  test("returns false when array contains none of the values", () => {
+    expect(hasAny(["finance", "crypto"]).fn(["tech", "business"])).toBe(false);
+  });
+
+  test("returns false for empty condition array", () => {
+    expect(hasAny<string>([]).fn(["tech"])).toBe(false);
+  });
+
+  test("carries correct metadata", () => {
+    const items = ["a", "b"];
+
+    expect(hasAny(items).operator).toBe("hasAny");
+    expect(hasAny(items).value).toEqual(items);
+  });
+});
+
+describe("isEmpty", () => {
+  test("returns true for empty array", () => {
+    expect(isEmpty().fn([])).toBe(true);
+  });
+
+  test("returns false for non-empty array", () => {
+    expect(isEmpty().fn(["item"])).toBe(false);
+  });
+
+  test("returns true for empty string", () => {
+    expect(isEmpty().fn("")).toBe(true);
+  });
+
+  test("returns false for non-empty string", () => {
+    expect(isEmpty().fn("hello")).toBe(false);
+  });
+
+  test("carries correct metadata", () => {
+    expect(isEmpty().operator).toBe("isEmpty");
+  });
+});
+
+describe("hasLength", () => {
+  test("returns true when array has exact length", () => {
+    expect(hasLength(2).fn(["a", "b"])).toBe(true);
+  });
+
+  test("returns false when array length differs", () => {
+    expect(hasLength(2).fn(["a"])).toBe(false);
+  });
+
+  test("returns true when string has exact length", () => {
+    expect(hasLength(5).fn("hello")).toBe(true);
+  });
+
+  test("supports min constraint", () => {
+    expect(hasLength({ min: 2 }).fn(["a", "b", "c"])).toBe(true);
+    expect(hasLength({ min: 2 }).fn(["a"])).toBe(false);
+  });
+
+  test("supports max constraint", () => {
+    expect(hasLength({ max: 3 }).fn(["a", "b"])).toBe(true);
+    expect(hasLength({ max: 3 }).fn(["a", "b", "c", "d"])).toBe(false);
+  });
+
+  test("supports min and max together", () => {
+    expect(hasLength({ min: 1, max: 3 }).fn(["a", "b"])).toBe(true);
+    expect(hasLength({ min: 1, max: 3 }).fn([])).toBe(false);
+    expect(hasLength({ min: 1, max: 3 }).fn(["a", "b", "c", "d"])).toBe(false);
+  });
+
+  test("carries correct metadata", () => {
+    expect(hasLength(3).operator).toBe("hasLength");
+    expect(hasLength(3).value).toBe(3);
+  });
+});
+
+describe("isDefined", () => {
+  test("returns true for non-null non-undefined values", () => {
+    expect(isDefined().fn("hello")).toBe(true);
+    expect(isDefined().fn(0)).toBe(true);
+    expect(isDefined().fn(false)).toBe(true);
+  });
+
+  test("returns false for null", () => {
+    expect(isDefined().fn(null)).toBe(false);
+  });
+
+  test("returns false for undefined", () => {
+    expect(isDefined().fn(undefined)).toBe(false);
+  });
+
+  test("carries correct metadata", () => {
+    expect(isDefined().operator).toBe("isDefined");
+  });
+});
+
+describe("isNullish", () => {
+  test("returns true for null", () => {
+    expect(isNullish().fn(null)).toBe(true);
+  });
+
+  test("returns true for undefined", () => {
+    expect(isNullish().fn(undefined)).toBe(true);
+  });
+
+  test("returns false for non-nullish values", () => {
+    expect(isNullish().fn("hello")).toBe(false);
+    expect(isNullish().fn(0)).toBe(false);
+  });
+
+  test("carries correct metadata", () => {
+    expect(isNullish().operator).toBe("isNullish");
+  });
+});
+
+type Post = {
+  id: number;
+  status: string;
+  authorId: number;
+  views: number;
+  tags: string[];
+  title: string;
+  publishedAt: Date;
+  deletedAt: Date | null | undefined;
+};
+
+const base: Post = {
+  id: 1,
+  status: "draft",
+  authorId: 1,
+  views: 0,
+  tags: [],
+  title: "Hello World",
+  publishedAt: new Date(),
+  deletedAt: null,
+};
+
+describe("helpers integrated with Policy", () => {
+  test("eq matches condition", () => {
+    const policy = new Policy<Post>();
+    policy.allow({ action: "read", conditions: { status: eq("draft") } });
+
+    expect(policy.can("read", base)).toMatchObject({ allowed: true });
+    expect(policy.can("read", { ...base, status: "published" })).toMatchObject({
+      allowed: false,
+    });
+  });
+
+  test("not(eq) forbids matching value", () => {
+    const policy = new Policy<Post>();
+    policy.allow({ action: "read", conditions: { authorId: not(eq(999)) } });
+
+    expect(policy.can("read", base)).toMatchObject({ allowed: true });
+    expect(policy.can("read", { ...base, authorId: 999 })).toMatchObject({
+      allowed: false,
+    });
+  });
+
+  test("and combines multiple helpers on one field", () => {
+    const policy = new Policy<Post>();
+    policy.allow({
+      action: "read",
+      conditions: { views: and(gte(10), lt(100)) },
+    });
+
+    expect(policy.can("read", { ...base, views: 50 })).toMatchObject({
+      allowed: true,
+    });
+    expect(policy.can("read", { ...base, views: 5 })).toMatchObject({
+      allowed: false,
+    });
+    expect(policy.can("read", { ...base, views: 100 })).toMatchObject({
+      allowed: false,
+    });
+  });
+
+  test("or allows multiple values on one field", () => {
+    const policy = new Policy<Post>();
+    policy.allow({
+      action: "read",
+      conditions: { status: or(eq("draft"), eq("review")) },
+    });
+
+    expect(policy.can("read", { ...base, status: "draft" })).toMatchObject({
+      allowed: true,
+    });
+    expect(policy.can("read", { ...base, status: "review" })).toMatchObject({
+      allowed: true,
+    });
+    expect(policy.can("read", { ...base, status: "published" })).toMatchObject({
+      allowed: false,
+    });
+  });
+
+  test("gt on Date field", () => {
+    const cutoff = new Date("2025-01-01");
+    const policy = new Policy<Post>();
+    policy.allow({ action: "read", conditions: { publishedAt: gt(cutoff) } });
+
+    expect(
+      policy.can("read", { ...base, publishedAt: new Date("2026-01-01") }),
+    ).toMatchObject({ allowed: true });
+    expect(
+      policy.can("read", { ...base, publishedAt: new Date("2024-01-01") }),
+    ).toMatchObject({ allowed: false });
+  });
+
+  test("startsWith on string field", () => {
+    const policy = new Policy<Post>();
+    policy.allow({
+      action: "read",
+      conditions: { title: startsWith("Hello") },
+    });
+
+    expect(policy.can("read", base)).toMatchObject({ allowed: true });
+    expect(policy.can("read", { ...base, title: "World Hello" })).toMatchObject(
+      { allowed: false },
+    );
+  });
+
+  test("matches on string field", () => {
+    const policy = new Policy<Post>();
+    policy.allow({ action: "read", conditions: { title: matches(/^Hello/i) } });
+
+    expect(policy.can("read", base)).toMatchObject({ allowed: true });
+    expect(policy.can("read", { ...base, title: "Goodbye" })).toMatchObject({
+      allowed: false,
+    });
+  });
+
+  test("has checks array inclusion (all values)", () => {
+    const policy = new Policy<Post>();
+    policy.allow({
+      action: "read",
+      conditions: { tags: has(["tech", "business"]) },
+    });
+
+    expect(
+      policy.can("read", { ...base, tags: ["tech", "business", "finance"] }),
+    ).toMatchObject({ allowed: true });
+    expect(policy.can("read", { ...base, tags: ["tech"] })).toMatchObject({
+      allowed: false,
+    });
+  });
+
+  test("hasAny checks array inclusion (any value)", () => {
+    const policy = new Policy<Post>();
+    policy.allow({
+      action: "read",
+      conditions: { tags: hasAny(["tech", "finance"]) },
+    });
+
+    expect(policy.can("read", { ...base, tags: ["tech"] })).toMatchObject({
+      allowed: true,
+    });
+    expect(policy.can("read", { ...base, tags: ["business"] })).toMatchObject({
+      allowed: false,
+    });
+  });
+
+  test("isNullish allows null/undefined values", () => {
+    const policy = new Policy<Post>();
+    policy.allow({ action: "delete", conditions: { deletedAt: isNullish() } });
+
+    expect(policy.can("delete", { ...base, deletedAt: null })).toMatchObject({
+      allowed: true,
+    });
+    expect(
+      policy.can("delete", { ...base, deletedAt: new Date() }),
+    ).toMatchObject({ allowed: false });
+  });
+});

--- a/src/lib/policy/helpers.test.ts
+++ b/src/lib/policy/helpers.test.ts
@@ -34,7 +34,6 @@ describe("eq", () => {
   test("carries correct metadata", () => {
     const helper = eq(42);
 
-    expect(helper.__isConditionHelper).toBe(true);
     expect(helper.operator).toBe("eq");
     expect(helper.value).toBe(42);
   });

--- a/src/lib/policy/helpers.ts
+++ b/src/lib/policy/helpers.ts
@@ -2,7 +2,6 @@ const _brand = Symbol("conditionHelper");
 
 export type ConditionHelper<V> = {
   readonly [_brand]: (actual: V) => boolean;
-  __isConditionHelper: true;
   operator: string;
   value: unknown;
   fn: (actual: V) => boolean;
@@ -13,7 +12,6 @@ export const eq = <V>(value: V): ConditionHelper<V> => {
 
   return {
     [_brand]: fn,
-    __isConditionHelper: true,
     operator: "eq",
     value,
     fn,
@@ -25,7 +23,6 @@ export const neq = <V>(value: V): ConditionHelper<V> => {
 
   return {
     [_brand]: fn,
-    __isConditionHelper: true,
     operator: "neq",
     value,
     fn,
@@ -39,7 +36,6 @@ export const gt = (
 
   return {
     [_brand]: fn,
-    __isConditionHelper: true,
     operator: "gt",
     value,
     fn,
@@ -53,7 +49,6 @@ export const gte = (
 
   return {
     [_brand]: fn,
-    __isConditionHelper: true,
     operator: "gte",
     value,
     fn,
@@ -67,7 +62,6 @@ export const lt = (
 
   return {
     [_brand]: fn,
-    __isConditionHelper: true,
     operator: "lt",
     value,
     fn,
@@ -81,7 +75,6 @@ export const lte = (
 
   return {
     [_brand]: fn,
-    __isConditionHelper: true,
     operator: "lte",
     value,
     fn,
@@ -93,7 +86,6 @@ export const not = <V>(inner: ConditionHelper<V>): ConditionHelper<V> => {
 
   return {
     [_brand]: fn,
-    __isConditionHelper: true,
     operator: "not",
     value: inner,
     fn,
@@ -107,7 +99,6 @@ export const and = <V>(
 
   return {
     [_brand]: fn,
-    __isConditionHelper: true,
     operator: "and",
     value: helpers,
     fn,
@@ -119,7 +110,6 @@ export const or = <V>(...helpers: ConditionHelper<V>[]): ConditionHelper<V> => {
 
   return {
     [_brand]: fn,
-    __isConditionHelper: true,
     operator: "or",
     value: helpers,
     fn,
@@ -131,7 +121,6 @@ export const startsWith = (prefix: string): ConditionHelper<string> => {
 
   return {
     [_brand]: fn,
-    __isConditionHelper: true,
     operator: "startsWith",
     value: prefix,
     fn,
@@ -143,7 +132,6 @@ export const endsWith = (suffix: string): ConditionHelper<string> => {
 
   return {
     [_brand]: fn,
-    __isConditionHelper: true,
     operator: "endsWith",
     value: suffix,
     fn,
@@ -155,7 +143,6 @@ export const includes = (substring: string): ConditionHelper<string> => {
 
   return {
     [_brand]: fn,
-    __isConditionHelper: true,
     operator: "includes",
     value: substring,
     fn,
@@ -167,7 +154,6 @@ export const matches = (pattern: RegExp): ConditionHelper<string> => {
 
   return {
     [_brand]: fn,
-    __isConditionHelper: true,
     operator: "matches",
     value: pattern,
     fn,
@@ -185,7 +171,6 @@ export const has = <V>(items: V | V[]): ConditionHelper<V[]> => {
 
   return {
     [_brand]: fn,
-    __isConditionHelper: true,
     operator: "has",
     value: items,
     fn,
@@ -197,7 +182,6 @@ export const hasAny = <V>(items: V[]): ConditionHelper<V[]> => {
 
   return {
     [_brand]: fn,
-    __isConditionHelper: true,
     operator: "hasAny",
     value: items,
     fn,
@@ -229,7 +213,6 @@ export const hasLength = (
 
   return {
     [_brand]: fn,
-    __isConditionHelper: true,
     operator: "hasLength",
     value: length,
     fn,
@@ -241,7 +224,6 @@ export const isEmpty = (): ConditionHelper<string | unknown[]> => {
 
   return {
     [_brand]: fn,
-    __isConditionHelper: true,
     operator: "isEmpty",
     value: undefined,
     fn,
@@ -253,7 +235,6 @@ export const isDefined = (): ConditionHelper<unknown> => {
 
   return {
     [_brand]: fn,
-    __isConditionHelper: true,
     operator: "isDefined",
     value: undefined,
     fn,
@@ -265,7 +246,6 @@ export const isNullish = (): ConditionHelper<unknown> => {
 
   return {
     [_brand]: fn,
-    __isConditionHelper: true,
     operator: "isNullish",
     value: undefined,
     fn,

--- a/src/lib/policy/helpers.ts
+++ b/src/lib/policy/helpers.ts
@@ -1,0 +1,255 @@
+const _brand = Symbol("conditionHelper");
+
+export type ConditionHelper<V> = {
+  readonly [_brand]: (actual: V) => boolean;
+  __isConditionHelper: true;
+  operator: string;
+  value: unknown;
+  fn: (actual: V) => boolean;
+};
+
+export const eq = <V>(value: V): ConditionHelper<V> => {
+  const fn = (actual: V) => actual === value;
+
+  return { [_brand]: fn, __isConditionHelper: true, operator: "eq", value, fn };
+};
+
+export const neq = <V>(value: V): ConditionHelper<V> => {
+  const fn = (actual: V) => actual !== value;
+
+  return {
+    [_brand]: fn,
+    __isConditionHelper: true,
+    operator: "neq",
+    value,
+    fn,
+  };
+};
+
+export const gt = (
+  value: string | number | Date,
+): ConditionHelper<string | number | Date> => {
+  const fn = (actual: string | number | Date) => actual > value;
+
+  return { [_brand]: fn, __isConditionHelper: true, operator: "gt", value, fn };
+};
+
+export const gte = (
+  value: string | number | Date,
+): ConditionHelper<string | number | Date> => {
+  const fn = (actual: string | number | Date) => actual >= value;
+
+  return {
+    [_brand]: fn,
+    __isConditionHelper: true,
+    operator: "gte",
+    value,
+    fn,
+  };
+};
+
+export const lt = (
+  value: string | number | Date,
+): ConditionHelper<string | number | Date> => {
+  const fn = (actual: string | number | Date) => actual < value;
+
+  return { [_brand]: fn, __isConditionHelper: true, operator: "lt", value, fn };
+};
+
+export const lte = (
+  value: string | number | Date,
+): ConditionHelper<string | number | Date> => {
+  const fn = (actual: string | number | Date) => actual <= value;
+
+  return {
+    [_brand]: fn,
+    __isConditionHelper: true,
+    operator: "lte",
+    value,
+    fn,
+  };
+};
+
+export const not = <V>(inner: ConditionHelper<V>): ConditionHelper<V> => {
+  const fn = (actual: V) => !inner.fn(actual);
+
+  return {
+    [_brand]: fn,
+    __isConditionHelper: true,
+    operator: "not",
+    value: inner,
+    fn,
+  };
+};
+
+export const and = <V>(
+  ...helpers: ConditionHelper<V>[]
+): ConditionHelper<V> => {
+  const fn = (actual: V) => helpers.every((h) => h.fn(actual));
+
+  return {
+    [_brand]: fn,
+    __isConditionHelper: true,
+    operator: "and",
+    value: helpers,
+    fn,
+  };
+};
+
+export const or = <V>(...helpers: ConditionHelper<V>[]): ConditionHelper<V> => {
+  const fn = (actual: V) => helpers.some((h) => h.fn(actual));
+
+  return {
+    [_brand]: fn,
+    __isConditionHelper: true,
+    operator: "or",
+    value: helpers,
+    fn,
+  };
+};
+
+export const startsWith = (prefix: string): ConditionHelper<string> => {
+  const fn = (actual: string) => actual.startsWith(prefix);
+
+  return {
+    [_brand]: fn,
+    __isConditionHelper: true,
+    operator: "startsWith",
+    value: prefix,
+    fn,
+  };
+};
+
+export const endsWith = (suffix: string): ConditionHelper<string> => {
+  const fn = (actual: string) => actual.endsWith(suffix);
+
+  return {
+    [_brand]: fn,
+    __isConditionHelper: true,
+    operator: "endsWith",
+    value: suffix,
+    fn,
+  };
+};
+
+export const includes = (substring: string): ConditionHelper<string> => {
+  const fn = (actual: string) => actual.includes(substring);
+
+  return {
+    [_brand]: fn,
+    __isConditionHelper: true,
+    operator: "includes",
+    value: substring,
+    fn,
+  };
+};
+
+export const matches = (pattern: RegExp): ConditionHelper<string> => {
+  const fn = (actual: string) => pattern.test(actual);
+
+  return {
+    [_brand]: fn,
+    __isConditionHelper: true,
+    operator: "matches",
+    value: pattern,
+    fn,
+  };
+};
+
+export const has = <V>(items: V | V[]): ConditionHelper<V[]> => {
+  const fn = (actual: V[]) => {
+    if (Array.isArray(items)) {
+      return items.every((item) => actual.includes(item));
+    }
+
+    return actual.includes(items);
+  };
+
+  return {
+    [_brand]: fn,
+    __isConditionHelper: true,
+    operator: "has",
+    value: items,
+    fn,
+  };
+};
+
+export const hasAny = <V>(items: V[]): ConditionHelper<V[]> => {
+  const fn = (actual: V[]) => items.some((item) => actual.includes(item));
+
+  return {
+    [_brand]: fn,
+    __isConditionHelper: true,
+    operator: "hasAny",
+    value: items,
+    fn,
+  };
+};
+
+type HasLengthArg = number | { min?: number; max?: number };
+
+export const hasLength = (
+  length: HasLengthArg,
+): ConditionHelper<string | unknown[]> => {
+  const fn = (actual: string | unknown[]) => {
+    const len = actual.length;
+
+    if (typeof length === "number") {
+      return len === length;
+    }
+
+    if (length.min !== undefined && len < length.min) {
+      return false;
+    }
+
+    if (length.max !== undefined && len > length.max) {
+      return false;
+    }
+
+    return true;
+  };
+
+  return {
+    [_brand]: fn,
+    __isConditionHelper: true,
+    operator: "hasLength",
+    value: length,
+    fn,
+  };
+};
+
+export const isEmpty = (): ConditionHelper<string | unknown[]> => {
+  const fn = (actual: string | unknown[]) => actual.length === 0;
+
+  return {
+    [_brand]: fn,
+    __isConditionHelper: true,
+    operator: "isEmpty",
+    value: undefined,
+    fn,
+  };
+};
+
+export const isDefined = (): ConditionHelper<unknown> => {
+  const fn = (actual: unknown) => actual !== null && actual !== undefined;
+
+  return {
+    [_brand]: fn,
+    __isConditionHelper: true,
+    operator: "isDefined",
+    value: undefined,
+    fn,
+  };
+};
+
+export const isNullish = (): ConditionHelper<unknown> => {
+  const fn = (actual: unknown) => actual === null || actual === undefined;
+
+  return {
+    [_brand]: fn,
+    __isConditionHelper: true,
+    operator: "isNullish",
+    value: undefined,
+    fn,
+  };
+};

--- a/src/lib/policy/helpers.ts
+++ b/src/lib/policy/helpers.ts
@@ -197,8 +197,9 @@ export const has = <V>(items: V | V[]): ConditionHelper<V[]> => {
   };
 };
 
-export const hasAny = <V>(items: V[]): ConditionHelper<V[]> => {
-  const fn = (actual: V[]) => items.some((item) => actual.includes(item));
+export const hasAny = <V>(items: V | V[]): ConditionHelper<V[]> => {
+  const normalized = Array.isArray(items) ? items : [items];
+  const fn = (actual: V[]) => normalized.some((item) => actual.includes(item));
 
   return {
     [_brand]: fn,

--- a/src/lib/policy/helpers.ts
+++ b/src/lib/policy/helpers.ts
@@ -11,7 +11,13 @@ export type ConditionHelper<V> = {
 export const eq = <V>(value: V): ConditionHelper<V> => {
   const fn = (actual: V) => actual === value;
 
-  return { [_brand]: fn, __isConditionHelper: true, operator: "eq", value, fn };
+  return {
+    [_brand]: fn,
+    __isConditionHelper: true,
+    operator: "eq",
+    value,
+    fn,
+  };
 };
 
 export const neq = <V>(value: V): ConditionHelper<V> => {
@@ -31,7 +37,13 @@ export const gt = (
 ): ConditionHelper<string | number | Date> => {
   const fn = (actual: string | number | Date) => actual > value;
 
-  return { [_brand]: fn, __isConditionHelper: true, operator: "gt", value, fn };
+  return {
+    [_brand]: fn,
+    __isConditionHelper: true,
+    operator: "gt",
+    value,
+    fn,
+  };
 };
 
 export const gte = (
@@ -53,7 +65,13 @@ export const lt = (
 ): ConditionHelper<string | number | Date> => {
   const fn = (actual: string | number | Date) => actual < value;
 
-  return { [_brand]: fn, __isConditionHelper: true, operator: "lt", value, fn };
+  return {
+    [_brand]: fn,
+    __isConditionHelper: true,
+    operator: "lt",
+    value,
+    fn,
+  };
 };
 
 export const lte = (

--- a/src/lib/policy/helpers.ts
+++ b/src/lib/policy/helpers.ts
@@ -29,7 +29,11 @@ export const neq = <V>(value: V): ConditionHelper<V> => {
   };
 };
 
-export const gt = (
+export const gt: {
+  (value: Date): ConditionHelper<Date>;
+  (value: number): ConditionHelper<number>;
+  (value: string): ConditionHelper<string>;
+} = (
   value: string | number | Date,
 ): ConditionHelper<string | number | Date> => {
   const fn = (actual: string | number | Date) => actual > value;
@@ -42,7 +46,11 @@ export const gt = (
   };
 };
 
-export const gte = (
+export const gte: {
+  (value: Date): ConditionHelper<Date>;
+  (value: number): ConditionHelper<number>;
+  (value: string): ConditionHelper<string>;
+} = (
   value: string | number | Date,
 ): ConditionHelper<string | number | Date> => {
   const fn = (actual: string | number | Date) => actual >= value;
@@ -55,7 +63,11 @@ export const gte = (
   };
 };
 
-export const lt = (
+export const lt: {
+  (value: Date): ConditionHelper<Date>;
+  (value: number): ConditionHelper<number>;
+  (value: string): ConditionHelper<string>;
+} = (
   value: string | number | Date,
 ): ConditionHelper<string | number | Date> => {
   const fn = (actual: string | number | Date) => actual < value;
@@ -68,7 +80,11 @@ export const lt = (
   };
 };
 
-export const lte = (
+export const lte: {
+  (value: Date): ConditionHelper<Date>;
+  (value: number): ConditionHelper<number>;
+  (value: string): ConditionHelper<string>;
+} = (
   value: string | number | Date,
 ): ConditionHelper<string | number | Date> => {
   const fn = (actual: string | number | Date) => actual <= value;
@@ -150,7 +166,11 @@ export const includes = (substring: string): ConditionHelper<string> => {
 };
 
 export const matches = (pattern: RegExp): ConditionHelper<string> => {
-  const fn = (actual: string) => pattern.test(actual);
+  const fn = (actual: string) => {
+    pattern.lastIndex = 0;
+
+    return pattern.test(actual);
+  };
 
   return {
     [_brand]: fn,

--- a/src/lib/policy/index.test.ts
+++ b/src/lib/policy/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { Policy } from "./index.js";
+import { gt, has, Policy, startsWith } from "./index.js";
 
 type Post = {
   id: number;
@@ -479,13 +479,13 @@ describe("Policy", () => {
     expect(policy.can("delete", post)).toMatchObject({ allowed: false });
   });
 
-  test("should support predicate functions in conditions", () => {
+  test("should support helper functions in conditions", () => {
     const policy = new Policy<Post>();
 
     policy.allow({
       action: "read",
       conditions: {
-        title: (v) => v.startsWith("Public"),
+        title: startsWith("Public"),
       },
     });
 
@@ -612,12 +612,12 @@ describe("Policy", () => {
       expect(policy.can("read", user)).toMatchObject({ allowed: false });
     });
 
-    test("should support predicate on array field", () => {
+    test("should support helper on array field", () => {
       const policy = new Policy<User>();
 
       policy.allow({
         action: "read",
-        conditions: { roles: (roles) => roles.includes("admin") },
+        conditions: { roles: has("admin") },
       });
 
       const admin: User = {
@@ -729,7 +729,7 @@ describe("Policy", () => {
       expect(policy.can("read", user)).toMatchObject({ allowed: false });
     });
 
-    test("should support predicate on Date field inside nested object", () => {
+    test("should support helper on Date field inside nested object", () => {
       const policy = new Policy<User>();
 
       const cutoff = new Date("2024-06-01");
@@ -737,7 +737,7 @@ describe("Policy", () => {
       policy.allow({
         action: "read",
         conditions: {
-          meta: (m) => m.createdAt > cutoff,
+          meta: { createdAt: gt(cutoff) },
         },
       });
 
@@ -764,14 +764,14 @@ describe("Policy", () => {
     });
   });
 
-  test("should support mixing direct equality and predicate conditions", () => {
+  test("should support mixing direct equality and helper conditions", () => {
     const policy = new Policy<Post>();
 
     policy.allow({
       action: "read",
       conditions: {
         status: "published",
-        authorId: (v) => v > 0,
+        authorId: gt(0),
       },
     });
 

--- a/src/lib/policy/index.test.ts
+++ b/src/lib/policy/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { gt, has, Policy, startsWith } from "./index.js";
+import { eq, gt, has, isEmpty, Policy, startsWith } from "./index.js";
 
 type Post = {
   id: number;
@@ -27,7 +27,7 @@ describe("Policy", () => {
     policy.allow({
       action: "read",
       conditions: {
-        status: "published",
+        status: eq("published"),
       },
     });
 
@@ -49,7 +49,7 @@ describe("Policy", () => {
     policy.allow({
       action: "read",
       conditions: {
-        status: "published",
+        status: eq("published"),
       },
     });
 
@@ -71,7 +71,7 @@ describe("Policy", () => {
     policy.forbid({
       action: "update",
       conditions: {
-        status: "published",
+        status: eq("published"),
       },
     });
 
@@ -97,7 +97,7 @@ describe("Policy", () => {
     policy.forbid({
       action: "update",
       conditions: {
-        status: "published",
+        status: eq("published"),
       },
     });
 
@@ -129,8 +129,8 @@ describe("Policy", () => {
     policy.allow({
       action: "delete",
       conditions: {
-        authorId: 1,
-        status: "draft",
+        authorId: eq(1),
+        status: eq("draft"),
       },
     });
 
@@ -210,7 +210,7 @@ describe("Policy", () => {
     const policy = new Policy<CommentToUser>();
     policy.allow({
       conditions: {
-        comments,
+        comments: eq(comments),
       },
       action: ["update", "create", "delete"],
     });
@@ -251,14 +251,14 @@ describe("Policy", () => {
     policy.allow({
       action: "read",
       conditions: {
-        status: "published",
+        status: eq("published"),
       },
     });
 
     policy.forbid({
       action: "update",
       conditions: {
-        status: "published",
+        status: eq("published"),
       },
     });
 
@@ -276,14 +276,14 @@ describe("Policy", () => {
     policy.allow({
       action: "read",
       conditions: {
-        status: "published",
+        status: eq("published"),
       },
     });
 
     policy.allow({
       action: "update",
       conditions: {
-        status: "draft",
+        status: eq("draft"),
       },
     });
 
@@ -334,7 +334,7 @@ describe("Policy", () => {
       action: "delete",
       reason: "You cannot delete published posts",
       conditions: {
-        status: "published",
+        status: eq("published"),
       },
     });
 
@@ -359,7 +359,7 @@ describe("Policy", () => {
       action: "read",
       reason: "Public posts are visible to everyone",
       conditions: {
-        status: "published",
+        status: eq("published"),
       },
     });
 
@@ -383,7 +383,7 @@ describe("Policy", () => {
     policy.allow({
       action: "read",
       conditions: {
-        status: "published",
+        status: eq("published"),
       },
     });
 
@@ -419,8 +419,8 @@ describe("Policy", () => {
       action: "update",
       reason: "Admins cannot update their own published posts",
       conditions: {
-        authorId: 1,
-        status: "published",
+        authorId: eq(1),
+        status: eq("published"),
       },
     });
 
@@ -507,7 +507,7 @@ describe("Policy", () => {
     expect(policy.can("read", hiddenPost)).toMatchObject({ allowed: false });
   });
 
-  test("should match nested object conditions by value", () => {
+  test("should match nested object conditions", () => {
     type Post = {
       id: number;
       title: string;
@@ -520,7 +520,7 @@ describe("Policy", () => {
     policy.allow({
       action: "update",
       conditions: {
-        author: { id: 1, name: "john" },
+        author: { id: eq(1), name: eq("john") },
       },
     });
 
@@ -544,12 +544,12 @@ describe("Policy", () => {
   });
 
   describe("array conditions", () => {
-    test("should allow when array condition matches exactly", () => {
+    test("should allow when array contains the required item", () => {
       const policy = new Policy<User>();
 
-      policy.allow({ action: "read", conditions: { roles: ["admin"] } });
+      policy.allow({ action: "read", conditions: { roles: has("admin") } });
 
-      const user: User = {
+      const admin: User = {
         id: 1,
         name: "Alice",
         roles: ["admin"],
@@ -558,32 +558,40 @@ describe("Policy", () => {
         meta: { createdAt: new Date(), updatedAt: new Date() },
       };
 
-      expect(policy.can("read", user)).toMatchObject({ allowed: true });
-    });
-
-    test("should deny when array elements do not match", () => {
-      const policy = new Policy<User>();
-
-      policy.allow({ action: "read", conditions: { roles: ["admin"] } });
-
-      const user: User = {
-        id: 1,
+      const adminWithExtra: User = {
+        id: 2,
         name: "Bob",
+        roles: ["admin", "editor"],
+        age: 30,
+        posts: [],
+        meta: { createdAt: new Date(), updatedAt: new Date() },
+      };
+
+      const guest: User = {
+        id: 3,
+        name: "Carol",
         roles: ["guest"],
         age: 25,
         posts: [],
         meta: { createdAt: new Date(), updatedAt: new Date() },
       };
 
-      expect(policy.can("read", user)).toMatchObject({ allowed: false });
+      expect(policy.can("read", admin)).toMatchObject({ allowed: true });
+      expect(policy.can("read", adminWithExtra)).toMatchObject({
+        allowed: true,
+      });
+      expect(policy.can("read", guest)).toMatchObject({ allowed: false });
     });
 
-    test("should deny when actual array is a superset of condition array", () => {
+    test("should allow when array contains all required items", () => {
       const policy = new Policy<User>();
 
-      policy.allow({ action: "read", conditions: { roles: ["admin"] } });
+      policy.allow({
+        action: "read",
+        conditions: { roles: has(["admin", "editor"]) },
+      });
 
-      const user: User = {
+      const adminEditor: User = {
         id: 1,
         name: "Alice",
         roles: ["admin", "editor"],
@@ -592,24 +600,44 @@ describe("Policy", () => {
         meta: { createdAt: new Date(), updatedAt: new Date() },
       };
 
-      expect(policy.can("read", user)).toMatchObject({ allowed: false });
-    });
-
-    test("should deny when condition is empty array but actual is not", () => {
-      const policy = new Policy<User>();
-
-      policy.allow({ action: "read", conditions: { roles: [] } });
-
-      const user: User = {
-        id: 1,
-        name: "Alice",
+      const adminOnly: User = {
+        id: 2,
+        name: "Bob",
         roles: ["admin"],
         age: 30,
         posts: [],
         meta: { createdAt: new Date(), updatedAt: new Date() },
       };
 
-      expect(policy.can("read", user)).toMatchObject({ allowed: false });
+      expect(policy.can("read", adminEditor)).toMatchObject({ allowed: true });
+      expect(policy.can("read", adminOnly)).toMatchObject({ allowed: false });
+    });
+
+    test("should allow when array is empty", () => {
+      const policy = new Policy<User>();
+
+      policy.allow({ action: "read", conditions: { roles: isEmpty() } });
+
+      const noRoles: User = {
+        id: 1,
+        name: "Alice",
+        roles: [],
+        age: 30,
+        posts: [],
+        meta: { createdAt: new Date(), updatedAt: new Date() },
+      };
+
+      const withRoles: User = {
+        id: 2,
+        name: "Bob",
+        roles: ["admin"],
+        age: 25,
+        posts: [],
+        meta: { createdAt: new Date(), updatedAt: new Date() },
+      };
+
+      expect(policy.can("read", noRoles)).toMatchObject({ allowed: true });
+      expect(policy.can("read", withRoles)).toMatchObject({ allowed: false });
     });
 
     test("should support helper on array field", () => {
@@ -642,7 +670,7 @@ describe("Policy", () => {
       expect(policy.can("read", guest)).toMatchObject({ allowed: false });
     });
 
-    test("should match array of objects exactly", () => {
+    test("should allow when array contains a specific object", () => {
       const policy = new Policy<User>();
 
       const post: Post = {
@@ -652,7 +680,7 @@ describe("Policy", () => {
         status: "published",
       };
 
-      policy.allow({ action: "delete", conditions: { posts: [post] } });
+      policy.allow({ action: "delete", conditions: { posts: has(post) } });
 
       const userWithPost: User = {
         id: 1,
@@ -689,7 +717,7 @@ describe("Policy", () => {
 
       policy.allow({
         action: "read",
-        conditions: { meta: { createdAt: date, updatedAt: date } },
+        conditions: { meta: { createdAt: eq(date), updatedAt: eq(date) } },
       });
 
       const user: User = {
@@ -713,7 +741,7 @@ describe("Policy", () => {
       policy.allow({
         action: "read",
         conditions: {
-          meta: { createdAt: conditionDate, updatedAt: conditionDate },
+          meta: { createdAt: eq(conditionDate), updatedAt: eq(conditionDate) },
         },
       });
 
@@ -764,13 +792,13 @@ describe("Policy", () => {
     });
   });
 
-  test("should support mixing direct equality and helper conditions", () => {
+  test("should support combining conditions", () => {
     const policy = new Policy<Post>();
 
     policy.allow({
       action: "read",
       conditions: {
-        status: "published",
+        status: eq("published"),
         authorId: gt(0),
       },
     });
@@ -841,7 +869,7 @@ describe("Policy", () => {
       policy.allow({
         action: "update",
         conditions: {
-          authorId: 1,
+          authorId: eq(1),
         },
       });
 
@@ -893,7 +921,7 @@ describe("Policy", () => {
       policy.forbid({
         action: ["update"],
         conditions: {
-          authorId: 1,
+          authorId: eq(1),
         },
       });
 

--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -106,10 +106,6 @@ export class Policy<
   }
 
   private matchValue(actual: unknown, condition: unknown) {
-    if (typeof condition === "function") {
-      return condition(actual);
-    }
-
     if (Array.isArray(condition)) {
       return this.matchArray(actual, condition);
     }
@@ -117,6 +113,12 @@ export class Policy<
     if (typeof condition !== "object") return actual === condition;
 
     if (condition === null) return actual === null;
+
+    if ("__isConditionHelper" in condition) {
+      if ("fn" in condition && typeof condition.fn === "function") {
+        return condition.fn(actual);
+      }
+    }
 
     const proto = Object.getPrototypeOf(condition);
 
@@ -139,3 +141,26 @@ export class Policy<
     return true;
   }
 }
+
+export type { ConditionHelper } from "./helpers.js";
+export {
+  and,
+  endsWith,
+  eq,
+  gt,
+  gte,
+  has,
+  hasAny,
+  hasLength,
+  includes,
+  isDefined,
+  isEmpty,
+  isNullish,
+  lt,
+  lte,
+  matches,
+  neq,
+  not,
+  or,
+  startsWith,
+} from "./helpers.js";

--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -106,39 +106,15 @@ export class Policy<
   }
 
   private matchValue(actual: unknown, condition: unknown) {
-    if (Array.isArray(condition)) {
-      return this.matchArray(actual, condition);
+    if (typeof condition !== "object" || condition === null) {
+      return false;
     }
 
-    if (typeof condition !== "object") return actual === condition;
-
-    if (condition === null) return actual === null;
-
-    if ("__isConditionHelper" in condition) {
-      if ("fn" in condition && typeof condition.fn === "function") {
-        return condition.fn(actual);
-      }
+    if ("fn" in condition && typeof condition.fn === "function") {
+      return condition.fn(actual);
     }
-
-    const proto = Object.getPrototypeOf(condition);
-
-    if (proto !== Object.prototype && proto !== null)
-      return actual === condition;
 
     return this.deepMatch(actual, condition);
-  }
-
-  private matchArray(actual: unknown, condition: unknown[]) {
-    if (!Array.isArray(actual)) return false;
-    if (actual.length !== condition.length) return false;
-
-    for (let i = 0; i < condition.length; i++) {
-      if (!this.matchValue(actual[i], condition[i])) {
-        return false;
-      }
-    }
-
-    return true;
   }
 }
 

--- a/src/lib/policy/types.ts
+++ b/src/lib/policy/types.ts
@@ -4,8 +4,8 @@ export type Action = "read" | "create" | "update" | "delete" | (string & {});
 
 export type ConditionValue<V> =
   V extends Record<string, unknown>
-    ? V | ConditionHelper<V> | Conditions<V>
-    : V | ConditionHelper<V>;
+    ? ConditionHelper<V> | Conditions<V>
+    : ConditionHelper<V>;
 
 export type Conditions<T = Record<string, unknown>> = {
   [K in keyof T]?: ConditionValue<T[K]>;

--- a/src/lib/policy/types.ts
+++ b/src/lib/policy/types.ts
@@ -1,6 +1,11 @@
+import type { ConditionHelper } from "./helpers.js";
+
 export type Action = "read" | "create" | "update" | "delete" | (string & {});
 
-export type ConditionValue<V> = V | ((value: V) => boolean);
+export type ConditionValue<V> =
+  V extends Record<string, unknown>
+    ? V | ConditionHelper<V> | Conditions<V>
+    : V | ConditionHelper<V>;
 
 export type Conditions<T = Record<string, unknown>> = {
   [K in keyof T]?: ConditionValue<T[K]>;


### PR DESCRIPTION
## Summary
- Removes support for raw predicate functions (`(v) => v === "draft"`) in policy conditions
- Introduces typed helper functions as the only way to express conditions beyond exact value matching
- Each helper carries operator and value metadata on its type, enabling future adapter support (e.g. SQL WHERE clause generation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a formal set of composable condition helpers (comparisons, logic combinators, string/array checks, presence checks) and exposes them via the policy API for building rules.

* **Documentation**
  * Policy docs and README updated with helper-based examples and guidance showing permission- and helper-driven conditions.

* **Tests**
  * Large new unit and integration test suite validating each helper, metadata propagation, edge cases, and integration with policy evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->