### PR TITLE
Coerce SQLite boolean values

### DIFF
--- a/src/lib/orm/dialect/sqlite.test.ts
+++ b/src/lib/orm/dialect/sqlite.test.ts
@@ -226,7 +226,7 @@ describe("buildFindManyQuery", () => {
     );
     expect(query.params).toEqual([]);
     expect(query.includeDescriptors).toEqual([
-      { name: "posts", type: "hasMany" },
+      expect.objectContaining({ name: "posts", type: "hasMany" }),
     ]);
   });
 
@@ -244,7 +244,7 @@ describe("buildFindManyQuery", () => {
     );
     expect(query.params).toEqual([]);
     expect(query.includeDescriptors).toEqual([
-      { name: "author", type: "hasOne" },
+      expect.objectContaining({ name: "author", type: "hasOne" }),
     ]);
   });
 
@@ -337,7 +337,7 @@ describe("buildFindManyQuery", () => {
       'SELECT "code" AS code, "name" AS name, COALESCE((SELECT json_group_array(json_object(\'id\', members__members."id", \'groupCode\', members__members."group_code")) FROM "members" AS members__members WHERE members__members."group_code" = "groups"."code"), \'[]\') AS members FROM "groups"',
     );
     expect(query.includeDescriptors).toEqual([
-      { name: "members", type: "hasMany" },
+      expect.objectContaining({ name: "members", type: "hasMany" }),
     ]);
   });
 
@@ -492,7 +492,7 @@ describe("buildFindFirstQuery", () => {
     );
     expect(query.params).toEqual([1, 2]);
     expect(query.includeDescriptors).toEqual([
-      { name: "posts", type: "hasMany" },
+      expect.objectContaining({ name: "posts", type: "hasMany" }),
     ]);
   });
 });
