### PR TITLE
Improve PubSub module to support multiple active subscribers per instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,16 @@ const pubsub = new PubSub({
 });
 
 // Subscribe to messages
-await pubsub.subscribe((message) => {
+const [, unsubscribeHandler] = await pubsub.subscribe((message) => {
   console.log("Received:", message);
 });
 
 // Publish a message
 await pubsub.publish({ userId: 123, text: "New alert!" });
+
+if (unsubscribeHandler) {
+  await unsubscribeHandler();
+}
 ```
 
 ### Cache Data with TTL

--- a/docs/pubsub.md
+++ b/docs/pubsub.md
@@ -50,24 +50,31 @@ if (error) {
 
 **`pubsub.subscribe(handler: MessageHandler<T>)`**
 
-Subscribes to messages with a handler function. Returns a result tuple indicating success or failure.
+Registers a local handler for messages on this PubSub instance. Returns a result tuple with a handler-level unsubscribe function.
 
 ```typescript
 type MessageHandler<T> = (message: T, channel: string) => void | Promise<void>;
 
-const [error] = await pubsub.subscribe(async (message, channel) => {
-  console.log(`Received on ${channel}:`, message);
-  await processMessage(message);
-});
+const [error, unsubscribeHandler] = await pubsub.subscribe(
+  async (message, channel) => {
+    console.log(`Received on ${channel}:`, message);
+    await processMessage(message);
+  },
+);
 
 if (error) {
   console.error("Failed to subscribe:", error.message);
+}
+
+if (unsubscribeHandler) {
+  // Removes only this handler.
+  await unsubscribeHandler();
 }
 ```
 
 **`pubsub.unsubscribe()`**
 
-Unsubscribes from the channel or pattern and cleans up the handler.
+Unsubscribes all local handlers for this instance and removes the Redis subscription.
 
 ```typescript
 const [error] = await pubsub.unsubscribe();
@@ -111,7 +118,7 @@ const events = new PubSub<UserEvent>({
 });
 
 // Subscribe to events
-await events.subscribe(async (event) => {
+const [, unsubscribeEvents] = await events.subscribe(async (event) => {
   console.log(`User ${event.userId} performed ${event.action}`);
   await logToDatabase(event);
 });
@@ -122,6 +129,45 @@ await events.publish({
   action: "login",
   timestamp: Date.now(),
 });
+
+if (unsubscribeEvents) {
+  await unsubscribeEvents();
+}
+```
+
+### Multiple Handlers On One Instance
+
+```typescript
+import { PubSub } from "semola/pubsub";
+
+const subscriber = new Bun.RedisClient("redis://localhost:6379");
+const publisher = new Bun.RedisClient("redis://localhost:6379");
+
+const pubsub = new PubSub<{ text: string }>({
+  subscriber,
+  publisher,
+  channel: "notifications",
+});
+
+const [, unsubscribeLogger] = await pubsub.subscribe(async (message) => {
+  console.log("logger:", message.text);
+});
+
+const [, unsubscribeMetrics] = await pubsub.subscribe(async (message) => {
+  await metrics.increment("notifications.received", { text: message.text });
+});
+
+await pubsub.publish({ text: "New alert" });
+
+// Remove one handler, keep the other active
+if (unsubscribeLogger) {
+  await unsubscribeLogger();
+}
+
+// Redis unsubscribe happens only when the last local handler is removed
+if (unsubscribeMetrics) {
+  await unsubscribeMetrics();
+}
 ```
 
 ### Error Handling
@@ -139,10 +185,12 @@ const pubsub = new PubSub<{ notification: string }>({
 });
 
 // Subscribe with error handling
-const [subscribeError] = await pubsub.subscribe(async (message) => {
-  // Handler errors are caught automatically; subscription remains active even if handler throws
-  await processNotification(message.notification);
-});
+const [subscribeError, unsubscribeHandler] = await pubsub.subscribe(
+  async (message) => {
+    // Handler errors are caught automatically; subscription remains active even if handler throws
+    await processNotification(message.notification);
+  },
+);
 
 if (subscribeError) {
   console.error("Failed to subscribe:", subscribeError.message);
@@ -166,7 +214,9 @@ if (publishError) {
 }
 
 // Clean up
-await pubsub.unsubscribe();
+if (unsubscribeHandler) {
+  await unsubscribeHandler();
+}
 ```
 
 ### Multiple Instances
@@ -230,6 +280,10 @@ await publisher.quit();
 
 **JSON Serialization:** Messages are automatically serialized to JSON when published and deserialized when received. This ensures type safety but means only JSON-serializable values can be sent. Attempting to publish circular references or other non-serializable values will return a `SerializationError`.
 
-**One Handler Per Instance:** Each PubSub instance supports a single message handler. If you need multiple handlers for the same channel, create multiple PubSub instances.
+**Multiple Local Handlers:** A single PubSub instance can have multiple active handlers. Internally, it keeps one Redis subscription per channel per instance and fans out each message to every active local handler.
+
+**Handler-Level Unsubscribe:** Each successful `subscribe()` call returns a dedicated unsubscribe function for that handler only. Other handlers remain active.
+
+**Last Handler Cleanup:** Redis-level `unsubscribe` runs only when the final local handler is removed (or when `pubsub.unsubscribe()` is called to clear all handlers).
 
 **When to Use Redis Streams:** If you need message acknowledgment, guaranteed delivery, message history, or consumer groups, use Redis Streams instead of pub/sub. PubSub is best for real-time, fire-and-forget messaging where occasional message loss is acceptable.

--- a/src/lib/pubsub/index.test.ts
+++ b/src/lib/pubsub/index.test.ts
@@ -5,6 +5,8 @@ type Handler = (message: string, channel: string) => void | Promise<void>;
 
 class MockRedisClient {
   private subscriptions = new Map<string, Handler[]>();
+  private subscribeCalls = new Map<string, number>();
+  private unsubscribeCalls = new Map<string, number>();
   private shouldFail = false;
 
   public setShouldFail(value: boolean) {
@@ -36,6 +38,10 @@ class MockRedisClient {
       throw new Error("Redis connection error");
     }
 
+    const subscribeCount = this.subscribeCalls.get(channel) ?? 0;
+
+    this.subscribeCalls.set(channel, subscribeCount + 1);
+
     const handlers = this.subscriptions.get(channel) ?? [];
     handlers.push(handler);
     this.subscriptions.set(channel, handlers);
@@ -48,6 +54,10 @@ class MockRedisClient {
       throw new Error("Redis connection error");
     }
 
+    const unsubscribeCount = this.unsubscribeCalls.get(channel) ?? 0;
+
+    this.unsubscribeCalls.set(channel, unsubscribeCount + 1);
+
     this.subscriptions.delete(channel);
   }
 
@@ -57,6 +67,14 @@ class MockRedisClient {
 
   public getSubscriptions() {
     return this.subscriptions;
+  }
+
+  public getSubscribeCallCount(channel: string) {
+    return this.subscribeCalls.get(channel) ?? 0;
+  }
+
+  public getUnsubscribeCallCount(channel: string) {
+    return this.unsubscribeCalls.get(channel) ?? 0;
   }
 }
 
@@ -76,14 +94,14 @@ describe("PubSub", () => {
 
       const messages: Array<{ userId: string; action: string }> = [];
 
-      const [subscribeError, subscriberCount] = await pubsub.subscribe(
+      const [subscribeError, unsubscribeHandler] = await pubsub.subscribe(
         async (message) => {
           messages.push(message);
         },
       );
 
       expect(subscribeError).toBeNull();
-      expect(subscriberCount).toBe(1);
+      expect(typeof unsubscribeHandler).toBe("function");
       expect(pubsub.isActive()).toBe(true);
 
       const [publishError, count] = await pubsub.publish({
@@ -141,7 +159,7 @@ describe("PubSub", () => {
       expect(redis.getSubscriptions().size).toBe(0);
     });
 
-    test("should return error when subscribing twice", async () => {
+    test("should fan out messages to multiple handlers on one instance", async () => {
       const redis = createMockRedis();
       const pubsub = new PubSub<{ message: string }>({
         subscriber: redis,
@@ -149,21 +167,35 @@ describe("PubSub", () => {
         channel: "test",
       });
 
-      const [error1, count1] = await pubsub.subscribe(async () => {});
+      const handler1Messages: string[] = [];
+      const handler2Messages: string[] = [];
+
+      const [error1] = await pubsub.subscribe(async (message) => {
+        handler1Messages.push(message.message);
+      });
+
+      const [error2] = await pubsub.subscribe(async (message) => {
+        handler2Messages.push(message.message);
+      });
 
       expect(error1).toBeNull();
-      expect(count1).toBe(1);
+      expect(error2).toBeNull();
 
-      const [error2, count2] = await pubsub.subscribe(async () => {});
-
-      expect(error2).toEqual({
-        type: "SubscribeError",
-        message: "Already subscribed",
+      const [publishError, publishCount] = await pubsub.publish({
+        message: "hello",
       });
-      expect(count2).toBeNull();
+
+      expect(publishError).toBeNull();
+      expect(publishCount).toBe(1);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(handler1Messages).toEqual(["hello"]);
+      expect(handler2Messages).toEqual(["hello"]);
+      expect(redis.getSubscribeCallCount("test")).toBe(1);
     });
 
-    test("should return subscriber count on successful subscribe", async () => {
+    test("should return handler-level unsubscribe function", async () => {
       const redis = createMockRedis();
       const pubsub = new PubSub<{ message: string }>({
         subscriber: redis,
@@ -171,12 +203,15 @@ describe("PubSub", () => {
         channel: "test",
       });
 
-      const [, count] = await pubsub.subscribe(async () => {});
+      const [error, unsubscribeHandler] = await pubsub.subscribe(
+        async () => {},
+      );
 
-      expect(count).toBe(1);
+      expect(error).toBeNull();
+      expect(typeof unsubscribeHandler).toBe("function");
     });
 
-    test("should return null count on subscribe error", async () => {
+    test("should return null unsubscribe function on subscribe error", async () => {
       const redis = createMockRedis();
       const pubsub = new PubSub<{ message: string }>({
         subscriber: redis,
@@ -186,12 +221,18 @@ describe("PubSub", () => {
 
       redis.setShouldFail(true);
 
-      const [, count] = await pubsub.subscribe(async () => {});
+      const [error, unsubscribeHandler] = await pubsub.subscribe(
+        async () => {},
+      );
 
-      expect(count).toBeNull();
+      expect(error).toEqual({
+        type: "SubscribeError",
+        message: "Unable to subscribe to test",
+      });
+      expect(unsubscribeHandler).toBeNull();
     });
 
-    test("should increment subscriber count with multiple subscribers", async () => {
+    test("should increment subscriber count with multiple PubSub instances", async () => {
       const redis = createMockRedis();
 
       const pubsub1 = new PubSub<{ message: string }>({
@@ -212,13 +253,17 @@ describe("PubSub", () => {
         channel: "shared-channel",
       });
 
-      const [, count1] = await pubsub1.subscribe(async () => {});
-      const [, count2] = await pubsub2.subscribe(async () => {});
-      const [, count3] = await pubsub3.subscribe(async () => {});
+      const [error1] = await pubsub1.subscribe(async () => {});
+      const [error2] = await pubsub2.subscribe(async () => {});
+      const [error3] = await pubsub3.subscribe(async () => {});
 
-      expect(count1).toBe(1);
-      expect(count2).toBe(2);
-      expect(count3).toBe(3);
+      expect(error1).toBeNull();
+      expect(error2).toBeNull();
+      expect(error3).toBeNull();
+
+      const subscribers = redis.getSubscriptions().get("shared-channel") ?? [];
+
+      expect(subscribers).toHaveLength(3);
     });
 
     test("should return error when unsubscribing without subscription", async () => {
@@ -476,14 +521,16 @@ describe("PubSub", () => {
 
       redis.setShouldFail(true);
 
-      const [error, count] = await pubsub.subscribe(async () => {});
+      const [error, unsubscribeHandler] = await pubsub.subscribe(
+        async () => {},
+      );
 
       expect(error).toEqual({
         type: "SubscribeError",
         message: "Unable to subscribe to test",
       });
 
-      expect(count).toBeNull();
+      expect(unsubscribeHandler).toBeNull();
       expect(pubsub.isActive()).toBe(false);
     });
 
@@ -709,6 +756,74 @@ describe("PubSub", () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(callCount).toBe(11); // Old handler not called, new one adds 10
+    });
+
+    test("should unsubscribe one handler without affecting others", async () => {
+      const redis = createMockRedis();
+      const pubsub = new PubSub<{ message: string }>({
+        subscriber: redis,
+        publisher: redis,
+        channel: "test",
+      });
+
+      const handler1Messages: string[] = [];
+      const handler2Messages: string[] = [];
+
+      const [, unsubscribeHandler1] = await pubsub.subscribe(
+        async (message) => {
+          handler1Messages.push(message.message);
+        },
+      );
+
+      await pubsub.subscribe(async (message) => {
+        handler2Messages.push(message.message);
+      });
+
+      if (!unsubscribeHandler1) {
+        throw new Error("Expected unsubscribe handler");
+      }
+
+      await unsubscribeHandler1();
+
+      await pubsub.publish({ message: "fanout" });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(handler1Messages).toHaveLength(0);
+      expect(handler2Messages).toEqual(["fanout"]);
+      expect(pubsub.isActive()).toBe(true);
+    });
+
+    test("should unsubscribe Redis only when last handler is removed", async () => {
+      const redis = createMockRedis();
+      const pubsub = new PubSub<{ message: string }>({
+        subscriber: redis,
+        publisher: redis,
+        channel: "test",
+      });
+
+      const [, unsubscribeHandler1] = await pubsub.subscribe(async () => {});
+      const [, unsubscribeHandler2] = await pubsub.subscribe(async () => {});
+
+      if (!unsubscribeHandler1) {
+        throw new Error("Expected unsubscribe handlers");
+      }
+
+      if (!unsubscribeHandler2) {
+        throw new Error("Expected unsubscribe handlers");
+      }
+
+      expect(redis.getSubscribeCallCount("test")).toBe(1);
+      expect(redis.getUnsubscribeCallCount("test")).toBe(0);
+
+      await unsubscribeHandler1();
+
+      expect(redis.getUnsubscribeCallCount("test")).toBe(0);
+      expect(pubsub.isActive()).toBe(true);
+
+      await unsubscribeHandler2();
+
+      expect(redis.getUnsubscribeCallCount("test")).toBe(1);
+      expect(pubsub.isActive()).toBe(false);
     });
 
     test("should prevent concurrent unsubscribe calls", async () => {

--- a/src/lib/pubsub/index.test.ts
+++ b/src/lib/pubsub/index.test.ts
@@ -8,9 +8,43 @@ class MockRedisClient {
   private subscribeCalls = new Map<string, number>();
   private unsubscribeCalls = new Map<string, number>();
   private shouldFail = false;
+  private subscribeGate: Promise<void> | null = null;
+  private releaseSubscribeGate: (() => void) | null = null;
+  private unsubscribeGate: Promise<void> | null = null;
+  private releaseUnsubscribeGate: (() => void) | null = null;
 
   public setShouldFail(value: boolean) {
     this.shouldFail = value;
+  }
+
+  public blockNextSubscribe() {
+    this.subscribeGate = new Promise((resolve) => {
+      this.releaseSubscribeGate = resolve;
+    });
+  }
+
+  public unblockNextSubscribe() {
+    if (!this.releaseSubscribeGate) {
+      return;
+    }
+
+    this.releaseSubscribeGate();
+    this.releaseSubscribeGate = null;
+  }
+
+  public blockNextUnsubscribe() {
+    this.unsubscribeGate = new Promise((resolve) => {
+      this.releaseUnsubscribeGate = resolve;
+    });
+  }
+
+  public unblockNextUnsubscribe() {
+    if (!this.releaseUnsubscribeGate) {
+      return;
+    }
+
+    this.releaseUnsubscribeGate();
+    this.releaseUnsubscribeGate = null;
   }
 
   public async publish(channel: string, message: string) {
@@ -34,6 +68,11 @@ class MockRedisClient {
   }
 
   public async subscribe(channel: string, handler: Handler) {
+    if (this.subscribeGate) {
+      await this.subscribeGate;
+      this.subscribeGate = null;
+    }
+
     if (this.shouldFail) {
       throw new Error("Redis connection error");
     }
@@ -50,6 +89,11 @@ class MockRedisClient {
   }
 
   public async unsubscribe(channel: string) {
+    if (this.unsubscribeGate) {
+      await this.unsubscribeGate;
+      this.unsubscribeGate = null;
+    }
+
     if (this.shouldFail) {
       throw new Error("Redis connection error");
     }
@@ -629,9 +673,12 @@ describe("PubSub", () => {
         throw new Error("Synchronous handler error");
       });
 
-      await pubsub.publish({ message: "test" });
+      const [publishError, count] = await pubsub.publish({ message: "test" });
 
       await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(publishError).toBeNull();
+      expect(count).toBe(1);
 
       // Handler was called and threw error
       expect(errorThrown).toBe(true);
@@ -854,6 +901,132 @@ describe("PubSub", () => {
       expect(successCount).toBe(1);
       expect(failureCount).toBe(1);
       expect(pubsub.isActive()).toBe(false);
+    });
+
+    test("should not report active while subscribe is in flight", async () => {
+      const redis = createMockRedis();
+      const pubsub = new PubSub<{ message: string }>({
+        subscriber: redis,
+        publisher: redis,
+        channel: "test",
+      });
+
+      redis.blockNextSubscribe();
+
+      const subscribePromise = pubsub.subscribe(async () => {});
+
+      await Promise.resolve();
+
+      expect(pubsub.isActive()).toBe(false);
+
+      const [unsubscribeError] = await pubsub.unsubscribe();
+
+      expect(unsubscribeError).toEqual({
+        type: "UnsubscribeError",
+        message: "Not subscribed",
+      });
+
+      redis.unblockNextSubscribe();
+
+      const [subscribeError, unsubscribeHandler] = await subscribePromise;
+
+      expect(subscribeError).toBeNull();
+      expect(typeof unsubscribeHandler).toBe("function");
+      expect(pubsub.isActive()).toBe(true);
+    });
+
+    test("should serialize subscribe while unsubscribe is in flight", async () => {
+      const redis = createMockRedis();
+      const pubsub = new PubSub<{ message: string }>({
+        subscriber: redis,
+        publisher: redis,
+        channel: "test",
+      });
+
+      const received: string[] = [];
+
+      const [, unsubscribeHandler] = await pubsub.subscribe(async () => {});
+
+      if (!unsubscribeHandler) {
+        throw new Error("Expected unsubscribe handler");
+      }
+
+      redis.blockNextUnsubscribe();
+
+      const unsubscribePromise = unsubscribeHandler();
+      const subscribePromise = pubsub.subscribe(async (message) => {
+        received.push(message.message);
+      });
+
+      let subscribeResolved = false;
+
+      subscribePromise.then(() => {
+        subscribeResolved = true;
+      });
+
+      await Promise.resolve();
+
+      expect(subscribeResolved).toBe(false);
+
+      redis.unblockNextUnsubscribe();
+
+      const [unsubscribeError] = await unsubscribePromise;
+
+      expect(unsubscribeError).toBeNull();
+
+      const [subscribeError] = await subscribePromise;
+
+      expect(subscribeError).toBeNull();
+
+      const [publishError, count] = await pubsub.publish({
+        message: "after-race",
+      });
+
+      expect(publishError).toBeNull();
+      expect(count).toBe(1);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(received).toEqual(["after-race"]);
+      expect(redis.getUnsubscribeCallCount("test")).toBe(1);
+      expect(redis.getSubscribeCallCount("test")).toBe(2);
+    });
+
+    test("should remove new handler when in-flight subscribe fails", async () => {
+      const redis = createMockRedis();
+      const pubsub = new PubSub<{ message: string }>({
+        subscriber: redis,
+        publisher: redis,
+        channel: "test",
+      });
+
+      redis.blockNextSubscribe();
+
+      const subscribePromise = pubsub.subscribe(async () => {});
+
+      await Promise.resolve();
+
+      redis.setShouldFail(true);
+      redis.unblockNextSubscribe();
+
+      const [subscribeError, unsubscribeHandler] = await subscribePromise;
+
+      expect(subscribeError).toEqual({
+        type: "SubscribeError",
+        message: "Unable to subscribe to test",
+      });
+      expect(unsubscribeHandler).toBeNull();
+      expect(pubsub.isActive()).toBe(false);
+      expect(redis.getSubscribeCallCount("test")).toBe(0);
+
+      redis.setShouldFail(false);
+
+      const [publishError, count] = await pubsub.publish({
+        message: "should-not-deliver",
+      });
+
+      expect(publishError).toBeNull();
+      expect(count).toBe(0);
     });
   });
 });

--- a/src/lib/pubsub/index.ts
+++ b/src/lib/pubsub/index.ts
@@ -6,6 +6,9 @@ export class PubSub<T extends Record<string, unknown>> {
   private isSubscribed = false;
   private nextHandlerId = 0;
   private handlers = new Map<number, MessageHandler<T>>();
+  private unsubscribeInFlight: Promise<
+    readonly [null, unknown] | readonly [unknown, null]
+  > | null = null;
   private subscribeInFlight: Promise<
     readonly [null, number] | readonly [unknown, null]
   > | null = null;
@@ -23,11 +26,17 @@ export class PubSub<T extends Record<string, unknown>> {
     const handlers = Array.from(this.handlers.values());
 
     for (const handler of handlers) {
-      await mightThrow(Promise.resolve(handler(parsed, channel)));
+      await mightThrow(Promise.resolve().then(() => handler(parsed, channel)));
     }
   }
 
   private async unsubscribeHandler(handlerId: number) {
+    const inFlightUnsubscribe = this.unsubscribeInFlight;
+
+    if (inFlightUnsubscribe) {
+      await inFlightUnsubscribe;
+    }
+
     const handler = this.handlers.get(handlerId);
 
     if (!handler) {
@@ -42,11 +51,13 @@ export class PubSub<T extends Record<string, unknown>> {
 
     this.isSubscribed = false;
 
-    const [unsubscribeError] = await mightThrow(
+    this.unsubscribeInFlight = mightThrow(
       this.options.subscriber.unsubscribe(this.options.channel),
     );
 
-    if (unsubscribeError) {
+    const unsubscribeInFlight = this.unsubscribeInFlight;
+
+    if (!unsubscribeInFlight) {
       this.handlers.set(handlerId, handler);
       this.isSubscribed = true;
 
@@ -55,6 +66,21 @@ export class PubSub<T extends Record<string, unknown>> {
         `Unable to unsubscribe from ${this.options.channel}`,
       );
     }
+
+    const [unsubscribeError] = await unsubscribeInFlight;
+
+    if (unsubscribeError) {
+      this.handlers.set(handlerId, handler);
+      this.isSubscribed = true;
+      this.unsubscribeInFlight = null;
+
+      return err(
+        "UnsubscribeError",
+        `Unable to unsubscribe from ${this.options.channel}`,
+      );
+    }
+
+    this.unsubscribeInFlight = null;
 
     return ok(true);
   }
@@ -83,6 +109,12 @@ export class PubSub<T extends Record<string, unknown>> {
   }
 
   public async subscribe(handler: MessageHandler<T>) {
+    const inFlightUnsubscribe = this.unsubscribeInFlight;
+
+    if (inFlightUnsubscribe) {
+      await inFlightUnsubscribe;
+    }
+
     const handlerId = this.nextHandlerId;
 
     this.nextHandlerId += 1;
@@ -109,8 +141,6 @@ export class PubSub<T extends Record<string, unknown>> {
       return ok(() => this.unsubscribeHandler(handlerId));
     }
 
-    this.isSubscribed = true;
-
     this.subscribeInFlight = mightThrow(
       this.options.subscriber.subscribe(
         this.options.channel,
@@ -122,7 +152,6 @@ export class PubSub<T extends Record<string, unknown>> {
 
     if (!subscribeInFlight) {
       this.handlers.delete(handlerId);
-      this.isSubscribed = false;
 
       return err(
         "SubscribeError",
@@ -135,7 +164,6 @@ export class PubSub<T extends Record<string, unknown>> {
     this.subscribeInFlight = null;
 
     if (subscribeError) {
-      this.isSubscribed = false;
       this.handlers.delete(handlerId);
 
       return err(
@@ -146,7 +174,6 @@ export class PubSub<T extends Record<string, unknown>> {
 
     if (!count) {
       this.handlers.delete(handlerId);
-      this.isSubscribed = false;
 
       return err(
         "SubscribeError",
@@ -154,10 +181,18 @@ export class PubSub<T extends Record<string, unknown>> {
       );
     }
 
+    this.isSubscribed = true;
+
     return ok(() => this.unsubscribeHandler(handlerId));
   }
 
   public async unsubscribe() {
+    const inFlightUnsubscribe = this.unsubscribeInFlight;
+
+    if (inFlightUnsubscribe) {
+      await inFlightUnsubscribe;
+    }
+
     if (!this.isActive()) {
       return err("UnsubscribeError", "Not subscribed");
     }
@@ -168,11 +203,13 @@ export class PubSub<T extends Record<string, unknown>> {
 
     this.isSubscribed = false;
 
-    const [unsubscribeError] = await mightThrow(
+    this.unsubscribeInFlight = mightThrow(
       this.options.subscriber.unsubscribe(this.options.channel),
     );
 
-    if (unsubscribeError) {
+    const unsubscribeInFlight = this.unsubscribeInFlight;
+
+    if (!unsubscribeInFlight) {
       this.handlers = handlers;
       this.isSubscribed = true;
 
@@ -181,6 +218,21 @@ export class PubSub<T extends Record<string, unknown>> {
         `Unable to unsubscribe from ${this.options.channel}`,
       );
     }
+
+    const [unsubscribeError] = await unsubscribeInFlight;
+
+    if (unsubscribeError) {
+      this.handlers = handlers;
+      this.isSubscribed = true;
+      this.unsubscribeInFlight = null;
+
+      return err(
+        "UnsubscribeError",
+        `Unable to unsubscribe from ${this.options.channel}`,
+      );
+    }
+
+    this.unsubscribeInFlight = null;
 
     return ok(true);
   }

--- a/src/lib/pubsub/index.ts
+++ b/src/lib/pubsub/index.ts
@@ -4,9 +4,59 @@ import type { MessageHandler, PubSubOptions } from "./types.js";
 export class PubSub<T extends Record<string, unknown>> {
   private options: PubSubOptions;
   private isSubscribed = false;
+  private nextHandlerId = 0;
+  private handlers = new Map<number, MessageHandler<T>>();
+  private subscribeInFlight: Promise<
+    readonly [null, number] | readonly [unknown, null]
+  > | null = null;
 
   public constructor(options: PubSubOptions) {
     this.options = options;
+  }
+
+  private async onMessage(message: string, channel: string) {
+    const [parseError, parsed] = mightThrowSync<T>(() => JSON.parse(message));
+
+    if (parseError) return;
+    if (!parsed) return;
+
+    const handlers = Array.from(this.handlers.values());
+
+    for (const handler of handlers) {
+      await mightThrow(Promise.resolve(handler(parsed, channel)));
+    }
+  }
+
+  private async unsubscribeHandler(handlerId: number) {
+    const handler = this.handlers.get(handlerId);
+
+    if (!handler) {
+      return err("UnsubscribeError", "Not subscribed");
+    }
+
+    this.handlers.delete(handlerId);
+
+    if (this.handlers.size > 0) {
+      return ok(true);
+    }
+
+    this.isSubscribed = false;
+
+    const [unsubscribeError] = await mightThrow(
+      this.options.subscriber.unsubscribe(this.options.channel),
+    );
+
+    if (unsubscribeError) {
+      this.handlers.set(handlerId, handler);
+      this.isSubscribed = true;
+
+      return err(
+        "UnsubscribeError",
+        `Unable to unsubscribe from ${this.options.channel}`,
+      );
+    }
+
+    return ok(true);
   }
 
   public async publish(message: T) {
@@ -33,26 +83,45 @@ export class PubSub<T extends Record<string, unknown>> {
   }
 
   public async subscribe(handler: MessageHandler<T>) {
+    const handlerId = this.nextHandlerId;
+
+    this.nextHandlerId += 1;
+    this.handlers.set(handlerId, handler);
+
     if (this.isActive()) {
-      return err("SubscribeError", "Already subscribed");
+      return ok(() => this.unsubscribeHandler(handlerId));
+    }
+
+    const inFlightSubscribe = this.subscribeInFlight;
+
+    if (inFlightSubscribe) {
+      const [inFlightError] = await inFlightSubscribe;
+
+      if (inFlightError || !this.isSubscribed) {
+        this.handlers.delete(handlerId);
+
+        return err(
+          "SubscribeError",
+          `Unable to subscribe to ${this.options.channel}`,
+        );
+      }
+
+      return ok(() => this.unsubscribeHandler(handlerId));
     }
 
     this.isSubscribed = true;
 
-    const wrappedHandler = async (message: string, channel: string) => {
-      const [parseError, parsed] = mightThrowSync<T>(() => JSON.parse(message));
-
-      if (parseError) return;
-      if (!parsed) return;
-
-      await mightThrow(Promise.resolve(handler(parsed, channel)));
-    };
-
-    const [subscribeError, count] = await mightThrow(
-      this.options.subscriber.subscribe(this.options.channel, wrappedHandler),
+    this.subscribeInFlight = mightThrow(
+      this.options.subscriber.subscribe(
+        this.options.channel,
+        async (message, channel) => this.onMessage(message, channel),
+      ),
     );
 
-    if (subscribeError) {
+    const subscribeInFlight = this.subscribeInFlight;
+
+    if (!subscribeInFlight) {
+      this.handlers.delete(handlerId);
       this.isSubscribed = false;
 
       return err(
@@ -61,13 +130,41 @@ export class PubSub<T extends Record<string, unknown>> {
       );
     }
 
-    return ok(count);
+    const [subscribeError, count] = await subscribeInFlight;
+
+    this.subscribeInFlight = null;
+
+    if (subscribeError) {
+      this.isSubscribed = false;
+      this.handlers.delete(handlerId);
+
+      return err(
+        "SubscribeError",
+        `Unable to subscribe to ${this.options.channel}`,
+      );
+    }
+
+    if (!count) {
+      this.handlers.delete(handlerId);
+      this.isSubscribed = false;
+
+      return err(
+        "SubscribeError",
+        `Unable to subscribe to ${this.options.channel}`,
+      );
+    }
+
+    return ok(() => this.unsubscribeHandler(handlerId));
   }
 
   public async unsubscribe() {
     if (!this.isActive()) {
       return err("UnsubscribeError", "Not subscribed");
     }
+
+    const handlers = new Map(this.handlers);
+
+    this.handlers.clear();
 
     this.isSubscribed = false;
 
@@ -76,6 +173,7 @@ export class PubSub<T extends Record<string, unknown>> {
     );
 
     if (unsubscribeError) {
+      this.handlers = handlers;
       this.isSubscribed = true;
 
       return err(
@@ -88,6 +186,6 @@ export class PubSub<T extends Record<string, unknown>> {
   }
 
   public isActive() {
-    return this.isSubscribed;
+    return this.handlers.size > 0 && this.isSubscribed;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PubSub supports multiple local handlers with fan-out; `subscribe()` now returns a handler-level unsubscribe function.

* **Documentation**
  * Docs and examples updated to show handler-level unsubscribe usage and clarified overall unsubscribe behavior and semantics; README example updated to perform handler cleanup.

* **Bug Fixes**
  * Improved lifecycle and concurrency behavior to avoid races and ensure proper teardown semantics.

* **Tests**
  * Expanded tests covering multi-handler delivery, unsubscribe sequencing, error paths, and race conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->