@@ -500,11 +500,11 @@ describe("buildFindFirstQuery", () => {
 describe("parseIncludeRows", () => {
   test("parses JSON include values and normalizes null hasMany values", () => {
     const descriptors = [
-      { name: "posts", type: "hasMany" },
-      { name: "author", type: "hasOne" },
+      { name: "posts", type: "hasMany", table: postsTable },
+      { name: "author", type: "hasOne", table: usersTable },
     ] satisfies Array<IncludeDescriptor>;
 
-    const rows = [
+    const rows: Array<Record<string, unknown>> = [
       { id: "u1", posts: null, author: null },
       {
         id: "u2",
@@ -513,9 +513,9 @@ describe("parseIncludeRows", () => {
       },
     ];
 
-    const parsed = parseIncludeRows(rows, descriptors);
+    parseIncludeRows(usersTable, rows, descriptors);
 
-    expect(parsed).toEqual([
+    expect(rows).toEqual([
       { id: "u1", posts: [], author: null },
       {
         id: "u2",
@@ -889,7 +889,7 @@ describe("buildUpdateQuery", () => {
     );
     expect(query.params).toEqual(["Jane", "user-1"]);
     expect(query.includeDescriptors).toEqual([
-      { name: "posts", type: "hasMany" },
+      expect.objectContaining({ name: "posts", type: "hasMany" }),
     ]);
   });
 
@@ -909,7 +909,7 @@ describe("buildUpdateQuery", () => {
     );
     expect(query.params).toEqual(["Updated", "post-1"]);
     expect(query.includeDescriptors).toEqual([
-      { name: "author", type: "hasOne" },
+      expect.objectContaining({ name: "author", type: "hasOne" }),
     ]);
   });
 });
@@ -1082,7 +1082,7 @@ describe("buildDeleteQuery", () => {
     );
     expect(query.params).toEqual(["user-1"]);
     expect(query.includeDescriptors).toEqual([
-      { name: "posts", type: "hasMany" },
+      expect.objectContaining({ name: "posts", type: "hasMany" }),
     ]);
   });
 
@@ -1101,7 +1101,7 @@ describe("buildDeleteQuery", () => {
     );
     expect(query.params).toEqual(["post-1"]);
     expect(query.includeDescriptors).toEqual([
-      { name: "author", type: "hasOne" },
+      expect.objectContaining({ name: "author", type: "hasOne" }),
     ]);
   });
 

--- a/src/lib/orm/dialect/sqlite.test.ts
+++ b/src/lib/orm/dialect/sqlite.test.ts
@@ -1785,3 +1785,88 @@ describe("createSqliteDialect - deleteMany", () => {
     await sql.close();
   });
 });
+
+const nullableFlagsTable = defineTable("flags", {
+  id: uuid("id").primaryKey().notNull(),
+  isEnabled: boolean("is_enabled"),
+});
+
+const CREATE_FLAGS_TABLE_SQL =
+  "CREATE TABLE flags (id TEXT PRIMARY KEY, is_enabled INTEGER)";
+
+const createFlagsTable = async (sql: Bun.SQL) => {
+  await sql.unsafe(CREATE_FLAGS_TABLE_SQL);
+};
+
+describe("coerceBooleanColumns - nullable boolean", () => {
+  test("findMany preserves null for nullable boolean column", async () => {
+    const sql = createMemorySql();
+
+    await createFlagsTable(sql);
+    await sql.unsafe("INSERT INTO flags (id, is_enabled) VALUES (?, ?)", [
+      "flag-1",
+      null,
+    ]);
+
+    const dialect = createSqliteDialect(nullableFlagsTable, {});
+    const rows = await dialect.findMany(sql);
+
+    expect(rows[0]?.isEnabled).toBeNull();
+
+    await sql.close();
+  });
+
+  test("findMany coerces non-null integer to boolean", async () => {
+    const sql = createMemorySql();
+
+    await createFlagsTable(sql);
+    await sql.unsafe("INSERT INTO flags (id, is_enabled) VALUES (?, ?)", [
+      "flag-1",
+      0,
+    ]);
+    await sql.unsafe("INSERT INTO flags (id, is_enabled) VALUES (?, ?)", [
+      "flag-2",
+      1,
+    ]);
+
+    const dialect = createSqliteDialect(nullableFlagsTable, {});
+    const rows = await dialect.findMany(sql, { orderBy: { id: "asc" } });
+
+    expect(rows[0]?.isEnabled).toBe(false);
+    expect(rows[1]?.isEnabled).toBe(true);
+
+    await sql.close();
+  });
+
+  test("findUnique preserves null for nullable boolean column", async () => {
+    const sql = createMemorySql();
+
+    await createFlagsTable(sql);
+    await sql.unsafe("INSERT INTO flags (id, is_enabled) VALUES (?, ?)", [
+      "flag-1",
+      null,
+    ]);
+
+    const dialect = createSqliteDialect(nullableFlagsTable, {});
+    const row = await dialect.findUnique(sql, { where: { id: "flag-1" } });
+
+    expect(row?.isEnabled).toBeNull();
+
+    await sql.close();
+  });
+
+  test("create preserves null for nullable boolean column", async () => {
+    const sql = createMemorySql();
+
+    await createFlagsTable(sql);
+
+    const dialect = createSqliteDialect(nullableFlagsTable, {});
+    const row = await dialect.create(sql, {
+      data: { id: "flag-1" },
+    });
+
+    expect(row.isEnabled).toBeNull();
+
+    await sql.close();
+  });
+});

--- a/src/lib/orm/dialect/sqlite.test.ts
+++ b/src/lib/orm/dialect/sqlite.test.ts
@@ -663,6 +663,54 @@ describe("createSqliteDialect", () => {
 
     await sql.close();
   });
+
+  test("findUnique returns boolean fields as booleans", async () => {
+    const sql = createMemorySql();
+
+    await createUsersTable(sql);
+    await insertUser(sql, "user-1", "John", "2025-01-01T00:00:00.000Z", false);
+
+    const dialect = createSqliteDialect(usersTable, {});
+    const row = await dialect.findUnique(sql, { where: { id: "user-1" } });
+
+    expect(row?.isActive).toBe(false);
+
+    await sql.close();
+  });
+
+  test("findFirst returns boolean fields as booleans", async () => {
+    const sql = createMemorySql();
+
+    await createUsersTable(sql);
+    await insertUser(sql, "user-1", "John", "2025-01-01T00:00:00.000Z", false);
+
+    const dialect = createSqliteDialect(usersTable, {});
+    const row = await dialect.findFirst(sql, { where: { id: "user-1" } });
+
+    expect(row?.isActive).toBe(false);
+
+    await sql.close();
+  });
+
+  test("create returns boolean fields as booleans", async () => {
+    const sql = createMemorySql();
+
+    await createUsersTable(sql);
+
+    const dialect = createSqliteDialect(usersTable, {});
+    const row = await dialect.create(sql, {
+      data: {
+        id: "user-1",
+        firstName: "John",
+        createdAt: new Date("2025-01-01T00:00:00.000Z"),
+        isActive: false,
+      },
+    });
+
+    expect(row.isActive).toBe(false);
+
+    await sql.close();
+  });
 });
 
 describe("buildUpdateQuery", () => {
@@ -933,6 +981,23 @@ describe("createSqliteDialect - update", () => {
 
     await sql.close();
   });
+
+  test("returns boolean fields as booleans", async () => {
+    const sql = createMemorySql();
+
+    await createUsersTable(sql);
+    await insertUser(sql, "user-1", "John", "2025-01-01T00:00:00.000Z", false);
+
+    const dialect = createSqliteDialect(usersTable, {});
+    const row = await dialect.update(sql, {
+      where: { id: "user-1" },
+      data: { firstName: "Jane" },
+    });
+
+    expect(row.isActive).toBe(false);
+
+    await sql.close();
+  });
 });
 
 describe("buildDeleteQuery", () => {
@@ -1128,6 +1193,20 @@ describe("createSqliteDialect - delete", () => {
     expect(deleted.posts).toEqual([
       { id: "post-1", title: "Hello", authorId: "user-1" },
     ]);
+
+    await sql.close();
+  });
+
+  test("returns boolean fields as booleans", async () => {
+    const sql = createMemorySql();
+
+    await createUsersTable(sql);
+    await insertUser(sql, "user-1", "John", "2025-01-01T00:00:00.000Z", false);
+
+    const dialect = createSqliteDialect(usersTable, {});
+    const row = await dialect.delete(sql, { where: { id: "user-1" } });
+
+    expect(row.isActive).toBe(false);
 
     await sql.close();
   });
@@ -1445,6 +1524,28 @@ describe("createSqliteDialect - createMany", () => {
 
     await sql.close();
   });
+
+  test("returns boolean fields as booleans", async () => {
+    const sql = createMemorySql();
+
+    await createUsersTable(sql);
+
+    const dialect = createSqliteDialect(usersTable, {});
+    const rows = await dialect.createMany(sql, {
+      data: [
+        {
+          id: "user-1",
+          firstName: "John",
+          createdAt: new Date("2025-01-01T00:00:00.000Z"),
+          isActive: false,
+        },
+      ],
+    });
+
+    expect(rows[0]?.isActive).toBe(false);
+
+    await sql.close();
+  });
 });
 
 describe("createSqliteDialect - updateMany", () => {
@@ -1535,6 +1636,23 @@ describe("createSqliteDialect - updateMany", () => {
     expect(new Date(updated?.createdAt ?? 0).toISOString()).toBe(
       newDate.toISOString(),
     );
+
+    await sql.close();
+  });
+
+  test("returns boolean fields as booleans", async () => {
+    const sql = createMemorySql();
+
+    await createUsersTable(sql);
+    await insertUser(sql, "user-1", "John", "2025-01-01T00:00:00.000Z", false);
+
+    const dialect = createSqliteDialect(usersTable, {});
+    const rows = await dialect.updateMany(sql, {
+      where: { id: "user-1" },
+      data: { firstName: "John" },
+    });
+
+    expect(rows[0]?.isActive).toBe(false);
 
     await sql.close();
   });
@@ -1649,6 +1767,20 @@ describe("createSqliteDialect - deleteMany", () => {
     const remaining = await dialect.findMany(sql);
 
     expect(remaining[0]?.firstName).toBe("Alice");
+
+    await sql.close();
+  });
+
+  test("returns boolean fields as booleans", async () => {
+    const sql = createMemorySql();
+
+    await createUsersTable(sql);
+    await insertUser(sql, "user-1", "John", "2025-01-01T00:00:00.000Z", false);
+
+    const dialect = createSqliteDialect(usersTable, {});
+    const rows = await dialect.deleteMany(sql, { where: { id: "user-1" } });
+
+    expect(rows[0]?.isActive).toBe(false);
 
     await sql.close();
   });

--- a/src/lib/orm/dialect/sqlite.test.ts
+++ b/src/lib/orm/dialect/sqlite.test.ts
@@ -363,7 +363,8 @@ describe("buildFindManyQuery", () => {
       buildFindManyQuery(
         usersTable,
         {},
-        { where: { nonExistent: "x" } as never },
+        // @ts-expect-error testing invalid where key
+        { where: { nonExistent: "x" } },
       ),
     ).toThrow('Unknown where key "nonExistent" on table users');
   });
@@ -547,8 +548,8 @@ describe("parseIncludeRows", () => {
 
     parseIncludeRows(postsTable, rows, descriptors);
 
-    expect((rows[0]?.author as Record<string, unknown>)?.isActive).toBe(true);
-    expect((rows[1]?.author as Record<string, unknown>)?.isActive).toBe(false);
+    expect(rows[0]?.author).toMatchObject({ isActive: true });
+    expect(rows[1]?.author).toMatchObject({ isActive: false });
   });
 
   test("coerces boolean fields in a hasMany included relation", () => {
@@ -2006,8 +2007,10 @@ describe("boolean coercion in included relations", () => {
 
     const posts = rows[0]?.posts as Array<Record<string, unknown>>;
 
-    expect(posts[0]?.isFeatured).toBe(true);
-    expect(posts[1]?.isFeatured).toBe(false);
+    expect(posts).toHaveLength(2);
+    expect(posts.map((p) => p.isFeatured)).toEqual(
+      expect.arrayContaining([true, false]),
+    );
 
     await sql.close();
   });

--- a/src/lib/orm/dialect/sqlite.test.ts
+++ b/src/lib/orm/dialect/sqlite.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { date, string, uuid } from "../column/index.js";
+import { boolean, date, string, uuid } from "../column/index.js";
 import { many, one } from "../orm/index.js";
 import { defineTable } from "../table/index.js";
 import {
@@ -20,6 +20,9 @@ const usersTable = defineTable("users", {
   id: uuid("id").primaryKey().notNull(),
   firstName: string("first_name").notNull(),
   createdAt: date("created_at").notNull(),
+  isActive: boolean("is_active")
+    .notNull()
+    .default(() => true),
 });
 
 const postsTable = defineTable("posts", {
@@ -31,7 +34,7 @@ const postsTable = defineTable("posts", {
 });
 
 const CREATE_USERS_TABLE_SQL =
-  "CREATE TABLE users (id TEXT PRIMARY KEY, first_name TEXT NOT NULL, created_at TEXT NOT NULL)";
+  "CREATE TABLE users (id TEXT PRIMARY KEY, first_name TEXT NOT NULL, created_at TEXT NOT NULL, is_active INTEGER NOT NULL)";
 
 const CREATE_POSTS_TABLE_SQL =
   "CREATE TABLE posts (id TEXT PRIMARY KEY, title TEXT NOT NULL, author_id TEXT NOT NULL)";
@@ -53,10 +56,11 @@ const insertUser = async (
   id: string,
   firstName: string,
   createdAt: string,
+  isActive = true,
 ) => {
   await sql.unsafe(
-    "INSERT INTO users (id, first_name, created_at) VALUES (?, ?, ?)",
-    [id, firstName, createdAt],
+    "INSERT INTO users (id, first_name, created_at, is_active) VALUES (?, ?, ?, ?)",
+    [id, firstName, createdAt, isActive],
   );
 };
 
@@ -114,7 +118,7 @@ describe("buildFindManyQuery", () => {
     );
 
     expect(query.statement).toBe(
-      'SELECT "id" AS id, "first_name" AS firstName, "created_at" AS createdAt FROM "users" WHERE "first_name" LIKE ? ESCAPE \'\\\' AND "first_name" LIKE ? ESCAPE \'\\\' AND "first_name" LIKE ? ESCAPE \'\\\'',
+      'SELECT "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive FROM "users" WHERE "first_name" LIKE ? ESCAPE \'\\\' AND "first_name" LIKE ? ESCAPE \'\\\' AND "first_name" LIKE ? ESCAPE \'\\\'',
     );
     expect(query.params).toEqual([
       "a\\%\\_\\\\%",
@@ -144,7 +148,7 @@ describe("buildFindManyQuery", () => {
     );
 
     expect(query.statement).toBe(
-      'SELECT "id" AS id, "first_name" AS firstName, "created_at" AS createdAt FROM "users" WHERE "id" = ? AND "created_at" = ? AND "first_name" IS NULL',
+      'SELECT "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive FROM "users" WHERE "id" = ? AND "created_at" = ? AND "first_name" IS NULL',
     );
     expect(query.params).toEqual([idList, createdAt.toISOString()]);
     expect(query.includeDescriptors).toEqual([]);
@@ -154,7 +158,7 @@ describe("buildFindManyQuery", () => {
     const query = buildFindManyQuery(usersTable, {}, { skip: 3 });
 
     expect(query.statement).toBe(
-      'SELECT "id" AS id, "first_name" AS firstName, "created_at" AS createdAt FROM "users" LIMIT -1 OFFSET ?',
+      'SELECT "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive FROM "users" LIMIT -1 OFFSET ?',
     );
     expect(query.params).toEqual([3]);
   });
@@ -163,7 +167,7 @@ describe("buildFindManyQuery", () => {
     const query = buildFindManyQuery(usersTable, {}, { select: {} });
 
     expect(query.statement).toBe(
-      'SELECT "id" AS id, "first_name" AS firstName, "created_at" AS createdAt FROM "users"',
+      'SELECT "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive FROM "users"',
     );
     expect(query.params).toEqual([]);
     expect(query.includeDescriptors).toEqual([]);
@@ -179,7 +183,7 @@ describe("buildFindManyQuery", () => {
     );
 
     expect(query.statement).toBe(
-      'SELECT "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, COALESCE((SELECT json_group_array(json_object(\'id\', posts__posts."id", \'title\', posts__posts."title", \'authorId\', posts__posts."author_id")) FROM "posts" AS posts__posts WHERE posts__posts."author_id" = "users"."id"), \'[]\') AS posts FROM "users"',
+      'SELECT "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive, COALESCE((SELECT json_group_array(json_object(\'id\', posts__posts."id", \'title\', posts__posts."title", \'authorId\', posts__posts."author_id")) FROM "posts" AS posts__posts WHERE posts__posts."author_id" = "users"."id"), \'[]\') AS posts FROM "users"',
     );
     expect(query.params).toEqual([]);
     expect(query.includeDescriptors).toEqual([
@@ -197,7 +201,7 @@ describe("buildFindManyQuery", () => {
     );
 
     expect(query.statement).toBe(
-      'SELECT "id" AS id, "title" AS title, "author_id" AS authorId, (SELECT json_object(\'id\', author__users."id", \'firstName\', author__users."first_name", \'createdAt\', author__users."created_at") FROM "users" AS author__users WHERE author__users."id" = "posts"."author_id" LIMIT 1) AS author FROM "posts"',
+      'SELECT "id" AS id, "title" AS title, "author_id" AS authorId, (SELECT json_object(\'id\', author__users."id", \'firstName\', author__users."first_name", \'createdAt\', author__users."created_at", \'isActive\', author__users."is_active") FROM "users" AS author__users WHERE author__users."id" = "posts"."author_id" LIMIT 1) AS author FROM "posts"',
     );
     expect(query.params).toEqual([]);
     expect(query.includeDescriptors).toEqual([
@@ -218,7 +222,7 @@ describe("buildFindManyQuery", () => {
     );
 
     expect(query.statement).toBe(
-      'SELECT "id" AS id, "first_name" AS firstName, "created_at" AS createdAt FROM "users" LIMIT ?',
+      'SELECT "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive FROM "users" LIMIT ?',
     );
     expect(query.params).toEqual([2]);
     expect(query.includeDescriptors).toEqual([]);
@@ -339,7 +343,7 @@ describe("buildFindUniqueQuery", () => {
     );
 
     expect(query.statement).toBe(
-      'SELECT "id" AS id, "first_name" AS firstName, "created_at" AS createdAt FROM "users" WHERE "id" = ? LIMIT 1',
+      'SELECT "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive FROM "users" WHERE "id" = ? LIMIT 1',
     );
     expect(query.params).toEqual(["user-1"]);
     expect(query.includeDescriptors).toEqual([]);
@@ -358,7 +362,7 @@ describe("buildFindUniqueQuery", () => {
     );
 
     expect(query.statement).toBe(
-      'SELECT "id" AS id, "first_name" AS firstName, "created_at" AS createdAt FROM "users" WHERE "id" = ? AND "first_name" = ? LIMIT 1',
+      'SELECT "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive FROM "users" WHERE "id" = ? AND "first_name" = ? LIMIT 1',
     );
     expect(query.params).toEqual(["user-1", "John"]);
     expect(query.includeDescriptors).toEqual([]);
@@ -426,7 +430,7 @@ describe("buildFindFirstQuery", () => {
     );
 
     expect(query.statement).toBe(
-      'SELECT "id" AS id, "first_name" AS firstName, "created_at" AS createdAt FROM "users" WHERE "first_name" LIKE ? ESCAPE \'\\\' ORDER BY "created_at" DESC LIMIT ?',
+      'SELECT "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive FROM "users" WHERE "first_name" LIKE ? ESCAPE \'\\\' ORDER BY "created_at" DESC LIMIT ?',
     );
     expect(query.params).toEqual(["Jo%", 1]);
     expect(query.includeDescriptors).toEqual([]);
@@ -445,7 +449,7 @@ describe("buildFindFirstQuery", () => {
     );
 
     expect(query.statement).toBe(
-      'SELECT "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, COALESCE((SELECT json_group_array(json_object(\'id\', posts__posts."id", \'title\', posts__posts."title", \'authorId\', posts__posts."author_id")) FROM "posts" AS posts__posts WHERE posts__posts."author_id" = "users"."id"), \'[]\') AS posts FROM "users" LIMIT ? OFFSET ?',
+      'SELECT "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive, COALESCE((SELECT json_group_array(json_object(\'id\', posts__posts."id", \'title\', posts__posts."title", \'authorId\', posts__posts."author_id")) FROM "posts" AS posts__posts WHERE posts__posts."author_id" = "users"."id"), \'[]\') AS posts FROM "users" LIMIT ? OFFSET ?',
     );
     expect(query.params).toEqual([1, 2]);
     expect(query.includeDescriptors).toEqual([
@@ -506,6 +510,26 @@ describe("createSqliteDialect", () => {
     expect(new Date(row?.createdAt ?? 0).toISOString()).toBe(
       "2025-01-01T00:00:00.000Z",
     );
+
+    await sql.close();
+  });
+
+  test("findMany returns boolean fields as booleans", async () => {
+    const sql = createMemorySql();
+
+    await createUsersTable(sql);
+    await insertUser(sql, "user-1", "John", "2025-01-01T00:00:00.000Z", false);
+
+    const dialect = createSqliteDialect(usersTable, {});
+    const rows = await dialect.findMany(sql, {
+      where: {
+        id: "user-1",
+      },
+    });
+
+    const [row] = rows;
+
+    expect(row?.isActive).toBe(false);
 
     await sql.close();
   });
@@ -653,7 +677,7 @@ describe("buildUpdateQuery", () => {
     );
 
     expect(query.statement).toBe(
-      'UPDATE "users" SET "first_name" = ? WHERE "id" = ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt',
+      'UPDATE "users" SET "first_name" = ? WHERE "id" = ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive',
     );
     expect(query.params).toEqual(["Jane", "user-1"]);
     expect(query.includeDescriptors).toEqual([]);
@@ -673,7 +697,7 @@ describe("buildUpdateQuery", () => {
     );
 
     expect(query.statement).toBe(
-      'UPDATE "users" SET "first_name" = ?, "created_at" = ? WHERE "id" = ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt',
+      'UPDATE "users" SET "first_name" = ?, "created_at" = ? WHERE "id" = ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive',
     );
     expect(query.params).toEqual([
       "Jane",
@@ -726,7 +750,7 @@ describe("buildUpdateQuery", () => {
     );
 
     expect(query.statement).toBe(
-      'UPDATE "users" SET "first_name" = ? WHERE "id" = ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt',
+      'UPDATE "users" SET "first_name" = ? WHERE "id" = ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive',
     );
     expect(query.params).toEqual(["Jane", "user-1"]);
   });
@@ -757,7 +781,7 @@ describe("buildUpdateQuery", () => {
     );
 
     expect(query.statement).toBe(
-      'UPDATE "users" SET "created_at" = ? WHERE "id" = ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt',
+      'UPDATE "users" SET "created_at" = ? WHERE "id" = ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive',
     );
     expect(query.params).toEqual(["2026-06-01T00:00:00.000Z", "user-1"]);
   });
@@ -774,7 +798,7 @@ describe("buildUpdateQuery", () => {
     );
 
     expect(query.statement).toBe(
-      'UPDATE "users" SET "first_name" = ? WHERE "id" = ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, COALESCE((SELECT json_group_array(json_object(\'id\', posts__posts."id", \'title\', posts__posts."title", \'authorId\', posts__posts."author_id")) FROM "posts" AS posts__posts WHERE posts__posts."author_id" = "users"."id"), \'[]\') AS posts',
+      'UPDATE "users" SET "first_name" = ? WHERE "id" = ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive, COALESCE((SELECT json_group_array(json_object(\'id\', posts__posts."id", \'title\', posts__posts."title", \'authorId\', posts__posts."author_id")) FROM "posts" AS posts__posts WHERE posts__posts."author_id" = "users"."id"), \'[]\') AS posts',
     );
     expect(query.params).toEqual(["Jane", "user-1"]);
     expect(query.includeDescriptors).toEqual([
@@ -794,7 +818,7 @@ describe("buildUpdateQuery", () => {
     );
 
     expect(query.statement).toBe(
-      'UPDATE "posts" SET "title" = ? WHERE "id" = ? RETURNING "id" AS id, "title" AS title, "author_id" AS authorId, (SELECT json_object(\'id\', author__users."id", \'firstName\', author__users."first_name", \'createdAt\', author__users."created_at") FROM "users" AS author__users WHERE author__users."id" = "posts"."author_id" LIMIT 1) AS author',
+      'UPDATE "posts" SET "title" = ? WHERE "id" = ? RETURNING "id" AS id, "title" AS title, "author_id" AS authorId, (SELECT json_object(\'id\', author__users."id", \'firstName\', author__users."first_name", \'createdAt\', author__users."created_at", \'isActive\', author__users."is_active") FROM "users" AS author__users WHERE author__users."id" = "posts"."author_id" LIMIT 1) AS author',
     );
     expect(query.params).toEqual(["Updated", "post-1"]);
     expect(query.includeDescriptors).toEqual([
@@ -916,7 +940,7 @@ describe("buildDeleteQuery", () => {
     const query = buildDeleteQuery(usersTable, {}, { where: { id: "user-1" } });
 
     expect(query.statement).toBe(
-      'DELETE FROM "users" WHERE "id" = ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt',
+      'DELETE FROM "users" WHERE "id" = ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive',
     );
     expect(query.params).toEqual(["user-1"]);
     expect(query.includeDescriptors).toEqual([]);
@@ -950,7 +974,7 @@ describe("buildDeleteQuery", () => {
     );
 
     expect(query.statement).toBe(
-      'DELETE FROM "users" WHERE "id" = ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, COALESCE((SELECT json_group_array(json_object(\'id\', posts__posts."id", \'title\', posts__posts."title", \'authorId\', posts__posts."author_id")) FROM "posts" AS posts__posts WHERE posts__posts."author_id" = "users"."id"), \'[]\') AS posts',
+      'DELETE FROM "users" WHERE "id" = ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive, COALESCE((SELECT json_group_array(json_object(\'id\', posts__posts."id", \'title\', posts__posts."title", \'authorId\', posts__posts."author_id")) FROM "posts" AS posts__posts WHERE posts__posts."author_id" = "users"."id"), \'[]\') AS posts',
     );
     expect(query.params).toEqual(["user-1"]);
     expect(query.includeDescriptors).toEqual([
@@ -969,7 +993,7 @@ describe("buildDeleteQuery", () => {
     );
 
     expect(query.statement).toBe(
-      'DELETE FROM "posts" WHERE "id" = ? RETURNING "id" AS id, "title" AS title, "author_id" AS authorId, (SELECT json_object(\'id\', author__users."id", \'firstName\', author__users."first_name", \'createdAt\', author__users."created_at") FROM "users" AS author__users WHERE author__users."id" = "posts"."author_id" LIMIT 1) AS author',
+      'DELETE FROM "posts" WHERE "id" = ? RETURNING "id" AS id, "title" AS title, "author_id" AS authorId, (SELECT json_object(\'id\', author__users."id", \'firstName\', author__users."first_name", \'createdAt\', author__users."created_at", \'isActive\', author__users."is_active") FROM "users" AS author__users WHERE author__users."id" = "posts"."author_id" LIMIT 1) AS author',
     );
     expect(query.params).toEqual(["post-1"]);
     expect(query.includeDescriptors).toEqual([
@@ -1122,12 +1146,13 @@ describe("buildCreateManyQuery", () => {
     });
 
     expect(query.statement).toBe(
-      'INSERT INTO "users" ("id", "first_name", "created_at") VALUES (?, ?, ?) RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt',
+      'INSERT INTO "users" ("id", "first_name", "created_at", "is_active") VALUES (?, ?, ?, ?) RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive',
     );
     expect(query.params).toEqual([
       "user-1",
       "John",
       "2025-01-01T00:00:00.000Z",
+      true,
     ]);
   });
 
@@ -1148,15 +1173,17 @@ describe("buildCreateManyQuery", () => {
     });
 
     expect(query.statement).toBe(
-      'INSERT INTO "users" ("id", "first_name", "created_at") VALUES (?, ?, ?), (?, ?, ?) RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt',
+      'INSERT INTO "users" ("id", "first_name", "created_at", "is_active") VALUES (?, ?, ?, ?), (?, ?, ?, ?) RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive',
     );
     expect(query.params).toEqual([
       "user-1",
       "John",
       "2025-01-01T00:00:00.000Z",
+      true,
       "user-2",
       "Alice",
       "2025-01-02T00:00:00.000Z",
+      true,
     ]);
   });
 
@@ -1175,9 +1202,11 @@ describe("buildCreateManyQuery", () => {
       "a",
       "A",
       d1.toISOString(),
+      true,
       "b",
       "B",
       d2.toISOString(),
+      true,
     ]);
   });
 
@@ -1213,7 +1242,7 @@ describe("buildUpdateManyQuery", () => {
     });
 
     expect(query.statement).toBe(
-      'UPDATE "users" SET "first_name" = ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt',
+      'UPDATE "users" SET "first_name" = ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive',
     );
     expect(query.params).toEqual(["Everyone"]);
   });
@@ -1225,7 +1254,7 @@ describe("buildUpdateManyQuery", () => {
     });
 
     expect(query.statement).toBe(
-      'UPDATE "users" SET "first_name" = ? WHERE "first_name" LIKE ? ESCAPE \'\\\' RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt',
+      'UPDATE "users" SET "first_name" = ? WHERE "first_name" LIKE ? ESCAPE \'\\\' RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive',
     );
     expect(query.params).toEqual(["John", "Jo%"]);
   });
@@ -1240,7 +1269,7 @@ describe("buildUpdateManyQuery", () => {
     });
 
     expect(query.statement).toBe(
-      'UPDATE "users" SET "first_name" = ?, "created_at" = ? WHERE "id" = ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt',
+      'UPDATE "users" SET "first_name" = ?, "created_at" = ? WHERE "id" = ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive',
     );
     expect(query.params).toEqual([
       "Jane",
@@ -1267,7 +1296,7 @@ describe("buildUpdateManyQuery", () => {
     });
 
     expect(query.statement).toBe(
-      'UPDATE "users" SET "first_name" = ? WHERE "id" = ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt',
+      'UPDATE "users" SET "first_name" = ? WHERE "id" = ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive',
     );
     expect(query.params).toEqual(["Jane", "user-1"]);
   });
@@ -1286,7 +1315,7 @@ describe("buildDeleteManyQuery", () => {
     const query = buildDeleteManyQuery(usersTable, {});
 
     expect(query.statement).toBe(
-      'DELETE FROM "users" RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt',
+      'DELETE FROM "users" RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive',
     );
     expect(query.params).toEqual([]);
   });
@@ -1297,7 +1326,7 @@ describe("buildDeleteManyQuery", () => {
     });
 
     expect(query.statement).toBe(
-      'DELETE FROM "users" WHERE "first_name" LIKE ? ESCAPE \'\\\' RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt',
+      'DELETE FROM "users" WHERE "first_name" LIKE ? ESCAPE \'\\\' RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive',
     );
     expect(query.params).toEqual(["Jo%"]);
   });
@@ -1308,7 +1337,7 @@ describe("buildDeleteManyQuery", () => {
     });
 
     expect(query.statement).toBe(
-      'DELETE FROM "users" WHERE "first_name" = ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt',
+      'DELETE FROM "users" WHERE "first_name" = ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive',
     );
     expect(query.params).toEqual(["John"]);
   });
@@ -1321,7 +1350,7 @@ describe("buildDeleteManyQuery", () => {
     });
 
     expect(query.statement).toBe(
-      'DELETE FROM "users" WHERE "created_at" < ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt',
+      'DELETE FROM "users" WHERE "created_at" < ? RETURNING "id" AS id, "first_name" AS firstName, "created_at" AS createdAt, "is_active" AS isActive',
     );
     expect(query.params).toEqual([cutoff.toISOString()]);
   });

--- a/src/lib/orm/dialect/sqlite.test.ts
+++ b/src/lib/orm/dialect/sqlite.test.ts
@@ -524,6 +524,53 @@ describe("parseIncludeRows", () => {
       },
     ]);
   });
+
+  test("coerces boolean fields in a hasOne included relation", () => {
+    const descriptors = [
+      { name: "author", type: "hasOne", table: usersTable },
+    ] satisfies Array<IncludeDescriptor>;
+
+    const rows: Array<Record<string, unknown>> = [
+      {
+        id: "p1",
+        title: "Hello",
+        author:
+          '{"id":"u1","firstName":"John","createdAt":"2025-01-01","isActive":1}',
+      },
+      {
+        id: "p2",
+        title: "World",
+        author:
+          '{"id":"u2","firstName":"Jane","createdAt":"2025-01-01","isActive":0}',
+      },
+    ];
+
+    parseIncludeRows(postsTable, rows, descriptors);
+
+    expect((rows[0]?.author as Record<string, unknown>)?.isActive).toBe(true);
+    expect((rows[1]?.author as Record<string, unknown>)?.isActive).toBe(false);
+  });
+
+  test("coerces boolean fields in a hasMany included relation", () => {
+    const descriptors = [
+      { name: "members", type: "hasMany", table: usersTable },
+    ] satisfies Array<IncludeDescriptor>;
+
+    const rows: Array<Record<string, unknown>> = [
+      {
+        id: "g1",
+        members:
+          '[{"id":"u1","firstName":"Alice","createdAt":"2025-01-01","isActive":1},{"id":"u2","firstName":"Bob","createdAt":"2025-01-01","isActive":0}]',
+      },
+    ];
+
+    parseIncludeRows(postsTable, rows, descriptors);
+
+    const members = rows[0]?.members as Array<Record<string, unknown>>;
+
+    expect(members[0]?.isActive).toBe(true);
+    expect(members[1]?.isActive).toBe(false);
+  });
 });
 
 describe("createSqliteDialect", () => {
@@ -1825,6 +1872,37 @@ describe("createSqliteDialect - deleteMany", () => {
   });
 });
 
+const postsWithFeaturedTable = defineTable("posts_with_featured", {
+  id: uuid("id").primaryKey().notNull(),
+  title: string("title").notNull(),
+  isFeatured: boolean("is_featured")
+    .notNull()
+    .default(() => false),
+  authorId: uuid("author_id")
+    .notNull()
+    .references(() => usersTable.columns.id),
+});
+
+const CREATE_POSTS_WITH_FEATURED_TABLE_SQL =
+  "CREATE TABLE posts_with_featured (id TEXT PRIMARY KEY, title TEXT NOT NULL, is_featured INTEGER NOT NULL, author_id TEXT NOT NULL)";
+
+const createPostsWithFeaturedTable = async (sql: Bun.SQL) => {
+  await sql.unsafe(CREATE_POSTS_WITH_FEATURED_TABLE_SQL);
+};
+
+const insertPostWithFeatured = async (
+  sql: Bun.SQL,
+  id: string,
+  title: string,
+  isFeatured: boolean,
+  authorId: string,
+) => {
+  await sql.unsafe(
+    "INSERT INTO posts_with_featured (id, title, is_featured, author_id) VALUES (?, ?, ?, ?)",
+    [id, title, isFeatured, authorId],
+  );
+};
+
 const nullableFlagsTable = defineTable("flags", {
   id: uuid("id").primaryKey().notNull(),
   isEnabled: boolean("is_enabled"),
@@ -1905,6 +1983,52 @@ describe("coerceBooleanColumns - nullable boolean", () => {
     });
 
     expect(row.isEnabled).toBeNull();
+
+    await sql.close();
+  });
+});
+
+describe("boolean coercion in included relations", () => {
+  test("findMany coerces booleans in a hasMany relation", async () => {
+    const sql = createMemorySql();
+
+    await createUsersTable(sql);
+    await createPostsWithFeaturedTable(sql);
+    await insertUser(sql, "user-1", "John", "2025-01-01T00:00:00.000Z");
+    await insertPostWithFeatured(sql, "post-1", "Hello", true, "user-1");
+    await insertPostWithFeatured(sql, "post-2", "World", false, "user-1");
+
+    const dialect = createSqliteDialect(usersTable, {
+      posts: many(() => postsWithFeaturedTable),
+    });
+
+    const rows = await dialect.findMany(sql, { include: { posts: true } });
+
+    const posts = rows[0]?.posts as Array<Record<string, unknown>>;
+
+    expect(posts[0]?.isFeatured).toBe(true);
+    expect(posts[1]?.isFeatured).toBe(false);
+
+    await sql.close();
+  });
+
+  test("findMany coerces booleans in a hasOne relation", async () => {
+    const sql = createMemorySql();
+
+    await createUsersTable(sql);
+    await createPostsWithFeaturedTable(sql);
+    await insertUser(sql, "user-1", "John", "2025-01-01T00:00:00.000Z", false);
+    await insertPostWithFeatured(sql, "post-1", "Hello", true, "user-1");
+
+    const dialect = createSqliteDialect(postsWithFeaturedTable, {
+      author: one(() => usersTable),
+    });
+
+    const rows = await dialect.findMany(sql, { include: { author: true } });
+
+    const author = rows[0]?.author as Record<string, unknown>;
+
+    expect(author.isActive).toBe(false);
 
     await sql.close();
   });

--- a/src/lib/orm/dialect/sqlite.ts
+++ b/src/lib/orm/dialect/sqlite.ts
@@ -647,8 +647,33 @@ export const parseIncludeRows = (
   });
 };
 
-const executeQuery = async (sql: Bun.SQL, query: ReturningQuery) => {
+const coerceBooleanColumns = (
+  table: Table,
+  rows: Record<string, unknown>[],
+) => {
+  const booleanKeys = Object.entries(table.columns)
+    .filter(([, col]) => col.type === "boolean")
+    .map(([key]) => key);
+
+  if (!booleanKeys.length) return;
+
+  for (const key of booleanKeys) {
+    for (const row of rows) {
+      if (key in row) {
+        row[key] = Boolean(row[key]);
+      }
+    }
+  }
+};
+
+const executeQuery = async (
+  sql: Bun.SQL,
+  table: Table,
+  query: ReturningQuery,
+) => {
   const rows = [...(await sql.unsafe(query.statement, query.params))];
+
+  coerceBooleanColumns(table, rows);
 
   if (!query.includeDescriptors.length) {
     return rows;
@@ -752,24 +777,24 @@ export const createSqliteDialect = <T extends Table, R extends TableRelations>(
     findMany: async (sql, options) => {
       const query = buildFindManyQuery(table, relations, options);
 
-      return await executeQuery(sql, query);
+      return await executeQuery(sql, table, query);
     },
     // findFirst and findUnique build different queries but share row execution/parsing.
     findFirst: async (sql, options) => {
       const query = buildFindFirstQuery(table, relations, options);
-      const [row] = await executeQuery(sql, query);
+      const [row] = await executeQuery(sql, table, query);
 
       return row ?? null;
     },
     findUnique: async (sql, options) => {
       const query = buildFindUniqueQuery(table, relations, options);
-      const [row] = await executeQuery(sql, query);
+      const [row] = await executeQuery(sql, table, query);
 
       return row ?? null;
     },
     create: async (sql, options) => {
       const query = buildCreateQuery(table, relations, options);
-      const [row] = await executeQuery(sql, query);
+      const [row] = await executeQuery(sql, table, query);
 
       if (!row) {
         throw new Error(
@@ -786,11 +811,11 @@ export const createSqliteDialect = <T extends Table, R extends TableRelations>(
 
       const query = buildCreateManyQuery(table, options);
 
-      return await executeQuery(sql, query);
+      return await executeQuery(sql, table, query);
     },
     update: async (sql, options) => {
       const query = buildUpdateQuery(table, relations, options);
-      const [row] = await executeQuery(sql, query);
+      const [row] = await executeQuery(sql, table, query);
 
       if (!row) {
         throw new Error(
@@ -803,11 +828,11 @@ export const createSqliteDialect = <T extends Table, R extends TableRelations>(
     updateMany: async (sql, options) => {
       const query = buildUpdateManyQuery(table, options);
 
-      return await executeQuery(sql, query);
+      return await executeQuery(sql, table, query);
     },
     delete: async (sql, options) => {
       const query = buildDeleteQuery(table, relations, options);
-      const [row] = await executeQuery(sql, query);
+      const [row] = await executeQuery(sql, table, query);
 
       if (!row) {
         throw new Error(
@@ -820,7 +845,7 @@ export const createSqliteDialect = <T extends Table, R extends TableRelations>(
     deleteMany: async (sql, options) => {
       const query = buildDeleteManyQuery(table, options);
 
-      return await executeQuery(sql, query);
+      return await executeQuery(sql, table, query);
     },
   };
 };

--- a/src/lib/orm/dialect/sqlite.ts
+++ b/src/lib/orm/dialect/sqlite.ts
@@ -653,6 +653,8 @@ export const parseIncludeRows = (
 
   for (const row of rows) {
     for (const key of mainBoolKeys) {
+      if (!(key in row)) continue;
+
       row[key] = coerceBooleanValue(row[key]);
     }
 

--- a/src/lib/orm/dialect/sqlite.ts
+++ b/src/lib/orm/dialect/sqlite.ts
@@ -659,9 +659,11 @@ const coerceBooleanColumns = (
 
   for (const key of booleanKeys) {
     for (const row of rows) {
-      if (key in row) {
-        row[key] = Boolean(row[key]);
-      }
+      if (!(key in row)) continue;
+      if (row[key] === null) continue;
+      if (row[key] === undefined) continue;
+
+      row[key] = Boolean(row[key]);
     }
   }
 };

--- a/src/lib/orm/dialect/sqlite.ts
+++ b/src/lib/orm/dialect/sqlite.ts
@@ -27,6 +27,7 @@ type SqlFragment = {
 export type IncludeDescriptor = {
   name: string;
   type: "hasMany" | "hasOne";
+  table: Table;
 };
 
 type IncludeClause = {
@@ -337,7 +338,11 @@ const buildIncludeClause = <T extends Table, R extends TableRelations>(
       clauses.push(
         `COALESCE((SELECT json_group_array(${relationJsonObject}) FROM ${quoteIdentifier(relationTable.sqlName)} AS ${relationAlias} WHERE ${relationAlias}.${quoteIdentifier(foreignKey.sqlName)} = ${quoteIdentifier(table.sqlName)}.${quoteIdentifier(sourceColumn.sqlName)}), '[]') AS ${relationName}`,
       );
-      descriptors.push({ name: relationName, type: "hasMany" });
+      descriptors.push({
+        name: relationName,
+        type: "hasMany",
+        table: relationTable,
+      });
       continue;
     }
 
@@ -357,7 +362,11 @@ const buildIncludeClause = <T extends Table, R extends TableRelations>(
     clauses.push(
       `(SELECT ${relationJsonObject} FROM ${quoteIdentifier(relationTable.sqlName)} AS ${relationAlias} WHERE ${relationAlias}.${quoteIdentifier(relationPrimaryKey.sqlName)} = ${quoteIdentifier(table.sqlName)}.${quoteIdentifier(localForeignKey.sqlName)} LIMIT 1) AS ${relationName}`,
     );
-    descriptors.push({ name: relationName, type: "hasOne" });
+    descriptors.push({
+      name: relationName,
+      type: "hasOne",
+      table: relationTable,
+    });
   }
 
   return {
@@ -620,19 +629,39 @@ export const buildFindUniqueQuery = <T extends Table, R extends TableRelations>(
   };
 };
 
+const getBooleanKeys = (table: Table) => {
+  const entries = Object.entries(table.columns);
+  const booleanColumns = entries.filter(([, col]) => col.type === "boolean");
+  const booleanKeys = booleanColumns.map(([key]) => key);
+
+  return new Set(booleanKeys);
+};
+
+const coerceBooleanValue = (val: unknown) => {
+  if (val === null) return val;
+  if (val === undefined) return val;
+
+  return Boolean(val);
+};
+
 export const parseIncludeRows = (
+  table: Table,
   rows: Array<Record<string, unknown>>,
   descriptors: IncludeDescriptor[],
 ) => {
-  return rows.map((row) => {
-    const result = { ...row };
+  const mainBoolKeys = getBooleanKeys(table);
+
+  for (const row of rows) {
+    for (const key of mainBoolKeys) {
+      row[key] = coerceBooleanValue(row[key]);
+    }
 
     for (const descriptor of descriptors) {
       const value = row[descriptor.name];
 
       if (value === null) {
         if (descriptor.type === "hasMany") {
-          result[descriptor.name] = [];
+          row[descriptor.name] = [];
         }
 
         continue;
@@ -640,30 +669,13 @@ export const parseIncludeRows = (
 
       if (typeof value !== "string") continue;
 
-      result[descriptor.name] = JSON.parse(value);
-    }
+      const boolKeys = getBooleanKeys(descriptor.table);
 
-    return result;
-  });
-};
+      row[descriptor.name] = JSON.parse(value, (key, val) => {
+        if (!boolKeys.has(key)) return val;
 
-const coerceBooleanColumns = (
-  table: Table,
-  rows: Record<string, unknown>[],
-) => {
-  const booleanKeys = Object.entries(table.columns)
-    .filter(([, col]) => col.type === "boolean")
-    .map(([key]) => key);
-
-  if (!booleanKeys.length) return;
-
-  for (const key of booleanKeys) {
-    for (const row of rows) {
-      if (!(key in row)) continue;
-      if (row[key] === null) continue;
-      if (row[key] === undefined) continue;
-
-      row[key] = Boolean(row[key]);
+        return coerceBooleanValue(val);
+      });
     }
   }
 };
@@ -675,13 +687,9 @@ const executeQuery = async (
 ) => {
   const rows = [...(await sql.unsafe(query.statement, query.params))];
 
-  coerceBooleanColumns(table, rows);
+  parseIncludeRows(table, rows, query.includeDescriptors);
 
-  if (!query.includeDescriptors.length) {
-    return rows;
-  }
-
-  return parseIncludeRows(rows, query.includeDescriptors);
+  return rows;
 };
 
 export const buildCreateManyQuery = <T extends Table>(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Boolean columns in SQLite are now properly returned as actual booleans instead of integers across all database operations (find, create, update, delete).
  * Boolean coercion now works correctly for nullable boolean fields and within included relations.

* **Tests**
  * Added comprehensive test coverage for boolean column handling, nullable boolean fields, and boolean coercion in related data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/leonardodipace/semola/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->