### PR TITLE
Stop using result tuple in internal modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ const cache = new Cache({
 await cache.set("user:123", { name: "John", age: 30 });
 
 // Retrieve data
-const [error, user] = await cache.get("user:123");
-if (!error) console.log(user);
+const user = await cache.get("user:123");
+console.log(user);
 ```
 
 ### Schedule Recurring Tasks

--- a/README.md
+++ b/README.md
@@ -122,16 +122,14 @@ const pubsub = new PubSub({
 });
 
 // Subscribe to messages
-const [, unsubscribeHandler] = await pubsub.subscribe((message) => {
+const unsubscribe = await pubsub.subscribe((message) => {
   console.log("Received:", message);
 });
 
 // Publish a message
 await pubsub.publish({ userId: 123, text: "New alert!" });
 
-if (unsubscribeHandler) {
-  await unsubscribeHandler();
-}
+await unsubscribe();
 ```
 
 ### Cache Data with TTL

--- a/docs/api.md
+++ b/docs/api.md
@@ -227,7 +227,6 @@ The handler receives a context object with type-safe request data and response m
 - **OpenAPI generation**: Automatic OpenAPI 3.1.0 spec from route definitions
 - **Schema reuse**: Define schemas once with `.meta({ id })` and reference them across routes
 - **Bun-native routing**: Leverages Bun.serve's SIMD-accelerated routing
-- **Result pattern**: Uses `[error, data]` tuples internally for error handling
 
 ## Usage Example
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -744,6 +744,7 @@ const corsMiddleware = new Middleware({
 #### Database Transaction Middleware
 
 ```typescript
+import { mightThrow } from "semola/errors";
 const transactionMiddleware = new Middleware({
   handler: async (c) => {
     const tx = await db.beginTransaction();
@@ -769,16 +770,23 @@ api.defineRoute({
   handler: async (c) => {
     const tx = c.get("transaction");
 
-    try {
-      await debit(tx, c.req.body.from, c.req.body.amount);
-      await credit(tx, c.req.body.to, c.req.body.amount);
-      await tx.commit();
+    const [debitError] = await mightThrow(debit(tx, c.req.body.from, c.req.body.amount));
 
-      return c.json(200, { success: true });
-    } catch (error) {
+    if (debitError) {
       await tx.rollback();
-      throw error;
+      throw debitError;
     }
+
+    const [creditError] = await mightThrow(credit(tx, c.req.body.to, c.req.body.amount));
+
+    if (creditError) {
+      await tx.rollback();
+      throw creditError;
+    }
+
+    await tx.commit();
+
+    return c.json(200, { success: true });
   },
 });
 ```

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -1,6 +1,6 @@
 # Cache
 
-A type-safe Redis cache wrapper with TTL support and result-based error handling. Built on Bun's native Redis client.
+A type-safe Redis cache wrapper with TTL support. Built on Bun's native Redis client.
 
 ## Import
 
@@ -15,8 +15,6 @@ import { Cache } from "semola/cache";
 Creates a new cache instance.
 
 ```typescript
-type CacheError = "CacheError" | "InvalidTTLError";
-
 type CacheOptions<T> = {
   redis: Bun.RedisClient;
   ttl?: number | ((key: string, value: T) => number); // TTL in ms, or per-entry function
@@ -24,7 +22,6 @@ type CacheOptions<T> = {
   prefix?: string; // Key prefix, e.g. "users" -> "users:key"
   serializer?: (value: T) => string; // Custom serializer (default: JSON.stringify)
   deserializer?: (raw: string) => T; // Custom deserializer (default: JSON.parse)
-  onError?: (error: { type: CacheError; message: string }) => void; // Error callback
 };
 
 const cache = new Cache<User>({
@@ -36,49 +33,29 @@ const cache = new Cache<User>({
 
 **`cache.get(key: string)`**
 
-Retrieves a value from the cache. Returns a result tuple with the parsed value or an error.
+Retrieves a value from the cache. Throws on error.
 
 ```typescript
-const [error, user] = await cache.get("user:123");
-
-if (error) {
-  switch (error.type) {
-    case "NotFoundError":
-      console.log("Cache miss");
-      break;
-    case "CacheError":
-      console.error("Cache error:", error.message);
-      break;
-  }
-} else {
-  console.log("Cache hit:", user);
-}
+const user = await cache.get("user:123");
+console.log("Cache hit:", user);
 ```
 
 **`cache.set(key: string, value: T)`**
 
-Stores a value in the cache with serialization. Applies TTL if configured.
+Stores a value in the cache with serialization. Applies TTL if configured. Returns the stored value.
 
 ```typescript
-const [error, data] = await cache.set("user:123", { id: 123, name: "John" });
-
-if (error) {
-  console.error("Failed to cache:", error.message);
-} else {
-  console.log("Cached successfully");
-}
+const user = await cache.set("user:123", { id: 123, name: "John" });
+console.log("Cached successfully:", user);
 ```
 
 **`cache.delete(key: string)`**
 
-Removes a key from the cache.
+Removes a key from the cache. Returns the number of keys deleted.
 
 ```typescript
-const [error] = await cache.delete("user:123");
-
-if (error) {
-  console.error("Failed to delete:", error.message);
-}
+const count = await cache.delete("user:123");
+console.log(`Deleted ${count} key(s)`);
 ```
 
 ## Usage Example
@@ -100,24 +77,21 @@ const userCache = new Cache<User>({
 
 // Get or fetch user
 async function getUser(id: string) {
-  // Try cache first
-  const [cacheError, cachedUser] = await userCache.get(`user:${id}`);
+  const [cacheError, cachedUser] = await mightThrow(
+    userCache.get(`user:${id}`),
+  );
 
   if (!cacheError) {
-    return ok(cachedUser);
+    return cachedUser;
   }
 
   // Cache miss - fetch from database
-  const [dbError, user] = await fetchUserFromDB(id);
-
-  if (dbError) {
-    return err("NotFoundError", "User not found");
-  }
+  const user = await fetchUserFromDB(id);
 
   // Store in cache for next time
   await userCache.set(`user:${id}`, user);
 
-  return ok(user);
+  return user;
 }
 ```
 
@@ -140,7 +114,7 @@ await usersCache.delete("123"); // Deletes "users:123"
 
 When `enabled` is set to `false`, all cache operations become no-ops:
 
-- `get` returns a `NotFoundError` (cache miss)
+- `get` throws `NotFoundError` (cache miss)
 - `set` returns the value without storing it
 - `delete` returns `0` without deleting
 
@@ -178,18 +152,7 @@ const cache = new Cache<Session>({
 ```
 
 - `ttl: 0` is treated as a valid TTL and passed to Redis as `PX 0`.
-- If the TTL function throws, `set` returns `InvalidTTLError` (and triggers `onError` when configured).
-
-### onError
-
-Receive a callback on unexpected errors (`CacheError`, `InvalidTTLError`). Not called on `NotFoundError` (normal cache miss).
-
-```typescript
-const cache = new Cache<User>({
-  redis: redisClient,
-  onError: (error) => logger.warn(`Cache: ${error.type} - ${error.message}`),
-});
-```
+- If the TTL function throws, `set` throws `InvalidTTLError`.
 
 **Note on lifecycle management:** The `Cache` class does not manage the Redis client lifecycle. Since you provide the client when creating the cache, you're responsible for closing it when done:
 

--- a/docs/cron.md
+++ b/docs/cron.md
@@ -218,13 +218,15 @@ process.on("SIGTERM", async () => {
 If the handler throws an error, the job continues to the next scheduled execution. Handle errors in your handler.
 
 ```typescript
+import { mightThrow } from "semola/errors";
+
 const job = new Cron({
   name: "fragile-task",
   schedule: "0 * * * *",
   handler: async () => {
-    try {
-      await riskyOperation();
-    } catch (error) {
+    const [error] = await mightThrow(riskyOperation());
+
+    if (error) {
       // Handle error here - execution continues to next schedule
       console.error("Task failed:", error);
       await sendAlert(error);

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -156,13 +156,12 @@ const name = await input({
 
 ```typescript
 import { PromptCancelledError } from "semola/prompts";
+import { mightThrow } from "semola/errors";
 
-try {
-  const name = await input({ message: "Project name" });
-} catch (error) {
-  if (error instanceof PromptCancelledError) {
-    console.log("Cancelled");
-  }
+const [error, name] = await mightThrow(input({ message: "Project name" }));
+
+if (error instanceof PromptCancelledError) {
+  console.log("Cancelled");
 }
 ```
 
@@ -279,12 +278,11 @@ If interactive mode is unavailable, a `PromptEnvironmentError` is thrown:
 
 ```typescript
 import { PromptEnvironmentError } from "semola/prompts";
+import { mightThrow } from "semola/errors";
 
-try {
-  const name = await input({ message: "Name" });
-} catch (error) {
-  if (error instanceof PromptEnvironmentError) {
-    console.error("Not running in an interactive terminal");
-  }
+const [error] = await mightThrow(input({ message: "Name" }));
+
+if (error instanceof PromptEnvironmentError) {
+  console.error("Not running in an interactive terminal");
 }
 ```

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -26,10 +26,13 @@ import {
 | `select(options)`      | `TValue`   | Single choice from a list - environments, regions |
 | `multiselect(options)` | `TValue[]` | Multiple choices from a list - features, tags     |
 
-All prompt functions return result tuples using `ok/err` pattern:
+All prompt functions throw on failure and return the value directly on success.
 
-- success: `[null, value]`
-- failure: `[{ type, message }, null]`
+Thrown errors extend `Error` and have a `name` property identifying the error class:
+
+- `PromptEnvironmentError` - runtime is not interactive (no TTY)
+- `PromptCancelledError` - user pressed Escape or Ctrl+C
+- `PromptIOError` - unexpected I/O failure
 
 ## Common options
 
@@ -59,16 +62,12 @@ All prompt functions return result tuples using `ok/err` pattern:
 ### Input
 
 ```typescript
-const [nameError, name] = await input({
+const name = await input({
   message: "Project name",
   required: true,
   placeholder: "my-app",
   validate: (value) => (value.length < 2 ? "Too short" : null),
 });
-
-if (nameError) {
-  console.error(nameError.type, nameError.message);
-}
 ```
 
 ### Password
@@ -77,10 +76,10 @@ When `mask` is omitted, the cursor stays still while typing and nothing is shown
 
 ```typescript
 // hidden mode - cursor stays still, nothing shown on submit
-const [err1, secret] = await password({ message: "Enter password" });
+const secret = await password({ message: "Enter password" });
 
 // masked mode - each character shown as "*", same count shown on submit
-const [err2, secret2] = await password({
+const secret2 = await password({
   message: "Enter password",
   mask: "*",
   validate: (value) =>
@@ -91,35 +90,27 @@ const [err2, secret2] = await password({
 ### Confirm
 
 ```typescript
-const [confirmError, shouldDeploy] = await confirm({
+const shouldDeploy = await confirm({
   message: "Deploy now?",
   defaultValue: true,
 });
-
-if (confirmError) {
-  console.error(confirmError.type, confirmError.message);
-}
 ```
 
 ### Number
 
 ```typescript
-const [portError, port] = await number({
+const port = await number({
   message: "Port",
   defaultValue: 3000,
   min: 1,
   max: 65535,
 });
-
-if (portError) {
-  console.error(portError.type, portError.message);
-}
 ```
 
 ### Select
 
 ```typescript
-const [environmentError, environment] = await select({
+const environment = await select({
   message: "Choose environment",
   choices: [
     { value: "dev", label: "Development" },
@@ -127,30 +118,22 @@ const [environmentError, environment] = await select({
     { value: "prod", label: "Production", hint: "irreversible" },
   ],
 });
-
-if (environmentError) {
-  console.error(environmentError.type, environmentError.message);
-}
 ```
 
 ### Multiselect
 
 ```typescript
-const [toolsError, tools] = await multiselect({
+const tools = await multiselect({
   message: "Enable tools",
   choices: [{ value: "lint" }, { value: "test" }, { value: "build" }],
   min: 1,
 });
-
-if (toolsError) {
-  console.error(toolsError.type, toolsError.message);
-}
 ```
 
 ### Transform
 
 ```typescript
-const [portError, port] = await number({
+const port = await number({
   message: "Port",
   defaultValue: 3000,
   transform: (value) => Math.floor(value),
@@ -160,13 +143,27 @@ const [portError, port] = await number({
 ### Async validate
 
 ```typescript
-const [nameError, name] = await input({
+const name = await input({
   message: "Username",
   validate: async (value) => {
     const taken = await checkUsernameExists(value);
     return taken ? "Username already taken" : null;
   },
 });
+```
+
+### Error handling
+
+```typescript
+import { PromptCancelledError } from "semola/prompts";
+
+try {
+  const name = await input({ message: "Project name" });
+} catch (error) {
+  if (error instanceof PromptCancelledError) {
+    console.log("Cancelled");
+  }
+}
 ```
 
 ## Types
@@ -271,21 +268,23 @@ import type { PromptRuntime } from "semola/prompts";
 
 const runtime: PromptRuntime = { ... };
 
-const [error, value] = await input({ message: "Name" }, runtime);
+const value = await input({ message: "Name" }, runtime);
 ```
 
 ## Interactive-only behavior
 
 Prompts require a TTY with raw mode support.
 
-If interactive mode is unavailable, prompt functions return:
+If interactive mode is unavailable, a `PromptEnvironmentError` is thrown:
 
 ```typescript
-[
-  {
-    type: "PromptEnvironmentError",
-    message: "Interactive prompts require a TTY with raw mode support",
-  },
-  null,
-];
+import { PromptEnvironmentError } from "semola/prompts";
+
+try {
+  const name = await input({ message: "Name" });
+} catch (error) {
+  if (error instanceof PromptEnvironmentError) {
+    console.error("Not running in an interactive terminal");
+  }
+}
 ```

--- a/docs/pubsub.md
+++ b/docs/pubsub.md
@@ -153,7 +153,7 @@ await unsubscribeMetrics();
 ### Error Handling
 
 ```typescript
-import { PublishError, PubSub, SerializationError } from "semola/pubsub";
+import { PubSub } from "semola/pubsub";
 
 const subscriber = new Bun.RedisClient("redis://localhost:6379");
 const publisher = new Bun.RedisClient("redis://localhost:6379");
@@ -173,16 +173,8 @@ const unsubscribeHandler = await pubsub.subscribe(
 );
 
 // Publish
-try {
-  const count = await pubsub.publish({ notification: "Hello!" });
-  console.log(`Delivered to ${count} subscribers`);
-} catch (error) {
-  if (error instanceof SerializationError) {
-    console.error("Invalid message format");
-  } else if (error instanceof PublishError) {
-    console.error("Redis connection failed");
-  }
-}
+const count = await pubsub.publish({ notification: "Hello!" });
+console.log(`Delivered to ${count} subscribers`);
 
 // Clean up
 await unsubscribeHandler();

--- a/docs/pubsub.md
+++ b/docs/pubsub.md
@@ -1,6 +1,6 @@
 # PubSub
 
-A type-safe Redis pub/sub wrapper for real-time messaging with result-based error handling. Built on Bun's native Redis client.
+A type-safe Redis pub/sub wrapper for real-time messaging. Built on Bun's native Redis client.
 
 ## Import
 
@@ -32,56 +32,42 @@ Use two separate `Bun.RedisClient` instances when you both subscribe and publish
 
 **`pubsub.publish(message: T)`**
 
-Publishes a message to the channel or pattern. Returns a result tuple with the number of subscribers who received the message.
+Publishes a message to the channel. Returns the number of subscribers who received the message. Throws `SerializationError` if the message cannot be serialized, or `PublishError` on Redis failure.
 
 ```typescript
-const [error, count] = await pubsub.publish({
+const count = await pubsub.publish({
   userId: "123",
   action: "login",
   timestamp: Date.now(),
 });
 
-if (error) {
-  console.error("Failed to publish:", error.message);
-} else {
-  console.log(`Message delivered to ${count} subscribers`);
-}
+console.log(`Message delivered to ${count} subscribers`);
 ```
 
 **`pubsub.subscribe(handler: MessageHandler<T>)`**
 
-Registers a local handler for messages on this PubSub instance. Returns a result tuple with a handler-level unsubscribe function.
+Registers a local handler for messages on this PubSub instance. Returns a handler-level unsubscribe function. Throws `SubscribeError` on Redis failure.
 
 ```typescript
 type MessageHandler<T> = (message: T, channel: string) => void | Promise<void>;
 
-const [error, unsubscribeHandler] = await pubsub.subscribe(
+const unsubscribeHandler = await pubsub.subscribe(
   async (message, channel) => {
     console.log(`Received on ${channel}:`, message);
     await processMessage(message);
   },
 );
 
-if (error) {
-  console.error("Failed to subscribe:", error.message);
-}
-
-if (unsubscribeHandler) {
-  // Removes only this handler.
-  await unsubscribeHandler();
-}
+// Removes only this handler.
+await unsubscribeHandler();
 ```
 
 **`pubsub.unsubscribe()`**
 
-Unsubscribes all local handlers for this instance and removes the Redis subscription.
+Unsubscribes all local handlers for this instance and removes the Redis subscription. Throws `UnsubscribeError` if not currently subscribed.
 
 ```typescript
-const [error] = await pubsub.unsubscribe();
-
-if (error) {
-  console.error("Failed to unsubscribe:", error.message);
-}
+await pubsub.unsubscribe();
 ```
 
 **`pubsub.isActive()`**
@@ -118,7 +104,7 @@ const events = new PubSub<UserEvent>({
 });
 
 // Subscribe to events
-const [, unsubscribeEvents] = await events.subscribe(async (event) => {
+const unsubscribeEvents = await events.subscribe(async (event) => {
   console.log(`User ${event.userId} performed ${event.action}`);
   await logToDatabase(event);
 });
@@ -130,9 +116,7 @@ await events.publish({
   timestamp: Date.now(),
 });
 
-if (unsubscribeEvents) {
-  await unsubscribeEvents();
-}
+await unsubscribeEvents();
 ```
 
 ### Multiple Handlers On One Instance
@@ -149,31 +133,27 @@ const pubsub = new PubSub<{ text: string }>({
   channel: "notifications",
 });
 
-const [, unsubscribeLogger] = await pubsub.subscribe(async (message) => {
+const unsubscribeLogger = await pubsub.subscribe(async (message) => {
   console.log("logger:", message.text);
 });
 
-const [, unsubscribeMetrics] = await pubsub.subscribe(async (message) => {
+const unsubscribeMetrics = await pubsub.subscribe(async (message) => {
   await metrics.increment("notifications.received", { text: message.text });
 });
 
 await pubsub.publish({ text: "New alert" });
 
 // Remove one handler, keep the other active
-if (unsubscribeLogger) {
-  await unsubscribeLogger();
-}
+await unsubscribeLogger();
 
 // Redis unsubscribe happens only when the last local handler is removed
-if (unsubscribeMetrics) {
-  await unsubscribeMetrics();
-}
+await unsubscribeMetrics();
 ```
 
 ### Error Handling
 
 ```typescript
-import { PubSub } from "semola/pubsub";
+import { PublishError, PubSub, SerializationError } from "semola/pubsub";
 
 const subscriber = new Bun.RedisClient("redis://localhost:6379");
 const publisher = new Bun.RedisClient("redis://localhost:6379");
@@ -185,38 +165,27 @@ const pubsub = new PubSub<{ notification: string }>({
 });
 
 // Subscribe with error handling
-const [subscribeError, unsubscribeHandler] = await pubsub.subscribe(
+const unsubscribeHandler = await pubsub.subscribe(
   async (message) => {
     // Handler errors are caught automatically; subscription remains active even if handler throws
     await processNotification(message.notification);
   },
 );
 
-if (subscribeError) {
-  console.error("Failed to subscribe:", subscribeError.message);
-  return;
-}
-
-// Publish with error handling
-const [publishError, count] = await pubsub.publish({ notification: "Hello!" });
-
-if (publishError) {
-  switch (publishError.type) {
-    case "SerializationError":
-      console.error("Invalid message format");
-      break;
-    case "PublishError":
-      console.error("Redis connection failed");
-      break;
-  }
-} else {
+// Publish
+try {
+  const count = await pubsub.publish({ notification: "Hello!" });
   console.log(`Delivered to ${count} subscribers`);
+} catch (error) {
+  if (error instanceof SerializationError) {
+    console.error("Invalid message format");
+  } else if (error instanceof PublishError) {
+    console.error("Redis connection failed");
+  }
 }
 
 // Clean up
-if (unsubscribeHandler) {
-  await unsubscribeHandler();
-}
+await unsubscribeHandler();
 ```
 
 ### Multiple Instances

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -20,7 +20,7 @@ const queue = new Queue({
 });
 
 // Add a job
-const [error, jobId] = await queue.enqueue({ message: "Hello!" });
+const jobId = await queue.enqueue({ message: "Hello!" });
 
 // Graceful shutdown
 await queue.stop();
@@ -65,14 +65,10 @@ const taskQueue = new Queue({
 });
 
 // Add a job
-const [error, jobId] = await taskQueue.enqueue({
+const jobId = await taskQueue.enqueue({
   taskId: "task-123",
   userId: "user-456",
 });
-
-if (error) {
-  console.error("Failed to enqueue:", error.message);
-}
 
 // Graceful shutdown
 process.on("SIGTERM", async () => {

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -65,10 +65,17 @@ const taskQueue = new Queue({
 });
 
 // Add a job
-const jobId = await taskQueue.enqueue({
+import { mightThrow } from "semola/errors";
+
+const [enqueueError, jobId] = await mightThrow(taskQueue.enqueue({
   taskId: "task-123",
   userId: "user-456",
-});
+}));
+
+if (enqueueError) {
+  console.error("Failed to enqueue task:", enqueueError);
+  throw enqueueError;
+}
 
 // Graceful shutdown
 process.on("SIGTERM", async () => {

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -30,7 +30,7 @@ const onboardUser = defineWorkflow<User>({
   },
 });
 
-const [startError, started] = await onboardUser.start({
+const started = await onboardUser.start({
   id: 1,
   email: "leo@example.com",
 });

--- a/src/lib/api/core/index.ts
+++ b/src/lib/api/core/index.ts
@@ -112,7 +112,9 @@ export class Api<TMiddlewares extends readonly Middleware[] = readonly []> {
     const v: Record<string, unknown> = {};
 
     if (schema.body) {
-      const [err, val] = await validateBody(req, schema.body, bodyCache);
+      const [err, val] = await mightThrow(
+        validateBody(req, schema.body, bodyCache),
+      );
 
       if (err) {
         return {
@@ -125,7 +127,7 @@ export class Api<TMiddlewares extends readonly Middleware[] = readonly []> {
     }
 
     if (schema.query) {
-      const [err, val] = await validateQuery(req, schema.query);
+      const [err, val] = await mightThrow(validateQuery(req, schema.query));
 
       if (err) {
         return {
@@ -138,7 +140,7 @@ export class Api<TMiddlewares extends readonly Middleware[] = readonly []> {
     }
 
     if (schema.headers) {
-      const [err, val] = await validateHeaders(req, schema.headers);
+      const [err, val] = await mightThrow(validateHeaders(req, schema.headers));
 
       if (err) {
         return {
@@ -151,7 +153,7 @@ export class Api<TMiddlewares extends readonly Middleware[] = readonly []> {
     }
 
     if (schema.cookies) {
-      const [err, val] = await validateCookies(req, schema.cookies);
+      const [err, val] = await mightThrow(validateCookies(req, schema.cookies));
 
       if (err) {
         return {
@@ -164,7 +166,7 @@ export class Api<TMiddlewares extends readonly Middleware[] = readonly []> {
     }
 
     if (schema.params) {
-      const [err, val] = await validateParams(req, schema.params);
+      const [err, val] = await mightThrow(validateParams(req, schema.params));
 
       if (err) {
         return {
@@ -212,7 +214,9 @@ export class Api<TMiddlewares extends readonly Middleware[] = readonly []> {
       return responseHelpers.json(400, { message: "Invalid response body" });
     }
 
-    const [validationError] = await validateSchema(statusSchema, body);
+    const [validationError] = await mightThrow(
+      validateSchema(statusSchema, body),
+    );
 
     if (validationError) {
       return responseHelpers.json(400, { message: validationError.message });

--- a/src/lib/api/errors.ts
+++ b/src/lib/api/errors.ts
@@ -1,0 +1,13 @@
+export class ParseError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "ParseError";
+  }
+}
+
+export class ValidationError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "ValidationError";
+  }
+}

--- a/src/lib/api/validation/index.test.ts
+++ b/src/lib/api/validation/index.test.ts
@@ -20,10 +20,12 @@ describe("Validation Module", () => {
 
       const invalid = { user: { email: "invalid" } };
 
-      await expect(validateSchema(schema, invalid)).rejects.toMatchObject({
+      const promise1 = validateSchema(schema, invalid);
+      await expect(promise1).rejects.toMatchObject({
         message: expect.stringContaining("user.email:"),
       });
-      await expect(validateSchema(schema, invalid)).rejects.toMatchObject({
+      const promise2 = validateSchema(schema, invalid);
+      await expect(promise2).rejects.toMatchObject({
         message: expect.stringContaining("age:"),
       });
     });
@@ -50,7 +52,8 @@ describe("Validation Module", () => {
         body: "{ invalid json }",
       });
 
-      await expect(validateBody(req, z.any())).rejects.toMatchObject({
+      const promise = validateBody(req, z.any());
+      await expect(promise).rejects.toMatchObject({
         name: "ParseError",
       });
     });
@@ -157,7 +160,8 @@ describe("Validation Module", () => {
       const schema = z.object({ requiredCookie: z.string() });
       const req = new Request("http://localhost");
 
-      await expect(validateCookies(req, schema)).rejects.toMatchObject({
+      const promise = validateCookies(req, schema);
+      await expect(promise).rejects.toMatchObject({
         message: expect.stringContaining("requiredCookie:"),
       });
     });

--- a/src/lib/api/validation/index.test.ts
+++ b/src/lib/api/validation/index.test.ts
@@ -18,13 +18,14 @@ describe("Validation Module", () => {
         age: z.number(),
       });
 
-      const [error, data] = await validateSchema(schema, {
-        user: { email: "invalid" },
-      });
+      const invalid = { user: { email: "invalid" } };
 
-      expect(data).toBeNull();
-      expect(error?.message).toContain("user.email:");
-      expect(error?.message).toContain("age:");
+      await expect(validateSchema(schema, invalid)).rejects.toMatchObject({
+        message: expect.stringContaining("user.email:"),
+      });
+      await expect(validateSchema(schema, invalid)).rejects.toMatchObject({
+        message: expect.stringContaining("age:"),
+      });
     });
   });
 
@@ -37,21 +38,21 @@ describe("Validation Module", () => {
         body: JSON.stringify({ id: 123 }),
       });
 
-      const [error, data] = await validateBody(req, schema);
+      const data = await validateBody(req, schema);
 
-      expect(error).toBeNull();
       expect(data).toEqual({ id: 123 });
     });
 
-    test("should return ParseError for malformed JSON", async () => {
+    test("should throw ParseError for malformed JSON", async () => {
       const req = new Request("http://localhost", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: "{ invalid json }",
       });
 
-      const [error] = await validateBody(req, z.any());
-      expect(error?.type).toBe("ParseError");
+      await expect(validateBody(req, z.any())).rejects.toMatchObject({
+        name: "ParseError",
+      });
     });
 
     test("should skip validation if Content-Type is not JSON", async () => {
@@ -61,8 +62,7 @@ describe("Validation Module", () => {
         body: "hello",
       });
 
-      const [error, data] = await validateBody(req, z.string());
-      expect(error).toBeNull();
+      const data = await validateBody(req, z.string());
       expect(data).toBeUndefined();
     });
 
@@ -76,17 +76,15 @@ describe("Validation Module", () => {
 
       const bodyCache = { parsed: false, value: undefined as unknown };
 
-      const [err1, data1] = await validateBody(req, schema, bodyCache);
+      const data1 = await validateBody(req, schema, bodyCache);
 
-      expect(err1).toBeNull();
       expect(data1).toEqual({ name: "test" });
       expect(bodyCache.parsed).toBe(true);
       expect(bodyCache.value).toEqual({ name: "test" });
 
       // Second call should use cached value (would fail without cache since body is consumed)
-      const [err2, data2] = await validateBody(req, schema, bodyCache);
+      const data2 = await validateBody(req, schema, bodyCache);
 
-      expect(err2).toBeNull();
       expect(data2).toEqual({ name: "test" });
     });
 
@@ -102,13 +100,11 @@ describe("Validation Module", () => {
       const bodyCache = { parsed: false, value: undefined as unknown };
 
       // First validation with partial schema
-      const [err1, data1] = await validateBody(req, partialSchema, bodyCache);
-      expect(err1).toBeNull();
+      const data1 = await validateBody(req, partialSchema, bodyCache);
       expect(data1).toEqual({ name: "test" });
 
       // Second validation with full schema using cached body
-      const [err2, data2] = await validateBody(req, fullSchema, bodyCache);
-      expect(err2).toBeNull();
+      const data2 = await validateBody(req, fullSchema, bodyCache);
       expect(data2).toEqual({ name: "test", age: 25 });
     });
   });
@@ -121,9 +117,8 @@ describe("Validation Module", () => {
       });
       const req = new Request("http://localhost?filter=active&tags=a&tags=b");
 
-      const [error, data] = await validateQuery(req, schema);
+      const data = await validateQuery(req, schema);
 
-      expect(error).toBeNull();
       expect(data).toEqual({ filter: "active", tags: ["a", "b"] });
     });
   });
@@ -137,9 +132,8 @@ describe("Validation Module", () => {
         headers: { "X-API-KEY": "secret-123" },
       });
 
-      const [error, data] = await validateHeaders(req, schema);
+      const data = await validateHeaders(req, schema);
 
-      expect(error).toBeNull();
       expect(data).toEqual({ "x-api-key": "secret-123" });
     });
   });
@@ -154,18 +148,18 @@ describe("Validation Module", () => {
         headers: { cookie: "theme=dark; session=abc" },
       });
 
-      const [error, data] = await validateCookies(req, schema);
+      const data = await validateCookies(req, schema);
 
-      expect(error).toBeNull();
       expect(data).toEqual({ theme: "dark", session: "abc" });
     });
 
-    test("should return error when required cookie is missing", async () => {
+    test("should throw when required cookie is missing", async () => {
       const schema = z.object({ requiredCookie: z.string() });
       const req = new Request("http://localhost");
 
-      const [error] = await validateCookies(req, schema);
-      expect(error?.message).toContain("requiredCookie:");
+      await expect(validateCookies(req, schema)).rejects.toMatchObject({
+        message: expect.stringContaining("requiredCookie:"),
+      });
     });
   });
 });

--- a/src/lib/api/validation/index.ts
+++ b/src/lib/api/validation/index.ts
@@ -1,5 +1,6 @@
 import type { StandardSchemaV1 } from "@standard-schema/spec";
-import { err, mightThrow, ok } from "../../errors/index.js";
+import { mightThrow } from "../../errors/index.js";
+import { ParseError, ValidationError } from "../errors.js";
 
 export const validateSchema = async <T>(
   schema: StandardSchemaV1,
@@ -8,7 +9,7 @@ export const validateSchema = async <T>(
   const result = await schema["~standard"].validate(data);
 
   if (!result.issues) {
-    return ok(result.value as T);
+    return result.value as T;
   }
 
   const issues = result.issues.map((issue) => {
@@ -23,7 +24,7 @@ export const validateSchema = async <T>(
 
   const message = issues.join(", ");
 
-  return err("ValidationError", message);
+  throw new ValidationError(message);
 };
 
 export type BodyCache = { parsed: boolean; value: unknown };
@@ -35,13 +36,13 @@ export const validateBody = async (
   bodyCache?: BodyCache,
 ) => {
   if (!bodySchema) {
-    return ok(true);
+    return true;
   }
 
   const contentType = req.headers.get("content-type") ?? "";
 
   if (!contentType.includes("application/json")) {
-    return ok(undefined);
+    return undefined;
   }
 
   if (bodyCache?.parsed) {
@@ -51,7 +52,7 @@ export const validateBody = async (
   const [parseError, parsedBody] = await mightThrow(req.json());
 
   if (parseError) {
-    return err("ParseError", "Invalid JSON body");
+    throw new ParseError("Invalid JSON body");
   }
 
   if (bodyCache) {
@@ -67,7 +68,7 @@ export const validateQuery = async (
   querySchema?: StandardSchemaV1,
 ) => {
   if (!querySchema) {
-    return ok(true);
+    return true;
   }
 
   const qIndex = req.url.indexOf("?");
@@ -105,7 +106,7 @@ export const validateHeaders = async (
   headersSchema?: StandardSchemaV1,
 ) => {
   if (!headersSchema) {
-    return ok(true);
+    return true;
   }
 
   const headers: Record<string, string> = {};
@@ -122,7 +123,7 @@ export const validateCookies = async (
   cookiesSchema?: StandardSchemaV1,
 ) => {
   if (!cookiesSchema) {
-    return ok(true);
+    return true;
   }
 
   // Use Bun's native CookieMap for efficient cookie parsing
@@ -138,7 +139,7 @@ export const validateParams = async (
   paramsSchema?: StandardSchemaV1,
 ) => {
   if (!paramsSchema) {
-    return ok(true);
+    return true;
   }
 
   return validateSchema(paramsSchema, req.params);

--- a/src/lib/cache/errors.ts
+++ b/src/lib/cache/errors.ts
@@ -1,0 +1,34 @@
+export class CacheError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "CacheError";
+  }
+}
+
+export class InvalidTTLError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "InvalidTTLError";
+  }
+}
+
+export class NotFoundError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "NotFoundError";
+  }
+}
+
+export class SerializationError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "SerializationError";
+  }
+}
+
+export class DeserializationError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "DeserializationError";
+  }
+}

--- a/src/lib/cache/index.test.ts
+++ b/src/lib/cache/index.test.ts
@@ -73,48 +73,44 @@ describe("Cache", () => {
 
       await redis.set("user:1", JSON.stringify({ name: "John" }));
 
-      const [error, data] = await cache.get("user:1");
-      expect(error).toBeNull();
+      const data = await cache.get("user:1");
       expect(data).toEqual({ name: "John" });
     });
 
-    test("should return NotFoundError when key does not exist", async () => {
+    test("should throw NotFoundError when key does not exist", async () => {
       const redis = createMockRedis();
       const cache = new Cache<string>({ redis });
 
-      const [error, data] = await cache.get("nonexistent");
-      expect(error).toEqual({
-        type: "NotFoundError",
+      const promise = cache.get("nonexistent");
+      await expect(promise).rejects.toMatchObject({
+        name: "NotFoundError",
         message: "Key nonexistent not found",
       });
-      expect(data).toBeNull();
     });
 
-    test("should return CacheError on Redis connection failure", async () => {
+    test("should throw CacheError on Redis connection failure", async () => {
       const redis = createMockRedis();
       redis.setShouldFail(true);
       const cache = new Cache<string>({ redis });
 
-      const [error, data] = await cache.get("key");
-      expect(error).toEqual({
-        type: "CacheError",
+      const promise = cache.get("key");
+      await expect(promise).rejects.toMatchObject({
+        name: "CacheError",
         message: "Unable to get value for key key",
       });
-      expect(data).toBeNull();
     });
 
-    test("should return CacheError on invalid JSON", async () => {
+    test("should throw DeserializationError on invalid JSON", async () => {
       const redis = createMockRedis();
       const cache = new Cache<object>({ redis });
 
       await redis.set("invalid", "not valid json {");
 
-      const [error, data] = await cache.get("invalid");
-      expect(error).toEqual({
-        type: "CacheError",
+      const promise = cache.get("invalid");
+      await expect(promise).rejects.toMatchObject({
+        name: "DeserializationError",
         message: "Unable to deserialize value for key invalid",
       });
-      expect(data).toBeNull();
     });
 
     test("should work with different data types", async () => {
@@ -123,20 +119,17 @@ describe("Cache", () => {
       // Test with number
       const numberCache = new Cache<number>({ redis });
       await redis.set("number", "42");
-      const [, num] = await numberCache.get("number");
-      expect(num).toBe(42);
+      expect(await numberCache.get("number")).toBe(42);
 
       // Test with boolean
       const boolCache = new Cache<boolean>({ redis });
       await redis.set("bool", "true");
-      const [, bool] = await boolCache.get("bool");
-      expect(bool).toBe(true);
+      expect(await boolCache.get("bool")).toBe(true);
 
       // Test with array
       const arrayCache = new Cache<number[]>({ redis });
       await redis.set("array", JSON.stringify([1, 2, 3]));
-      const [, arr] = await arrayCache.get("array");
-      expect(arr).toEqual([1, 2, 3]);
+      expect(await arrayCache.get("array")).toEqual([1, 2, 3]);
 
       // Test with nested object
       const objCache = new Cache<{ user: { name: string; age: number } }>({
@@ -146,8 +139,9 @@ describe("Cache", () => {
         "nested",
         JSON.stringify({ user: { name: "Alice", age: 30 } }),
       );
-      const [, obj] = await objCache.get("nested");
-      expect(obj).toEqual({ user: { name: "Alice", age: 30 } });
+      expect(await objCache.get("nested")).toEqual({
+        user: { name: "Alice", age: 30 },
+      });
     });
   });
 
@@ -156,8 +150,7 @@ describe("Cache", () => {
       const redis = createMockRedis();
       const cache = new Cache<{ name: string }>({ redis });
 
-      const [error, data] = await cache.set("user:1", { name: "John" });
-      expect(error).toBeNull();
+      const data = await cache.set("user:1", { name: "John" });
       expect(data).toEqual({ name: "John" });
 
       const stored = redis.getStore().get("user:1");
@@ -168,8 +161,7 @@ describe("Cache", () => {
       const redis = createMockRedis();
       const cache = new Cache<{ id: number }>({ redis });
 
-      const [error, data] = await cache.set("user:id", { id: NaN });
-      expect(error).toBeNull();
+      const data = await cache.set("user:id", { id: NaN });
       expect(data).toEqual({ id: NaN });
 
       const stored = redis.getStore().get("user:id");
@@ -180,8 +172,7 @@ describe("Cache", () => {
       const redis = createMockRedis();
       const cache = new Cache<string>({ redis, ttl: 5000 });
 
-      const [error, data] = await cache.set("key", "value");
-      expect(error).toBeNull();
+      const data = await cache.set("key", "value");
       expect(data).toBe("value");
       expect(redis.getLastSetOptions()).toEqual({ mode: "PX", ttl: 5000 });
     });
@@ -190,13 +181,12 @@ describe("Cache", () => {
       const redis = createMockRedis();
       const cache = new Cache<string>({ redis, ttl: 0 });
 
-      const [error, data] = await cache.set("key", "value");
-      expect(error).toBeNull();
+      const data = await cache.set("key", "value");
       expect(data).toBe("value");
       expect(redis.getLastSetOptions()).toEqual({ mode: "PX", ttl: 0 });
     });
 
-    test("should return CacheError on stringify failure", async () => {
+    test("should throw SerializationError on stringify failure", async () => {
       const redis = createMockRedis();
       type CircularType = { a: number; self?: CircularType };
       const cache = new Cache<CircularType>({ redis });
@@ -205,26 +195,24 @@ describe("Cache", () => {
       const circular: CircularType = { a: 1 };
       circular.self = circular;
 
-      const [error, data] = await cache.set("circular", circular);
-      expect(error).toEqual({
-        type: "CacheError",
+      const promise = cache.set("circular", circular);
+      await expect(promise).rejects.toMatchObject({
+        name: "SerializationError",
         message: "Unable to serialize value for key circular",
       });
-      expect(data).toBeNull();
     });
 
-    test("should return CacheError on Redis connection failure", async () => {
+    test("should throw CacheError on Redis connection failure", async () => {
       const redis = createMockRedis();
       const cache = new Cache<string>({ redis });
 
       redis.setShouldFail(true);
 
-      const [error, data] = await cache.set("key", "value");
-      expect(error).toEqual({
-        type: "CacheError",
+      const promise = cache.set("key", "value");
+      await expect(promise).rejects.toMatchObject({
+        name: "CacheError",
         message: "Unable to set value for key key",
       });
-      expect(data).toBeNull();
     });
 
     test("should work with different data types", async () => {
@@ -232,80 +220,74 @@ describe("Cache", () => {
 
       // Number
       const numCache = new Cache<number>({ redis });
-      const [, num] = await numCache.set("num", 42);
-      expect(num).toBe(42);
+      expect(await numCache.set("num", 42)).toBe(42);
       expect(redis.getStore().get("num")).toBe("42");
 
       // Boolean
       const boolCache = new Cache<boolean>({ redis });
-      const [, bool] = await boolCache.set("bool", false);
-      expect(bool).toBe(false);
+      expect(await boolCache.set("bool", false)).toBe(false);
       expect(redis.getStore().get("bool")).toBe("false");
 
       // Array
       const arrCache = new Cache<string[]>({ redis });
-      const [, arr] = await arrCache.set("arr", ["a", "b", "c"]);
-      expect(arr).toEqual(["a", "b", "c"]);
+      expect(await arrCache.set("arr", ["a", "b", "c"])).toEqual([
+        "a",
+        "b",
+        "c",
+      ]);
       expect(redis.getStore().get("arr")).toBe('["a","b","c"]');
 
       // Object
-      const objCache = new Cache<{ key: string }>({
-        redis,
+      const objCache = new Cache<{ key: string }>({ redis });
+      expect(await objCache.set("obj", { key: "value" })).toEqual({
+        key: "value",
       });
-      const [, obj] = await objCache.set("obj", { key: "value" });
-      expect(obj).toEqual({ key: "value" });
       expect(redis.getStore().get("obj")).toBe('{"key":"value"}');
     });
 
-    test("should return InvalidTTLError on negative TTL", async () => {
+    test("should throw InvalidTTLError on negative TTL", async () => {
       const redis = createMockRedis();
       const cache = new Cache<{ name: string }>({ redis, ttl: -1 });
 
-      const [error, data] = await cache.set("user:1", { name: "John" });
-      expect(error).toEqual({
-        type: "InvalidTTLError",
+      const promise = cache.set("user:1", { name: "John" });
+      await expect(promise).rejects.toMatchObject({
+        name: "InvalidTTLError",
         message: "Unable to save records with ttl equal to -1",
       });
-      expect(data).toBeNull();
     });
 
-    test("should return InvalidTTLError on non integer TTL", async () => {
+    test("should throw InvalidTTLError on non integer TTL", async () => {
       const redis = createMockRedis();
       const nonIntegerTTL = 0.1 + 0.2;
       const cache = new Cache<{ name: string }>({ redis, ttl: nonIntegerTTL });
 
-      const [error, data] = await cache.set("user:1", { name: "John" });
-      expect(error).toEqual({
-        type: "InvalidTTLError",
+      const promise = cache.set("user:1", { name: "John" });
+      await expect(promise).rejects.toMatchObject({
+        name: "InvalidTTLError",
         message: `Unable to save records with ttl equal to ${nonIntegerTTL}`,
       });
-      expect(data).toBeNull();
     });
 
-    test("should return InvalidTTLError on NaN TTL", async () => {
+    test("should throw InvalidTTLError on NaN TTL", async () => {
       const redis = createMockRedis();
       const cache = new Cache<{ name: string }>({ redis, ttl: NaN });
 
-      const [error, data] = await cache.set("user:1", { name: "John" });
-
-      expect(error).toEqual({
-        type: "InvalidTTLError",
+      const promise = cache.set("user:1", { name: "John" });
+      await expect(promise).rejects.toMatchObject({
+        name: "InvalidTTLError",
         message: "Unable to save records with ttl equal to NaN",
       });
-      expect(data).toBeNull();
     });
 
-    test("should return InvalidTTLError on very large TTL", async () => {
+    test("should throw InvalidTTLError on very large TTL", async () => {
       const redis = createMockRedis();
       const cache = new Cache<{ name: string }>({ redis, ttl: Infinity });
 
-      const [error, data] = await cache.set("user:1", { name: "John" });
-
-      expect(error).toEqual({
-        type: "InvalidTTLError",
+      const promise = cache.set("user:1", { name: "John" });
+      await expect(promise).rejects.toMatchObject({
+        name: "InvalidTTLError",
         message: "Unable to save records with ttl equal to Infinity",
       });
-      expect(data).toBeNull();
     });
   });
 
@@ -317,8 +299,7 @@ describe("Cache", () => {
       await redis.set("key", "value");
       expect(redis.getStore().has("key")).toBe(true);
 
-      const [error, count] = await cache.delete("key");
-      expect(error).toBeNull();
+      const count = await cache.delete("key");
       expect(count).toBe(1);
       expect(redis.getStore().has("key")).toBe(false);
     });
@@ -327,57 +308,52 @@ describe("Cache", () => {
       const redis = createMockRedis();
       const cache = new Cache<string>({ redis });
 
-      const [error, count] = await cache.delete("nonexistent");
-      expect(error).toBeNull();
+      const count = await cache.delete("nonexistent");
       expect(count).toBe(0);
     });
 
-    test("should return CacheError on Redis connection failure", async () => {
+    test("should throw CacheError on Redis connection failure", async () => {
       const redis = createMockRedis();
       const cache = new Cache<string>({ redis });
 
       redis.setShouldFail(true);
 
-      const [error, data] = await cache.delete("key");
-      expect(error).toEqual({
-        type: "CacheError",
+      const promise = cache.delete("key");
+      await expect(promise).rejects.toMatchObject({
+        name: "CacheError",
         message: "Unable to delete key key",
       });
-      expect(data).toBeNull();
     });
   });
 
   describe("enabled", () => {
-    test("get should return NotFoundError when disabled", async () => {
+    test("get should throw NotFoundError when disabled", async () => {
       const redis = createMockRedis();
       await redis.set("key", JSON.stringify("value"));
       const cache = new Cache<string>({ redis, enabled: false });
 
-      const [error, data] = await cache.get("key");
-      expect(error).toEqual({
-        type: "NotFoundError",
+      const promise = cache.get("key");
+      await expect(promise).rejects.toMatchObject({
+        name: "NotFoundError",
         message: "Key key not found",
       });
-      expect(data).toBeNull();
     });
 
-    test("set should return ok(value) without storing when disabled", async () => {
+    test("set should return value without storing when disabled", async () => {
       const redis = createMockRedis();
       const cache = new Cache<string>({ redis, enabled: false });
 
-      const [error, data] = await cache.set("key", "value");
-      expect(error).toBeNull();
+      const data = await cache.set("key", "value");
       expect(data).toBe("value");
       expect(redis.getStore().has("key")).toBe(false);
     });
 
-    test("delete should return ok(0) without deleting when disabled", async () => {
+    test("delete should return 0 without deleting when disabled", async () => {
       const redis = createMockRedis();
       await redis.set("key", "value");
       const cache = new Cache<string>({ redis, enabled: false });
 
-      const [error, count] = await cache.delete("key");
-      expect(error).toBeNull();
+      const count = await cache.delete("key");
       expect(count).toBe(0);
       expect(redis.getStore().has("key")).toBe(true);
     });
@@ -386,11 +362,9 @@ describe("Cache", () => {
       const redis = createMockRedis();
       const cache = new Cache<string>({ redis, enabled: true });
 
-      const [setError] = await cache.set("key", "value");
-      expect(setError).toBeNull();
+      await cache.set("key", "value");
 
-      const [getError, data] = await cache.get("key");
-      expect(getError).toBeNull();
+      const data = await cache.get("key");
       expect(data).toBe("value");
     });
 
@@ -398,11 +372,9 @@ describe("Cache", () => {
       const redis = createMockRedis();
       const cache = new Cache<string>({ redis });
 
-      const [setError] = await cache.set("key", "value");
-      expect(setError).toBeNull();
+      await cache.set("key", "value");
 
-      const [getError, data] = await cache.get("key");
-      expect(getError).toBeNull();
+      const data = await cache.get("key");
       expect(data).toBe("value");
     });
   });
@@ -414,8 +386,7 @@ describe("Cache", () => {
 
       await redis.set("users:123", JSON.stringify("John"));
 
-      const [error, data] = await cache.get("123");
-      expect(error).toBeNull();
+      const data = await cache.get("123");
       expect(data).toBe("John");
     });
 
@@ -434,8 +405,7 @@ describe("Cache", () => {
 
       await redis.set("users:123", JSON.stringify("John"));
 
-      const [error, count] = await cache.delete("123");
-      expect(error).toBeNull();
+      const count = await cache.delete("123");
       expect(count).toBe(1);
       expect(redis.getStore().has("users:123")).toBe(false);
     });
@@ -457,8 +427,7 @@ describe("Cache", () => {
         serializer: (value) => `custom:${value.name}`,
       });
 
-      const [error, data] = await cache.set("key", { name: "John" });
-      expect(error).toBeNull();
+      const data = await cache.set("key", { name: "John" });
       expect(data).toEqual({ name: "John" });
       expect(redis.getStore().get("key")).toBe("custom:John");
     });
@@ -470,8 +439,7 @@ describe("Cache", () => {
         serializer: () => "",
       });
 
-      const [error, data] = await cache.set("key", "value");
-      expect(error).toBeNull();
+      const data = await cache.set("key", "value");
       expect(data).toBe("value");
       expect(redis.getStore().get("key")).toBe("");
     });
@@ -486,8 +454,7 @@ describe("Cache", () => {
 
       await cache.set("key", "value");
 
-      const [error, data] = await cache.get("key");
-      expect(error).toBeNull();
+      const data = await cache.get("key");
       expect(data).toBe("");
     });
 
@@ -500,12 +467,11 @@ describe("Cache", () => {
 
       await redis.set("key", "custom:John");
 
-      const [error, data] = await cache.get("key");
-      expect(error).toBeNull();
+      const data = await cache.get("key");
       expect(data).toEqual({ name: "John" });
     });
 
-    test("should return CacheError when serializer throws", async () => {
+    test("should throw SerializationError when serializer throws", async () => {
       const redis = createMockRedis();
       const cache = new Cache<string>({
         redis,
@@ -514,15 +480,14 @@ describe("Cache", () => {
         },
       });
 
-      const [error, data] = await cache.set("key", "value");
-      expect(error).toEqual({
-        type: "CacheError",
+      const promise = cache.set("key", "value");
+      await expect(promise).rejects.toMatchObject({
+        name: "SerializationError",
         message: "Unable to serialize value for key key",
       });
-      expect(data).toBeNull();
     });
 
-    test("should return CacheError when deserializer throws", async () => {
+    test("should throw DeserializationError when deserializer throws", async () => {
       const redis = createMockRedis();
       const cache = new Cache<string>({
         redis,
@@ -533,111 +498,11 @@ describe("Cache", () => {
 
       await redis.set("key", "value");
 
-      const [error, data] = await cache.get("key");
-      expect(error).toEqual({
-        type: "CacheError",
+      const promise = cache.get("key");
+      await expect(promise).rejects.toMatchObject({
+        name: "DeserializationError",
         message: "Unable to deserialize value for key key",
       });
-      expect(data).toBeNull();
-    });
-  });
-
-  describe("onError", () => {
-    test("should call onError on CacheError from get", async () => {
-      const redis = createMockRedis();
-      const errors: { type: string; message: string }[] = [];
-      const cache = new Cache<string>({
-        redis,
-        onError: (error) => errors.push(error),
-      });
-
-      redis.setShouldFail(true);
-      await cache.get("key");
-
-      expect(errors).toEqual([
-        { type: "CacheError", message: "Unable to get value for key key" },
-      ]);
-    });
-
-    test("should call onError on CacheError from set", async () => {
-      const redis = createMockRedis();
-      const errors: { type: string; message: string }[] = [];
-      const cache = new Cache<string>({
-        redis,
-        onError: (error) => errors.push(error),
-      });
-
-      redis.setShouldFail(true);
-      await cache.set("key", "value");
-
-      expect(errors).toEqual([
-        { type: "CacheError", message: "Unable to set value for key key" },
-      ]);
-    });
-
-    test("should call onError on CacheError from delete", async () => {
-      const redis = createMockRedis();
-      const errors: { type: string; message: string }[] = [];
-      const cache = new Cache<string>({
-        redis,
-        onError: (error) => errors.push(error),
-      });
-
-      redis.setShouldFail(true);
-      await cache.delete("key");
-
-      expect(errors).toEqual([
-        { type: "CacheError", message: "Unable to delete key key" },
-      ]);
-    });
-
-    test("should call onError on InvalidTTLError", async () => {
-      const redis = createMockRedis();
-      const errors: { type: string; message: string }[] = [];
-      const cache = new Cache<string>({
-        redis,
-        ttl: -1,
-        onError: (error) => errors.push(error),
-      });
-
-      await cache.set("key", "value");
-
-      expect(errors).toEqual([
-        {
-          type: "InvalidTTLError",
-          message: "Unable to save records with ttl equal to -1",
-        },
-      ]);
-    });
-
-    test("should call onError on NotFoundError", async () => {
-      const redis = createMockRedis();
-      const errors: { type: string; message: string }[] = [];
-      const cache = new Cache<string>({
-        redis,
-        onError: (error) => errors.push(error),
-      });
-
-      await cache.get("nonexistent");
-
-      expect(errors).toEqual([
-        { type: "NotFoundError", message: "Key nonexistent not found" },
-      ]);
-    });
-
-    test("should not call onError when no errors occur", async () => {
-      const redis = createMockRedis();
-      const errors: { type: string; message: string }[] = [];
-      const cache = new Cache<string>({
-        redis,
-        onError: (error) => errors.push(error),
-      });
-
-      await cache.set("key", "value");
-      await cache.get("key");
-      await cache.delete("key");
-
-      expect(errors).toEqual([]);
     });
   });
 
@@ -649,8 +514,7 @@ describe("Cache", () => {
         ttl: (_key, value) => (value.priority === "high" ? 60000 : 5000),
       });
 
-      const [error, data] = await cache.set("item", { priority: "high" });
-      expect(error).toBeNull();
+      const data = await cache.set("item", { priority: "high" });
       expect(data).toEqual({ priority: "high" });
     });
 
@@ -674,22 +538,21 @@ describe("Cache", () => {
       expect(receivedValue).toBe("myValue");
     });
 
-    test("should return InvalidTTLError when function returns invalid TTL", async () => {
+    test("should throw InvalidTTLError when function returns invalid TTL", async () => {
       const redis = createMockRedis();
       const cache = new Cache<string>({
         redis,
         ttl: () => -1,
       });
 
-      const [error, data] = await cache.set("key", "value");
-      expect(error).toEqual({
-        type: "InvalidTTLError",
+      const promise = cache.set("key", "value");
+      await expect(promise).rejects.toMatchObject({
+        name: "InvalidTTLError",
         message: "Unable to save records with ttl equal to -1",
       });
-      expect(data).toBeNull();
     });
 
-    test("should return InvalidTTLError when function throws", async () => {
+    test("should throw InvalidTTLError when function throws", async () => {
       const redis = createMockRedis();
       const cache = new Cache<string>({
         redis,
@@ -698,43 +561,36 @@ describe("Cache", () => {
         },
       });
 
-      const [error, data] = await cache.set("key", "value");
-      expect(error).toEqual({
-        type: "InvalidTTLError",
+      const promise = cache.set("key", "value");
+      await expect(promise).rejects.toMatchObject({
+        name: "InvalidTTLError",
         message: "Unable to resolve ttl for key key",
       });
-      expect(data).toBeNull();
     });
   });
 
   describe("Integration scenarios", () => {
     test("should handle complete set-get-delete flow", async () => {
       const redis = createMockRedis();
-      const cache = new Cache<{ id: number; name: string }>({
-        redis,
-      });
+      const cache = new Cache<{ id: number; name: string }>({ redis });
 
       // Set
-      const [setError, setValue] = await cache.set("user:123", {
-        id: 123,
-        name: "Alice",
-      });
-      expect(setError).toBeNull();
+      const setValue = await cache.set("user:123", { id: 123, name: "Alice" });
       expect(setValue).toEqual({ id: 123, name: "Alice" });
 
       // Get
-      const [getError, getValue] = await cache.get("user:123");
-      expect(getError).toBeNull();
+      const getValue = await cache.get("user:123");
       expect(getValue).toEqual({ id: 123, name: "Alice" });
 
       // Delete
-      const [delError, delCount] = await cache.delete("user:123");
-      expect(delError).toBeNull();
+      const delCount = await cache.delete("user:123");
       expect(delCount).toBe(1);
 
       // Verify deleted
-      const [notFoundError] = await cache.get("user:123");
-      expect(notFoundError?.type).toBe("NotFoundError");
+      const promise = cache.get("user:123");
+      await expect(promise).rejects.toMatchObject({
+        name: "NotFoundError",
+      });
     });
 
     test("should handle multiple cache instances with same Redis client", async () => {
@@ -743,20 +599,17 @@ describe("Cache", () => {
       const cache2 = new Cache<string>({ redis });
 
       await cache1.set("shared", "value1");
-      const [, value] = await cache2.get("shared");
-      expect(value).toBe("value1");
+      expect(await cache2.get("shared")).toBe("value1");
     });
 
     test("should handle cache with TTL option", async () => {
       const redis = createMockRedis();
       const cache = new Cache<string>({ redis, ttl: 1000 });
 
-      const [error, data] = await cache.set("expiring", "value");
-      expect(error).toBeNull();
+      const data = await cache.set("expiring", "value");
       expect(data).toBe("value");
 
-      const [, retrieved] = await cache.get("expiring");
-      expect(retrieved).toBe("value");
+      expect(await cache.get("expiring")).toBe("value");
     });
 
     test("should overwrite existing keys", async () => {
@@ -764,12 +617,10 @@ describe("Cache", () => {
       const cache = new Cache<string>({ redis });
 
       await cache.set("key", "value1");
-      const [, first] = await cache.get("key");
-      expect(first).toBe("value1");
+      expect(await cache.get("key")).toBe("value1");
 
       await cache.set("key", "value2");
-      const [, second] = await cache.get("key");
-      expect(second).toBe("value2");
+      expect(await cache.get("key")).toBe("value2");
     });
   });
 });

--- a/src/lib/cache/index.ts
+++ b/src/lib/cache/index.ts
@@ -1,5 +1,12 @@
-import { err, mightThrow, mightThrowSync, ok } from "../errors/index.js";
-import type { CacheError, CacheOptions } from "./types.js";
+import { mightThrow, mightThrowSync } from "../errors/index.js";
+import {
+  CacheError,
+  DeserializationError,
+  InvalidTTLError,
+  NotFoundError,
+  SerializationError,
+} from "./errors.js";
+import type { CacheOptions } from "./types.js";
 
 export class Cache<T> {
   private options: CacheOptions<T>;
@@ -14,7 +21,7 @@ export class Cache<T> {
 
   public async get(key: string) {
     if (!this.isEnabled) {
-      return this.fail("NotFoundError", `Key ${key} not found`);
+      throw new NotFoundError(`Key ${key} not found`);
     }
 
     const resolvedKey = this.resolveKey(key);
@@ -24,11 +31,11 @@ export class Cache<T> {
     );
 
     if (error) {
-      return this.fail("CacheError", `Unable to get value for key ${key}`);
+      throw new CacheError(`Unable to get value for key ${key}`);
     }
 
     if (value === null || value === undefined) {
-      return this.fail("NotFoundError", `Key ${key} not found`);
+      throw new NotFoundError(`Key ${key} not found`);
     }
 
     const [deserializeErr, deserialized] = mightThrowSync<T>(() =>
@@ -36,18 +43,17 @@ export class Cache<T> {
     );
 
     if (deserializeErr) {
-      return this.fail(
-        "CacheError",
+      throw new DeserializationError(
         `Unable to deserialize value for key ${key}`,
       );
     }
 
-    return ok(deserialized);
+    return deserialized;
   }
 
   public async set(key: string, value: T) {
     if (!this.isEnabled) {
-      return ok(value);
+      return value;
     }
 
     const [serializeErr, serialized] = mightThrowSync(() =>
@@ -55,31 +61,21 @@ export class Cache<T> {
     );
 
     if (serializeErr) {
-      return this.fail(
-        "CacheError",
-        `Unable to serialize value for key ${key}`,
-      );
+      throw new SerializationError(`Unable to serialize value for key ${key}`);
     }
 
     if (serialized === null || serialized === undefined) {
-      return this.fail(
-        "CacheError",
-        `Unable to serialize value for key ${key}`,
-      );
+      throw new SerializationError(`Unable to serialize value for key ${key}`);
     }
 
     const [ttlErr, ttl] = mightThrowSync(() => this.resolveTTL(key, value));
 
     if (ttlErr) {
-      return this.fail(
-        "InvalidTTLError",
-        `Unable to resolve ttl for key ${key}`,
-      );
+      throw new InvalidTTLError(`Unable to resolve ttl for key ${key}`);
     }
 
     if (!this.isTTLValid(ttl)) {
-      return this.fail(
-        "InvalidTTLError",
+      throw new InvalidTTLError(
         `Unable to save records with ttl equal to ${ttl}`,
       );
     }
@@ -91,15 +87,15 @@ export class Cache<T> {
     const [setError] = await mightThrow(setPromise);
 
     if (setError) {
-      return this.fail("CacheError", `Unable to set value for key ${key}`);
+      throw new CacheError(`Unable to set value for key ${key}`);
     }
 
-    return ok(value);
+    return value;
   }
 
   public async delete(key: string) {
     if (!this.isEnabled) {
-      return ok(0);
+      return 0;
     }
 
     const resolvedKey = this.resolveKey(key);
@@ -107,16 +103,10 @@ export class Cache<T> {
     const [error, data] = await mightThrow(this.options.redis.del(resolvedKey));
 
     if (error) {
-      return this.fail("CacheError", `Unable to delete key ${key}`);
+      throw new CacheError(`Unable to delete key ${key}`);
     }
 
-    return ok(data);
-  }
-
-  private fail<E extends CacheError>(type: E, message: string) {
-    this.options.onError?.({ type, message });
-
-    return err(type, message);
+    return data;
   }
 
   private get isEnabled() {

--- a/src/lib/cache/types.ts
+++ b/src/lib/cache/types.ts
@@ -7,5 +7,4 @@ export type CacheOptions<T> = {
   prefix?: string;
   serializer?: (value: T) => string;
   deserializer?: (raw: string) => T;
-  onError?: (error: { type: CacheError; message: string }) => void;
 };

--- a/src/lib/cache/types.ts
+++ b/src/lib/cache/types.ts
@@ -1,5 +1,3 @@
-export type CacheError = "CacheError" | "InvalidTTLError" | "NotFoundError";
-
 export type CacheOptions<T> = {
   redis: Bun.RedisClient;
   ttl?: number | ((key: string, value: T) => number);

--- a/src/lib/cron/core/index.test.ts
+++ b/src/lib/cron/core/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { CronLengthError, OutOfBoundError } from "../errors.js";
 import { Cron } from "./index.js";
 
 describe("Cron", () => {
@@ -49,7 +50,7 @@ describe("Cron", () => {
           schedule: "invalid",
           handler,
         });
-      }).toThrow("CronLengthError");
+      }).toThrow(CronLengthError);
     });
 
     test("should throw error for cron expression with wrong field count", () => {
@@ -61,7 +62,7 @@ describe("Cron", () => {
           schedule: "0 0 * *",
           handler,
         });
-      }).toThrow("CronLengthError");
+      }).toThrow(CronLengthError);
     });
   });
 
@@ -75,7 +76,7 @@ describe("Cron", () => {
           schedule: "10000000 0 * * *",
           handler,
         });
-      }).toThrow("OutOfBoundError");
+      }).toThrow(OutOfBoundError);
     });
 
     test("should reject an out-of-bounds number in second (100)", () => {
@@ -87,7 +88,7 @@ describe("Cron", () => {
           schedule: "100 * * * * *",
           handler,
         });
-      }).toThrow("OutOfBoundError");
+      }).toThrow(OutOfBoundError);
     });
 
     test("should reject an out-of-bounds step range in minute field (50-70/5)", () => {
@@ -99,7 +100,7 @@ describe("Cron", () => {
           schedule: "* 50-70/5  * * * *",
           handler,
         });
-      }).toThrow("OutOfBoundError");
+      }).toThrow(OutOfBoundError);
     });
 
     test("should accept a step range in minute field without the starting value", () => {
@@ -135,7 +136,7 @@ describe("Cron", () => {
           schedule: "* -70/5  * * * *",
           handler,
         });
-      }).toThrow("OutOfBoundError");
+      }).toThrow(OutOfBoundError);
     });
 
     test("should reject an out-of-bounds step range in minute field (70/5)", () => {
@@ -147,7 +148,7 @@ describe("Cron", () => {
           schedule: "* 70/5  * * * *",
           handler,
         });
-      }).toThrow("OutOfBoundError");
+      }).toThrow(OutOfBoundError);
     });
 
     test("should reject an out-of-bounds step range in day of the week field (7)", () => {
@@ -159,7 +160,7 @@ describe("Cron", () => {
           schedule: "0 0 * * 7",
           handler,
         });
-      }).toThrow("OutOfBoundError");
+      }).toThrow(OutOfBoundError);
     });
 
     test("should reject an out-of-bounds list value in hour field (1,15,40)", () => {
@@ -171,7 +172,7 @@ describe("Cron", () => {
           schedule: "0 1,15,40 * * *",
           handler,
         });
-      }).toThrow("OutOfBoundError");
+      }).toThrow(OutOfBoundError);
     });
 
     test("should reject an out-of-bounds range value in day field (1-33)", () => {
@@ -183,7 +184,7 @@ describe("Cron", () => {
           schedule: "0 * 1-33 * *",
           handler,
         });
-      }).toThrow("OutOfBoundError");
+      }).toThrow(OutOfBoundError);
     });
 
     test("inverted range with step inside a list passes scanner", () => {
@@ -195,7 +196,7 @@ describe("Cron", () => {
           schedule: "30-10/5 * * * *",
           handler,
         });
-      }).toThrow("OutOfBoundError");
+      }).toThrow(OutOfBoundError);
     });
 
     test("inverted range inside a list passes scanner", () => {
@@ -207,7 +208,7 @@ describe("Cron", () => {
           schedule: "30-10 * * * *",
           handler,
         });
-      }).toThrow("OutOfBoundError");
+      }).toThrow(OutOfBoundError);
     });
 
     test("wildcard-with-step = 0 should fail", () => {
@@ -219,7 +220,7 @@ describe("Cron", () => {
           schedule: "*/0,30 * * * *",
           handler,
         });
-      }).toThrow("OutOfBoundError");
+      }).toThrow(OutOfBoundError);
     });
 
     test("should reject an out-of-bounds step range in minute field (2-70/5)", () => {
@@ -231,7 +232,7 @@ describe("Cron", () => {
           schedule: "2-70/5 * * * *",
           handler,
         });
-      }).toThrow("OutOfBoundError");
+      }).toThrow(OutOfBoundError);
     });
   });
 

--- a/src/lib/cron/core/index.ts
+++ b/src/lib/cron/core/index.ts
@@ -1,6 +1,7 @@
-import { err, mightThrow, ok } from "../../errors/index.js";
+import { mightThrow } from "../../errors/index.js";
+import { InvalidValueError, OutOfBoundError } from "../errors.js";
 import { FieldAmount, Scanner, type Token } from "./scanner.js";
-import type { CronOptions, CronParsingError, CronStatus } from "./types.js";
+import type { CronOptions, CronStatus } from "./types.js";
 
 const RETRY_DELAY_MS = 60 * 60 * 1000; // 1 hour
 const MAX_YEARS = 4;
@@ -72,31 +73,22 @@ export class Cron {
     const [rangePart, stepStr] = part.split("/");
 
     if (!rangePart) {
-      return err<CronParsingError>(
-        "InvalidValueError",
-        `'${rangePart}' is empty`,
-      );
+      throw new InvalidValueError(`'${rangePart}' is empty`);
     }
 
     if (!stepStr) {
-      return err<CronParsingError>(
-        "InvalidValueError",
-        `'${stepStr}' is empty`,
-      );
+      throw new InvalidValueError(`'${stepStr}' is empty`);
     }
 
     const step = Number(stepStr);
 
     // Validate step is a positive integer
     if (!Number.isInteger(step)) {
-      return err<CronParsingError>(
-        "InvalidValueError",
-        `'${step}' is not a valid number`,
-      );
+      throw new InvalidValueError(`'${step}' is not a valid number`);
     }
 
     if (step <= 0) {
-      return err<CronParsingError>("OutOfBoundError", `Expected ${step} > 0`);
+      throw new OutOfBoundError(`Expected ${step} > 0`);
     }
 
     if (rangePart === "*") {
@@ -105,7 +97,7 @@ export class Cron {
         values[i] = 1;
       }
 
-      return ok(true);
+      return true;
     }
 
     if (rangePart.includes("-")) {
@@ -128,7 +120,7 @@ export class Cron {
     const [startStr, endStr] = range.split("-");
 
     if (!endStr) {
-      return err<CronParsingError>("InvalidValueError", `'${endStr}' is empty`);
+      throw new InvalidValueError(`'${endStr}' is empty`);
     }
 
     let start = min;
@@ -140,38 +132,23 @@ export class Cron {
 
     // Validate range boundaries are integers within bounds
     if (!Number.isInteger(start)) {
-      return err<CronParsingError>(
-        "InvalidValueError",
-        `'${start}' is not a valid number`,
-      );
+      throw new InvalidValueError(`'${start}' is not a valid number`);
     }
 
     if (!Number.isInteger(end)) {
-      return err<CronParsingError>(
-        "InvalidValueError",
-        `'${end}' is not a valid number`,
-      );
+      throw new InvalidValueError(`'${end}' is not a valid number`);
     }
 
     if (start < min) {
-      return err<CronParsingError>(
-        "OutOfBoundError",
-        `Expected ${start} >= ${min}`,
-      );
+      throw new OutOfBoundError(`Expected ${start} >= ${min}`);
     }
 
     if (end > max) {
-      return err<CronParsingError>(
-        "OutOfBoundError",
-        `Expected ${end} <= ${max}`,
-      );
+      throw new OutOfBoundError(`Expected ${end} <= ${max}`);
     }
 
     if (start > end) {
-      return err<CronParsingError>(
-        "OutOfBoundError",
-        `Expected ${start} <= ${end}`,
-      );
+      throw new OutOfBoundError(`Expected ${start} <= ${end}`);
     }
 
     // Apply step through range
@@ -179,7 +156,7 @@ export class Cron {
       values[i] = 1;
     }
 
-    return ok(true);
+    return true;
   }
 
   private handleStepSingle(
@@ -193,24 +170,15 @@ export class Cron {
 
     // Validate starting value is an integer within bounds
     if (!Number.isInteger(start)) {
-      return err<CronParsingError>(
-        "InvalidValueError",
-        `'${start}' is not a valid number`,
-      );
+      throw new InvalidValueError(`'${start}' is not a valid number`);
     }
 
     if (start < min) {
-      return err<CronParsingError>(
-        "OutOfBoundError",
-        `Expected ${start} >= ${min}`,
-      );
+      throw new OutOfBoundError(`Expected ${start} >= ${min}`);
     }
 
     if (start > max) {
-      return err<CronParsingError>(
-        "OutOfBoundError",
-        `Expected ${start} <= ${max}`,
-      );
+      throw new OutOfBoundError(`Expected ${start} <= ${max}`);
     }
 
     // Apply step from start to end of range
@@ -218,7 +186,7 @@ export class Cron {
       values[i] = 1;
     }
 
-    return ok(true);
+    return true;
   }
 
   private handleRange(
@@ -231,14 +199,11 @@ export class Cron {
     const [startStr, endStr] = part.split("-");
 
     if (!startStr) {
-      return err<CronParsingError>(
-        "InvalidValueError",
-        `'${startStr}' is empty`,
-      );
+      throw new InvalidValueError(`'${startStr}' is empty`);
     }
 
     if (!endStr) {
-      return err<CronParsingError>("InvalidValueError", `'${endStr}' is empty`);
+      throw new InvalidValueError(`'${endStr}' is empty`);
     }
 
     const start = Number(startStr);
@@ -246,38 +211,23 @@ export class Cron {
 
     // Validate range boundaries are integers within bounds
     if (!Number.isInteger(start)) {
-      return err<CronParsingError>(
-        "InvalidValueError",
-        `'${start}' is not a valid number`,
-      );
+      throw new InvalidValueError(`'${start}' is not a valid number`);
     }
 
     if (!Number.isInteger(end)) {
-      return err<CronParsingError>(
-        "InvalidValueError",
-        `'${end}' is not a valid number`,
-      );
+      throw new InvalidValueError(`'${end}' is not a valid number`);
     }
 
     if (start < min) {
-      return err<CronParsingError>(
-        "OutOfBoundError",
-        `Expected ${start} >= ${min}`,
-      );
+      throw new OutOfBoundError(`Expected ${start} >= ${min}`);
     }
 
     if (end > max) {
-      return err<CronParsingError>(
-        "OutOfBoundError",
-        `Expected ${end} <= ${max}`,
-      );
+      throw new OutOfBoundError(`Expected ${end} <= ${max}`);
     }
 
     if (start > end) {
-      return err<CronParsingError>(
-        "OutOfBoundError",
-        `Expected ${start} <= ${end}`,
-      );
+      throw new OutOfBoundError(`Expected ${start} <= ${end}`);
     }
 
     // Mark all values in the range
@@ -285,7 +235,7 @@ export class Cron {
       values[i] = 1;
     }
 
-    return ok(true);
+    return true;
   }
 
   private handleNumber(
@@ -298,28 +248,19 @@ export class Cron {
 
     // Validate value is an integer within bounds
     if (!Number.isInteger(n)) {
-      return err<CronParsingError>(
-        "InvalidValueError",
-        `'${value}' is not a valid number`,
-      );
+      throw new InvalidValueError(`'${value}' is not a valid number`);
     }
 
     if (n < min) {
-      return err<CronParsingError>(
-        "OutOfBoundError",
-        `Expected ${n} >= ${min}`,
-      );
+      throw new OutOfBoundError(`Expected ${n} >= ${min}`);
     }
     if (n > max) {
-      return err<CronParsingError>(
-        "OutOfBoundError",
-        `Expected ${n} <= ${max}`,
-      );
+      throw new OutOfBoundError(`Expected ${n} <= ${max}`);
     }
 
     values[n] = 1;
 
-    return ok(true);
+    return true;
   }
 
   public constructor(options: CronOptions) {
@@ -327,18 +268,13 @@ export class Cron {
 
     // Resolve alias or use raw expression
     const expr = this.resolveAlias(options.schedule);
-    const [error, tokens] = new Scanner(expr).scan();
-    if (error) throw new Error(`${error.type}: ${error.message}`);
+    const tokens = new Scanner(expr).scan();
 
     const fields = expr.trim().split(/\s+/);
     this.hasSeconds = fields.length === FieldAmount.max;
 
     // Parse and validate the cron expression
-    const [parsingError, _] = this.parse(tokens);
-
-    if (parsingError) {
-      throw new Error(`${parsingError.type}: ${parsingError.message}`);
-    }
+    this.parse(tokens);
   }
 
   // Map alias to standard cron expression if present
@@ -351,60 +287,39 @@ export class Cron {
       const token = tokens[i];
 
       if (!token) {
-        return err<CronParsingError>("InvalidValueError", "Undefined token");
+        throw new InvalidValueError("Undefined token");
       }
 
       const tokenType = token.getTokenType();
 
       switch (token.getField()) {
         case "second": {
-          const [error, _] = this.handleField(
+          this.handleField(
             token,
             this.second,
             CronSecondRange.min,
             CronSecondRange.max,
           );
 
-          if (error) {
-            return err<CronParsingError>(
-              error.type,
-              `${error.message} in field '${token.getField()}'`,
-            );
-          }
-
           break;
         }
         case "minute": {
-          const [error, _] = this.handleField(
+          this.handleField(
             token,
             this.minute,
             CronMinuteRange.min,
             CronMinuteRange.max,
           );
 
-          if (error) {
-            return err<CronParsingError>(
-              error.type,
-              `${error.message} in field '${token.getField()}'`,
-            );
-          }
-
           break;
         }
         case "hour": {
-          const [error, _] = this.handleField(
+          this.handleField(
             token,
             this.hour,
             CronHourRange.min,
             CronHourRange.max,
           );
-
-          if (error) {
-            return err<CronParsingError>(
-              error.type,
-              `${error.message} in field '${token.getField()}'`,
-            );
-          }
 
           break;
         }
@@ -413,36 +328,17 @@ export class Cron {
             this._dayWildcard = true;
           }
 
-          const [error, _] = this.handleField(
-            token,
-            this.day,
-            CronDayRange.min,
-            CronDayRange.max,
-          );
-
-          if (error) {
-            return err<CronParsingError>(
-              error.type,
-              `${error.message} in field '${token.getField()}'`,
-            );
-          }
+          this.handleField(token, this.day, CronDayRange.min, CronDayRange.max);
 
           break;
         }
         case "month": {
-          const [error, _] = this.handleField(
+          this.handleField(
             token,
             this.month,
             CronMonthRange.min,
             CronMonthRange.max,
           );
-
-          if (error) {
-            return err<CronParsingError>(
-              error.type,
-              `${error.message} in field '${token.getField()}'`,
-            );
-          }
 
           break;
         }
@@ -451,31 +347,21 @@ export class Cron {
             this._dowWildcard = true;
           }
 
-          const [error, _] = this.handleField(
+          this.handleField(
             token,
             this.dayOfWeek,
             CronDayOfWeekRange.min,
             CronDayOfWeekRange.max,
           );
 
-          if (error) {
-            return err<CronParsingError>(
-              error.type,
-              `${error.message} in field '${token.getField()}'`,
-            );
-          }
-
           break;
         }
         default:
-          return err<CronParsingError>(
-            "InvalidValueError",
-            `Invalid field '${token.getField()}'`,
-          );
+          throw new InvalidValueError(`Invalid field '${token.getField()}'`);
       }
     }
 
-    return ok(true);
+    return true;
   }
 
   private handleField(token: Token, field: number[], min: number, max: number) {
@@ -485,38 +371,29 @@ export class Cron {
         break;
       }
       case "number": {
-        const [error, _] = this.handleNumber(
-          token.getComponent(),
-          field,
-          min,
-          max,
-        );
-        if (error) return err<CronParsingError>(error.type, error.message);
+        this.handleNumber(token.getComponent(), field, min, max);
 
         break;
       }
       case "range": {
         const component = token.getComponent();
-        const [error, _] = this.handleRange(component, field, min, max);
-        if (error) return err<CronParsingError>(error.type, error.message);
+        this.handleRange(component, field, min, max);
 
         break;
       }
       case "step": {
         const component = token.getComponent();
-        const [error, _] = this.handleStep(component, field, min, max);
-        if (error) return err<CronParsingError>(error.type, error.message);
+        this.handleStep(component, field, min, max);
 
         break;
       }
       default:
-        return err<CronParsingError>(
-          "InvalidValueError",
+        throw new InvalidValueError(
           `Invalid token type '${token.getTokenType()}'`,
         );
     }
 
-    return ok(true);
+    return true;
   }
 
   public matches(date: Date) {

--- a/src/lib/cron/core/index.ts
+++ b/src/lib/cron/core/index.ts
@@ -97,16 +97,18 @@ export class Cron {
         values[i] = 1;
       }
 
-      return true;
+      return;
     }
 
     if (rangePart.includes("-")) {
       // Range with step: delegate to specialized handler
-      return this.handleStepRange(rangePart, step, values, min, max);
+      this.handleStepRange(rangePart, step, values, min, max);
+
+      return;
     }
 
     // Single value with step: delegate to specialized handler
-    return this.handleStepSingle(rangePart, step, values, min, max);
+    this.handleStepSingle(rangePart, step, values, min, max);
   }
 
   private handleStepRange(
@@ -155,8 +157,6 @@ export class Cron {
     for (let i = start; i <= end; i += step) {
       values[i] = 1;
     }
-
-    return true;
   }
 
   private handleStepSingle(
@@ -185,8 +185,6 @@ export class Cron {
     for (let i = start; i <= max; i += step) {
       values[i] = 1;
     }
-
-    return true;
   }
 
   private handleRange(
@@ -234,8 +232,6 @@ export class Cron {
     for (let i = start; i <= end; i++) {
       values[i] = 1;
     }
-
-    return true;
   }
 
   private handleNumber(
@@ -259,8 +255,6 @@ export class Cron {
     }
 
     values[n] = 1;
-
-    return true;
   }
 
   public constructor(options: CronOptions) {
@@ -360,8 +354,6 @@ export class Cron {
           throw new InvalidValueError(`Invalid field '${token.getField()}'`);
       }
     }
-
-    return true;
   }
 
   private handleField(token: Token, field: number[], min: number, max: number) {
@@ -392,8 +384,6 @@ export class Cron {
           `Invalid token type '${token.getTokenType()}'`,
         );
     }
-
-    return true;
   }
 
   public matches(date: Date) {

--- a/src/lib/cron/core/scanner.test.ts
+++ b/src/lib/cron/core/scanner.test.ts
@@ -1,121 +1,91 @@
 import { describe, expect, test } from "bun:test";
+import {
+  CronExpressionError,
+  CronLengthError,
+  EmptyCronExpressionError,
+} from "../errors.js";
 import { Scanner, Token } from "./scanner.js";
 
 describe("Cron Scanner", () => {
   describe("Simple expression", () => {
     test("should have a valid length", () => {
-      const [errOne, fiveTokens] = new Scanner("* * * * *").scan();
-      const [errTwo, sixTokens] = new Scanner("* * * * * *").scan();
+      const fiveTokens = new Scanner("* * * * *").scan();
+      const sixTokens = new Scanner("* * * * * *").scan();
 
-      expect(errOne).toBeNull();
-      expect(errTwo).toBeNull();
       expect(fiveTokens).toBeArray();
       expect(sixTokens).toBeArray();
-      expect(fiveTokens?.length).toEqual(5);
-      expect(sixTokens?.length).toEqual(6);
+      expect(fiveTokens.length).toEqual(5);
+      expect(sixTokens.length).toEqual(6);
     });
 
     test("should ignore multiple white spaces, tabs", () => {
-      const [err, tokens] = new Scanner(
-        "*    * \t*  \t\n\r  * \t  * \t\r  *",
-      ).scan();
+      const tokens = new Scanner("*    * \t*  \t\n\r  * \t  * \t\r  *").scan();
 
-      expect(err).toBeNull();
       expect(tokens).toBeArray();
-      expect(tokens?.length).toEqual(6);
+      expect(tokens.length).toEqual(6);
 
       expect(
-        tokens?.[0]?.equals(new Token("*", "any", "*", "second")),
+        tokens[0]?.equals(new Token("*", "any", "*", "second")),
       ).toBeTrue();
-
       expect(
-        tokens?.[1]?.equals(new Token("*", "any", "*", "minute")),
+        tokens[1]?.equals(new Token("*", "any", "*", "minute")),
       ).toBeTrue();
-
+      expect(tokens[2]?.equals(new Token("*", "any", "*", "hour"))).toBeTrue();
+      expect(tokens[3]?.equals(new Token("*", "any", "*", "day"))).toBeTrue();
+      expect(tokens[4]?.equals(new Token("*", "any", "*", "month"))).toBeTrue();
       expect(
-        tokens?.[2]?.equals(new Token("*", "any", "*", "hour")),
-      ).toBeTrue();
-
-      expect(tokens?.[3]?.equals(new Token("*", "any", "*", "day"))).toBeTrue();
-
-      expect(
-        tokens?.[4]?.equals(new Token("*", "any", "*", "month")),
-      ).toBeTrue();
-
-      expect(
-        tokens?.[5]?.equals(new Token("*", "any", "*", "weekday")),
+        tokens[5]?.equals(new Token("*", "any", "*", "weekday")),
       ).toBeTrue();
     });
 
     test("should create a list of integer tokens", () => {
-      const [err, tokens] = new Scanner("1 2 3 4 5 6").scan();
+      const tokens = new Scanner("1 2 3 4 5 6").scan();
 
-      expect(err).toBeNull();
       expect(tokens).toBeArray();
-      expect(tokens?.length).toEqual(6);
+      expect(tokens.length).toEqual(6);
 
       expect(
-        tokens?.[0]?.equals(new Token("1", "number", 1, "second")),
+        tokens[0]?.equals(new Token("1", "number", 1, "second")),
       ).toBeTrue();
-
       expect(
-        tokens?.[1]?.equals(new Token("2", "number", 2, "minute")),
+        tokens[1]?.equals(new Token("2", "number", 2, "minute")),
       ).toBeTrue();
-
+      expect(tokens[2]?.equals(new Token("3", "number", 3, "hour"))).toBeTrue();
+      expect(tokens[3]?.equals(new Token("4", "number", 4, "day"))).toBeTrue();
       expect(
-        tokens?.[2]?.equals(new Token("3", "number", 3, "hour")),
+        tokens[4]?.equals(new Token("5", "number", 5, "month")),
       ).toBeTrue();
-
       expect(
-        tokens?.[3]?.equals(new Token("4", "number", 4, "day")),
-      ).toBeTrue();
-
-      expect(
-        tokens?.[4]?.equals(new Token("5", "number", 5, "month")),
-      ).toBeTrue();
-
-      expect(
-        tokens?.[5]?.equals(new Token("6", "number", 6, "weekday")),
+        tokens[5]?.equals(new Token("6", "number", 6, "weekday")),
       ).toBeTrue();
     });
 
     test("should generate EmptyCronExpressionError for an empty string", () => {
-      const [err, tokens] = new Scanner("").scan();
+      const fn = () => new Scanner("").scan();
 
-      expect(err).not.toBeNull();
-      expect(tokens).toBeNull();
-
-      expect(err?.type).toEqual("EmptyCronExpressionError");
-      expect(err?.message).toEqual("Cron expression have zero length");
+      expect(fn).toThrow(EmptyCronExpressionError);
+      expect(fn).toThrow("Cron expression have zero length");
     });
 
     test("should generate CronLengthError", () => {
-      const [errOne, tokensOne] = new Scanner("* * *").scan();
-      const [errTwo, tokensTwo] = new Scanner("* * * * * * * *").scan();
+      const fnOne = () => new Scanner("* * *").scan();
+      const fnTwo = () => new Scanner("* * * * * * * *").scan();
 
-      expect(errOne).not.toBeNull();
-      expect(errTwo).not.toBeNull();
-      expect(tokensOne).toBeNull();
-      expect(tokensTwo).toBeNull();
-
-      expect(errOne?.type).toEqual("CronLengthError");
-      expect(errOne?.message).toEqual(
+      expect(fnOne).toThrow(CronLengthError);
+      expect(fnOne).toThrow(
         "Invalid number of fields for '* * *'. Expected 5 or 6 fields but got 3 field(s)",
       );
-      expect(errTwo?.type).toEqual("CronLengthError");
-      expect(errTwo?.message).toEqual(
+      expect(fnTwo).toThrow(CronLengthError);
+      expect(fnTwo).toThrow(
         "Invalid number of fields for '* * * * * * * *'. Expected 5 or 6 fields but got 8 field(s)",
       );
     });
 
     test("should generate CronExpressionError for reading an invalid symbol", () => {
-      const [err, tokens] = new Scanner("t * * * *").scan();
+      const fn = () => new Scanner("t * * * *").scan();
 
-      expect(err).not.toBeNull();
-      expect(tokens).toBeNull();
-
-      expect(err?.type).toEqual("CronExpressionError");
-      expect(err?.message).toEqual(
+      expect(fn).toThrow(CronExpressionError);
+      expect(fn).toThrow(
         "Invalid cron expression 't * * * *' in field 'minute'",
       );
     });
@@ -123,301 +93,231 @@ describe("Cron Scanner", () => {
 
   describe("Number tokens", () => {
     test("should generate a numerical token", () => {
-      const [error, tokens] = new Scanner("10 * * * *").scan();
+      const tokens = new Scanner("10 * * * *").scan();
 
-      expect(error).toBeNull();
       expect(tokens).toBeArray();
-      expect(tokens?.length).toEqual(5);
+      expect(tokens.length).toEqual(5);
       expect(
-        tokens?.[0]?.equals(new Token("10", "number", 10, "minute")),
+        tokens[0]?.equals(new Token("10", "number", 10, "minute")),
       ).toBeTrue();
     });
 
     test("should generate a numerical token with a large number", () => {
-      const [error, tokens] = new Scanner("10000000 * * * *").scan();
+      const tokens = new Scanner("10000000 * * * *").scan();
 
-      expect(error).toBeNull();
       expect(tokens).toBeArray();
-      expect(tokens?.length).toEqual(5);
+      expect(tokens.length).toEqual(5);
       expect(
-        tokens?.[0]?.equals(
+        tokens[0]?.equals(
           new Token("10000000", "number", 10_000_000, "minute"),
         ),
       ).toBeTrue();
     });
 
     test("should generate a multiple numerical tokens with different values", () => {
-      const [error, tokens] = new Scanner("10 * 20 * 30").scan();
+      const tokens = new Scanner("10 * 20 * 30").scan();
 
-      expect(error).toBeNull();
       expect(tokens).toBeArray();
-      expect(tokens?.length).toEqual(5);
+      expect(tokens.length).toEqual(5);
       expect(
-        tokens?.[0]?.equals(new Token("10", "number", 10, "minute")),
+        tokens[0]?.equals(new Token("10", "number", 10, "minute")),
       ).toBeTrue();
-
       expect(
-        tokens?.[2]?.equals(new Token("20", "number", 20, "day")),
+        tokens[2]?.equals(new Token("20", "number", 20, "day")),
       ).toBeTrue();
-
       expect(
-        tokens?.[4]?.equals(new Token("30", "number", 30, "weekday")),
+        tokens[4]?.equals(new Token("30", "number", 30, "weekday")),
       ).toBeTrue();
     });
 
     test("should generate a CronExpressionError for an invalid symbol", () => {
-      const [err, tokens] = new Scanner("10 * 20 * 3s0").scan();
+      const fn = () => new Scanner("10 * 20 * 3s0").scan();
 
-      expect(err).not.toBeNull();
-      expect(tokens).toBeNull();
-
-      expect(err?.type).toEqual("CronExpressionError");
-      expect(err?.message).toEqual("Invalid number '3s0' for field 'weekday'");
+      expect(fn).toThrow(CronExpressionError);
+      expect(fn).toThrow("Invalid number '3s0' for field 'weekday'");
     });
 
     test("should generate a CronExpressionError for a decimal number with just a decimal point", () => {
-      const [err, tokens] = new Scanner("10. * * * *").scan();
+      const fn = () => new Scanner("10. * * * *").scan();
 
-      expect(err).not.toBeNull();
-      expect(tokens).toBeNull();
-
-      expect(err?.type).toEqual("CronExpressionError");
-      expect(err?.message).toEqual("Invalid number '10.' for field 'minute'");
+      expect(fn).toThrow(CronExpressionError);
+      expect(fn).toThrow("Invalid number '10.' for field 'minute'");
     });
   });
 
   describe("Step tokens", () => {
     test("should generate a 'step' token without a custom range", () => {
-      const [err, tokens] = new Scanner("*/1 * * * *").scan();
+      const tokens = new Scanner("*/1 * * * *").scan();
 
-      expect(err).toBeNull();
       expect(tokens).toBeArray();
-      expect(tokens?.length).toEqual(5);
-
+      expect(tokens.length).toEqual(5);
       expect(
-        tokens?.[0]?.equals(new Token("*/1", "step", 1, "minute")),
+        tokens[0]?.equals(new Token("*/1", "step", 1, "minute")),
       ).toBeTrue();
     });
 
     test("should generate a 'step' token with a custom range", () => {
-      const [err, tokens] = new Scanner("2-6/1 * * * *").scan();
+      const tokens = new Scanner("2-6/1 * * * *").scan();
 
-      expect(err).toBeNull();
       expect(tokens).toBeArray();
-      expect(tokens?.length).toEqual(5);
-
+      expect(tokens.length).toEqual(5);
       expect(
-        tokens?.[0]?.equals(new Token("2-6/1", "step", 1, "minute")),
+        tokens[0]?.equals(new Token("2-6/1", "step", 1, "minute")),
       ).toBeTrue();
     });
 
     test("should generate a 'step' token with just the starting point of its range", () => {
-      const [err, tokens] = new Scanner("6/1 * * * *").scan();
+      const tokens = new Scanner("6/1 * * * *").scan();
 
-      expect(err).toBeNull();
       expect(tokens).toBeArray();
-      expect(tokens?.length).toEqual(5);
-
+      expect(tokens.length).toEqual(5);
       expect(
-        tokens?.[0]?.equals(new Token("6/1", "step", 1, "minute")),
+        tokens[0]?.equals(new Token("6/1", "step", 1, "minute")),
       ).toBeTrue();
     });
 
     test("should generate a 'step' token with just the ending point of its range", () => {
-      const [err, tokens] = new Scanner("-6/1 * * * *").scan();
+      const tokens = new Scanner("-6/1 * * * *").scan();
 
-      expect(err).toBeNull();
       expect(tokens).toBeArray();
-      expect(tokens?.length).toEqual(5);
-
+      expect(tokens.length).toEqual(5);
       expect(
-        tokens?.[0]?.equals(new Token("-6/1", "step", 1, "minute")),
+        tokens[0]?.equals(new Token("-6/1", "step", 1, "minute")),
       ).toBeTrue();
     });
 
     test("should generate a valid 'step' token when reading numbers with leading zeros", () => {
-      const [err, tokens] = new Scanner("0001-007/0001 * * * *").scan();
+      const tokens = new Scanner("0001-007/0001 * * * *").scan();
 
-      expect(err).toBeNull();
       expect(tokens).toBeArray();
-      expect(tokens?.length).toEqual(5);
-
+      expect(tokens.length).toEqual(5);
       expect(
-        tokens?.[0]?.equals(new Token("0001-007/0001", "step", 1, "minute")),
+        tokens[0]?.equals(new Token("0001-007/0001", "step", 1, "minute")),
       ).toBeTrue();
     });
 
     test("should generate a CronExpressionError for a step expression with decimal point but no fraction", () => {
-      const [err, tokens] = new Scanner("*/10. * * * *").scan();
+      const fn = () => new Scanner("*/10. * * * *").scan();
 
-      expect(err).not.toBeNull();
-      expect(tokens).toBeNull();
-
-      expect(err?.type).toEqual("CronExpressionError");
-      expect(err?.message).toEqual(
-        "Invalid step expression '*/10.' for field 'minute'",
-      );
+      expect(fn).toThrow(CronExpressionError);
+      expect(fn).toThrow("Invalid step expression '*/10.' for field 'minute'");
     });
 
     test("should generate a 'step' token with a very long range", () => {
-      const [err, tokens] = new Scanner(
-        "11232324512-134414512/1233 * * * *",
-      ).scan();
+      const tokens = new Scanner("11232324512-134414512/1233 * * * *").scan();
 
-      expect(err).toBeNull();
       expect(tokens).toBeArray();
-      expect(tokens?.length).toEqual(5);
-
+      expect(tokens.length).toEqual(5);
       expect(
-        tokens?.[0]?.equals(
+        tokens[0]?.equals(
           new Token("11232324512-134414512/1233", "step", 1233, "minute"),
         ),
       ).toBeTrue();
     });
 
     test("should generate CronExpressionError for a step expression without its step value", () => {
-      const [err, tokens] = new Scanner("1-2/ * * * *").scan();
+      const fn = () => new Scanner("1-2/ * * * *").scan();
 
-      expect(tokens).toBeNull();
-      expect(err).not.toBeNull();
-      expect(err?.type).toEqual("CronExpressionError");
-      expect(err?.message).toEqual(
-        "Invalid step expression '1-2/' for field 'minute'",
-      );
+      expect(fn).toThrow(CronExpressionError);
+      expect(fn).toThrow("Invalid step expression '1-2/' for field 'minute'");
     });
 
     test("should generate CronExpressionError for a step expression with multiple asterisk", () => {
-      const [err, tokens] = new Scanner("**/1 * * * *").scan();
+      const fn = () => new Scanner("**/1 * * * *").scan();
 
-      expect(tokens).toBeNull();
-      expect(err).not.toBeNull();
-      expect(err?.type).toEqual("CronExpressionError");
-      expect(err?.message).toEqual(
-        "Invalid any expression '**/1' for field 'minute'",
-      );
+      expect(fn).toThrow(CronExpressionError);
+      expect(fn).toThrow("Invalid any expression '**/1' for field 'minute'");
     });
 
     test("should generate CronExpressionError for a step expression with invalid symbols", () => {
-      const [err, tokens] = new Scanner("1-32/2a41 * * * *").scan();
+      const fn = () => new Scanner("1-32/2a41 * * * *").scan();
 
-      expect(tokens).toBeNull();
-      expect(err).not.toBeNull();
-      expect(err?.type).toEqual("CronExpressionError");
-      expect(err?.message).toEqual(
+      expect(fn).toThrow(CronExpressionError);
+      expect(fn).toThrow(
         "Invalid step expression '1-32/2a41' for field 'minute'",
       );
     });
 
     test("should generate CronExpressionError for a step expression with a backslash symbol", () => {
-      const [err, tokens] = new Scanner("*/\\2 * * * *").scan();
+      const fn = () => new Scanner("*/\\2 * * * *").scan();
 
-      expect(tokens).toBeNull();
-      expect(err).not.toBeNull();
-      expect(err?.type).toEqual("CronExpressionError");
-      expect(err?.message).toEqual(
-        "Invalid step expression '*/\\2' for field 'minute'",
-      );
+      expect(fn).toThrow(CronExpressionError);
+      expect(fn).toThrow("Invalid step expression '*/\\2' for field 'minute'");
     });
 
     test("should generate CronExpressionError for a step expression with multiple slash symbols", () => {
-      const [err, tokens] = new Scanner("*/2/ * * * *").scan();
+      const fn = () => new Scanner("*/2/ * * * *").scan();
 
-      expect(tokens).toBeNull();
-      expect(err).not.toBeNull();
-      expect(err?.type).toEqual("CronExpressionError");
-      expect(err?.message).toEqual(
-        "Invalid step expression '*/2/' for field 'minute'",
-      );
+      expect(fn).toThrow(CronExpressionError);
+      expect(fn).toThrow("Invalid step expression '*/2/' for field 'minute'");
     });
 
     test("should generate CronExpressionError for a step expression with a range as a step value", () => {
-      const [err, tokens] = new Scanner("*/2-4 * * * *").scan();
+      const fn = () => new Scanner("*/2-4 * * * *").scan();
 
-      expect(tokens).toBeNull();
-      expect(err).not.toBeNull();
-      expect(err?.type).toEqual("CronExpressionError");
-      expect(err?.message).toEqual(
-        "Invalid step expression '*/2-4' for field 'minute'",
-      );
+      expect(fn).toThrow(CronExpressionError);
+      expect(fn).toThrow("Invalid step expression '*/2-4' for field 'minute'");
     });
   });
 
   describe("Range tokens", () => {
     test("should generate a valid 'range' token", () => {
-      const [error, tokens] = new Scanner("1-5 * * * *").scan();
+      const tokens = new Scanner("1-5 * * * *").scan();
 
-      expect(error).toBeNull();
       expect(tokens).toBeArray();
-      expect(tokens?.length).toEqual(5);
+      expect(tokens.length).toEqual(5);
       expect(
-        tokens?.[0]?.equals(new Token("1-5", "range", "1-5", "minute")),
+        tokens[0]?.equals(new Token("1-5", "range", "1-5", "minute")),
       ).toBeTrue();
     });
 
     test("should generate a valid 'range' token with large numbers", () => {
-      const [error, tokens] = new Scanner("1000000-5000000 * * * *").scan();
+      const tokens = new Scanner("1000000-5000000 * * * *").scan();
 
-      expect(error).toBeNull();
       expect(tokens).toBeArray();
-      expect(tokens?.length).toEqual(5);
+      expect(tokens.length).toEqual(5);
       expect(
-        tokens?.[0]?.equals(
+        tokens[0]?.equals(
           new Token("1000000-5000000", "range", "1000000-5000000", "minute"),
         ),
       ).toBeTrue();
     });
 
     test("should generate CronExpressionError for invalid symbols", () => {
-      const [err, tokens] = new Scanner("100-5a0 * * * *").scan();
+      const fn = () => new Scanner("100-5a0 * * * *").scan();
 
-      expect(tokens).toBeNull();
-      expect(err).not.toBeNull();
-      expect(err?.type).toEqual("CronExpressionError");
-      expect(err?.message).toEqual(
+      expect(fn).toThrow(CronExpressionError);
+      expect(fn).toThrow(
         "Invalid range expression '100-5a0' for field 'minute'",
       );
     });
 
     test("should generate CronExpressionError for missing the starting point", () => {
-      const [err, tokens] = new Scanner("-50 * * * *").scan();
+      const fn = () => new Scanner("-50 * * * *").scan();
 
-      expect(tokens).toBeNull();
-      expect(err).not.toBeNull();
-      expect(err?.type).toEqual("CronExpressionError");
-      expect(err?.message).toEqual(
-        "Invalid range expression '-50' for field 'minute'",
-      );
+      expect(fn).toThrow(CronExpressionError);
+      expect(fn).toThrow("Invalid range expression '-50' for field 'minute'");
     });
 
     test("should generate CronExpressionError for missing the ending point", () => {
-      const [err, tokens] = new Scanner("10- * * * *").scan();
+      const fn = () => new Scanner("10- * * * *").scan();
 
-      expect(tokens).toBeNull();
-      expect(err).not.toBeNull();
-      expect(err?.type).toEqual("CronExpressionError");
-      expect(err?.message).toEqual(
-        "Invalid range expression '10-' for field 'minute'",
-      );
+      expect(fn).toThrow(CronExpressionError);
+      expect(fn).toThrow("Invalid range expression '10-' for field 'minute'");
     });
 
     test("should generate CronExpressionError for multiple hyphen", () => {
-      const [err, tokens] = new Scanner("10--1 * * * *").scan();
+      const fn = () => new Scanner("10--1 * * * *").scan();
 
-      expect(tokens).toBeNull();
-      expect(err).not.toBeNull();
-      expect(err?.type).toEqual("CronExpressionError");
-      expect(err?.message).toEqual(
-        "Invalid range expression '10--1' for field 'minute'",
-      );
+      expect(fn).toThrow(CronExpressionError);
+      expect(fn).toThrow("Invalid range expression '10--1' for field 'minute'");
     });
 
     test("should generate CronExpressionError for multiple consecutive hyphen", () => {
-      const [err, tokens] = new Scanner("10-3-1 * * * *").scan();
+      const fn = () => new Scanner("10-3-1 * * * *").scan();
 
-      expect(tokens).toBeNull();
-      expect(err).not.toBeNull();
-      expect(err?.type).toEqual("CronExpressionError");
-      expect(err?.message).toEqual(
+      expect(fn).toThrow(CronExpressionError);
+      expect(fn).toThrow(
         "Invalid range expression '10-3-1' for field 'minute'",
       );
     });
@@ -425,547 +325,445 @@ describe("Cron Scanner", () => {
 
   describe("List tokens", () => {
     test("should generate a list with numbers", () => {
-      const [err, tokens] = new Scanner("10,20,30 2 3 4 5").scan();
+      const tokens = new Scanner("10,20,30 2 3 4 5").scan();
 
-      expect(err).toBeNull();
       expect(tokens).toBeArray();
-      expect(tokens?.length).toEqual(7);
+      expect(tokens.length).toEqual(7);
 
       expect(
-        tokens?.[0]?.equals(new Token("10", "number", 10, "minute")),
+        tokens[0]?.equals(new Token("10", "number", 10, "minute")),
       ).toBeTrue();
-
       expect(
-        tokens?.[1]?.equals(new Token("20", "number", 20, "minute")),
+        tokens[1]?.equals(new Token("20", "number", 20, "minute")),
       ).toBeTrue();
-
       expect(
-        tokens?.[2]?.equals(new Token("30", "number", 30, "minute")),
+        tokens[2]?.equals(new Token("30", "number", 30, "minute")),
       ).toBeTrue();
-
+      expect(tokens[3]?.equals(new Token("2", "number", 2, "hour"))).toBeTrue();
+      expect(tokens[4]?.equals(new Token("3", "number", 3, "day"))).toBeTrue();
       expect(
-        tokens?.[3]?.equals(new Token("2", "number", 2, "hour")),
+        tokens[5]?.equals(new Token("4", "number", 4, "month")),
       ).toBeTrue();
-
       expect(
-        tokens?.[4]?.equals(new Token("3", "number", 3, "day")),
-      ).toBeTrue();
-
-      expect(
-        tokens?.[5]?.equals(new Token("4", "number", 4, "month")),
-      ).toBeTrue();
-
-      expect(
-        tokens?.[6]?.equals(new Token("5", "number", 5, "weekday")),
+        tokens[6]?.equals(new Token("5", "number", 5, "weekday")),
       ).toBeTrue();
     });
 
     test("should generate a list with numbers and range expressions", () => {
-      const [err, tokens] = new Scanner("10,20-10,30-40 2 3 4 5").scan();
+      const tokens = new Scanner("10,20-10,30-40 2 3 4 5").scan();
 
-      expect(err).toBeNull();
       expect(tokens).toBeArray();
-      expect(tokens?.length).toEqual(7);
+      expect(tokens.length).toEqual(7);
 
       expect(
-        tokens?.[0]?.equals(new Token("10", "number", 10, "minute")),
+        tokens[0]?.equals(new Token("10", "number", 10, "minute")),
       ).toBeTrue();
-
       expect(
-        tokens?.[1]?.equals(new Token("20-10", "range", "20-10", "minute")),
+        tokens[1]?.equals(new Token("20-10", "range", "20-10", "minute")),
       ).toBeTrue();
-
       expect(
-        tokens?.[2]?.equals(new Token("30-40", "range", "30-40", "minute")),
+        tokens[2]?.equals(new Token("30-40", "range", "30-40", "minute")),
       ).toBeTrue();
-
+      expect(tokens[3]?.equals(new Token("2", "number", 2, "hour"))).toBeTrue();
+      expect(tokens[4]?.equals(new Token("3", "number", 3, "day"))).toBeTrue();
       expect(
-        tokens?.[3]?.equals(new Token("2", "number", 2, "hour")),
+        tokens[5]?.equals(new Token("4", "number", 4, "month")),
       ).toBeTrue();
-
       expect(
-        tokens?.[4]?.equals(new Token("3", "number", 3, "day")),
-      ).toBeTrue();
-
-      expect(
-        tokens?.[5]?.equals(new Token("4", "number", 4, "month")),
-      ).toBeTrue();
-
-      expect(
-        tokens?.[6]?.equals(new Token("5", "number", 5, "weekday")),
+        tokens[6]?.equals(new Token("5", "number", 5, "weekday")),
       ).toBeTrue();
     });
 
     test("should generate a list with numbers, range and step expressions", () => {
-      const [err, tokens] = new Scanner("10,20-10,30-40/20,*/3 2 3 4 5").scan();
+      const tokens = new Scanner("10,20-10,30-40/20,*/3 2 3 4 5").scan();
 
-      expect(err).toBeNull();
       expect(tokens).toBeArray();
-      expect(tokens?.length).toEqual(8);
+      expect(tokens.length).toEqual(8);
 
       expect(
-        tokens?.[0]?.equals(new Token("10", "number", 10, "minute")),
+        tokens[0]?.equals(new Token("10", "number", 10, "minute")),
       ).toBeTrue();
-
       expect(
-        tokens?.[1]?.equals(new Token("20-10", "range", "20-10", "minute")),
+        tokens[1]?.equals(new Token("20-10", "range", "20-10", "minute")),
       ).toBeTrue();
-
       expect(
-        tokens?.[2]?.equals(new Token("30-40/20", "step", 20, "minute")),
+        tokens[2]?.equals(new Token("30-40/20", "step", 20, "minute")),
       ).toBeTrue();
-
       expect(
-        tokens?.[3]?.equals(new Token("*/3", "step", 3, "minute")),
+        tokens[3]?.equals(new Token("*/3", "step", 3, "minute")),
       ).toBeTrue();
-
+      expect(tokens[4]?.equals(new Token("2", "number", 2, "hour"))).toBeTrue();
+      expect(tokens[5]?.equals(new Token("3", "number", 3, "day"))).toBeTrue();
       expect(
-        tokens?.[4]?.equals(new Token("2", "number", 2, "hour")),
+        tokens[6]?.equals(new Token("4", "number", 4, "month")),
       ).toBeTrue();
-
       expect(
-        tokens?.[5]?.equals(new Token("3", "number", 3, "day")),
-      ).toBeTrue();
-
-      expect(
-        tokens?.[6]?.equals(new Token("4", "number", 4, "month")),
-      ).toBeTrue();
-
-      expect(
-        tokens?.[7]?.equals(new Token("5", "number", 5, "weekday")),
+        tokens[7]?.equals(new Token("5", "number", 5, "weekday")),
       ).toBeTrue();
     });
 
     test("should generate a list with numbers and step expression variants", () => {
-      const [err, tokens] = new Scanner("10,20/10,-40/20 2 3 4 5").scan();
+      const tokens = new Scanner("10,20/10,-40/20 2 3 4 5").scan();
 
-      expect(err).toBeNull();
       expect(tokens).toBeArray();
-      expect(tokens?.length).toEqual(7);
+      expect(tokens.length).toEqual(7);
 
       expect(
-        tokens?.[0]?.equals(new Token("10", "number", 10, "minute")),
+        tokens[0]?.equals(new Token("10", "number", 10, "minute")),
       ).toBeTrue();
-
       expect(
-        tokens?.[1]?.equals(new Token("20/10", "step", 10, "minute")),
+        tokens[1]?.equals(new Token("20/10", "step", 10, "minute")),
       ).toBeTrue();
-
       expect(
-        tokens?.[2]?.equals(new Token("-40/20", "step", 20, "minute")),
+        tokens[2]?.equals(new Token("-40/20", "step", 20, "minute")),
       ).toBeTrue();
-
+      expect(tokens[3]?.equals(new Token("2", "number", 2, "hour"))).toBeTrue();
+      expect(tokens[4]?.equals(new Token("3", "number", 3, "day"))).toBeTrue();
       expect(
-        tokens?.[3]?.equals(new Token("2", "number", 2, "hour")),
+        tokens[5]?.equals(new Token("4", "number", 4, "month")),
       ).toBeTrue();
-
       expect(
-        tokens?.[4]?.equals(new Token("3", "number", 3, "day")),
-      ).toBeTrue();
-
-      expect(
-        tokens?.[5]?.equals(new Token("4", "number", 4, "month")),
-      ).toBeTrue();
-
-      expect(
-        tokens?.[6]?.equals(new Token("5", "number", 5, "weekday")),
+        tokens[6]?.equals(new Token("5", "number", 5, "weekday")),
       ).toBeTrue();
     });
 
     test("should generate a CronExpressionError for invalid list syntax", () => {
-      const [err, tokens] = new Scanner("10,20, 2 3 4 5").scan();
+      const fn = () => new Scanner("10,20, 2 3 4 5").scan();
 
-      expect(err).not.toBeNull();
-      expect(tokens).toBeNull();
-
-      expect(err?.type).toEqual("CronExpressionError");
-      expect(err?.message).toEqual(
-        "Invalid list expression '10,20,' for field 'minute'",
-      );
+      expect(fn).toThrow(CronExpressionError);
+      expect(fn).toThrow("Invalid list expression '10,20,' for field 'minute'");
     });
 
     test("should generate a CronExpressionError for invalid symbols inside a list", () => {
-      const [err, tokens] = new Scanner("10,a20, 2 3 4 5").scan();
+      const fn = () => new Scanner("10,a20, 2 3 4 5").scan();
 
-      expect(err).not.toBeNull();
-      expect(tokens).toBeNull();
-
-      expect(err?.type).toEqual("CronExpressionError");
-      expect(err?.message).toEqual(
+      expect(fn).toThrow(CronExpressionError);
+      expect(fn).toThrow(
         "Invalid cron expression '10,a20, 2 3 4 5' in field 'minute'",
       );
     });
 
     test("should generate a CronExpressionError for a leading comma", () => {
-      const [err, tokens] = new Scanner(",0 * * * *").scan();
+      const fn = () => new Scanner(",0 * * * *").scan();
 
-      expect(err).not.toBeNull();
-      expect(tokens).toBeNull();
-
-      expect(err?.type).toEqual("CronExpressionError");
+      expect(fn).toThrow(CronExpressionError);
     });
 
     test("should generate a CronExpressionError for a lone comma", () => {
-      // Expected: error - "," contains no valid items on either side
-      const [err, tokens] = new Scanner(", * * * *").scan();
+      const fn = () => new Scanner(", * * * *").scan();
 
-      expect(err).not.toBeNull();
-      expect(tokens).toBeNull();
-
-      expect(err?.type).toEqual("CronExpressionError");
+      expect(fn).toThrow(CronExpressionError);
     });
 
     test("should generate a list with a wildcard as the first item in a list", () => {
-      const [err, tokens] = new Scanner("*,5 * * * *").scan();
+      const tokens = new Scanner("*,5 * * * *").scan();
 
-      expect(err).toBeNull();
       expect(tokens).toBeArray();
-      expect(tokens?.length).toEqual(6);
+      expect(tokens.length).toEqual(6);
 
       expect(
-        tokens?.[0]?.equals(new Token("*", "any", "*", "minute")),
+        tokens[0]?.equals(new Token("*", "any", "*", "minute")),
       ).toBeTrue();
-
       expect(
-        tokens?.[1]?.equals(new Token("5", "number", 5, "minute")),
+        tokens[1]?.equals(new Token("5", "number", 5, "minute")),
       ).toBeTrue();
     });
 
     test("should generate a list with a wildcard in the middle of a list", () => {
-      const [err, tokens] = new Scanner("5,*,10 * * * *").scan();
+      const tokens = new Scanner("5,*,10 * * * *").scan();
 
-      expect(err).toBeNull();
       expect(tokens).toBeArray();
-      expect(tokens?.length).toEqual(7);
+      expect(tokens.length).toEqual(7);
 
       expect(
-        tokens?.[0]?.equals(new Token("5", "number", 5, "minute")),
+        tokens[0]?.equals(new Token("5", "number", 5, "minute")),
       ).toBeTrue();
-
       expect(
-        tokens?.[1]?.equals(new Token("*", "any", "*", "minute")),
+        tokens[1]?.equals(new Token("*", "any", "*", "minute")),
       ).toBeTrue();
-
       expect(
-        tokens?.[2]?.equals(new Token("10", "number", 10, "minute")),
+        tokens[2]?.equals(new Token("10", "number", 10, "minute")),
       ).toBeTrue();
     });
   });
 
   describe("Validation", () => {
     test("should accept a wildcard expression", () => {
-      const [err] = new Scanner("* * * * *").scan();
-      expect(err).toBeNull();
+      const fn = () => new Scanner("* * * * *").scan();
+      expect(fn).not.toThrow();
     });
 
     test("should accept a step expression", () => {
-      const [err] = new Scanner("*/5 * * * *").scan();
-      expect(err).toBeNull();
+      const fn = () => new Scanner("*/5 * * * *").scan();
+      expect(fn).not.toThrow();
     });
 
     test("should accept a range expression", () => {
-      const [err] = new Scanner("0 9-17 * * *").scan();
-      expect(err).toBeNull();
+      const fn = () => new Scanner("0 9-17 * * *").scan();
+      expect(fn).not.toThrow();
     });
 
     test("should accept a list expression", () => {
-      const [err] = new Scanner("0 9,12,15 * * *").scan();
-      expect(err).toBeNull();
+      const fn = () => new Scanner("0 9,12,15 * * *").scan();
+      expect(fn).not.toThrow();
     });
 
     test("should accept a combined expression", () => {
-      const [err] = new Scanner("0 9-17/2 * * 1-5").scan();
-      expect(err).toBeNull();
+      const fn = () => new Scanner("0 9-17/2 * * 1-5").scan();
+      expect(fn).not.toThrow();
     });
 
     test("should reject an out-of-bounds number (60 in minute field)", () => {
       // The scanner accepts any digit sequence - out-of-bounds is a semantic check,
       // not a tokenization error. This test documents that the scanner passes it through.
-      const [err] = new Scanner("60 * * * *").scan();
-      expect(err).toBeNull();
+      const fn = () => new Scanner("60 * * * *").scan();
+      expect(fn).not.toThrow();
     });
 
     test("should reject a step of zero", () => {
-      const [err] = new Scanner("*/0 * * * *").scan();
-      expect(err).toBeNull();
+      const fn = () => new Scanner("*/0 * * * *").scan();
+      expect(fn).not.toThrow();
     });
 
     test("should reject a double-hyphen (negative range attempt)", () => {
-      const [err] = new Scanner("0--5 * * * *").scan();
-      expect(err).not.toBeNull();
-      expect(err?.type).toEqual("CronExpressionError");
+      const fn = () => new Scanner("0--5 * * * *").scan();
+
+      expect(fn).toThrow(CronExpressionError);
     });
 
     test("should reject an out-of-bounds step range start in day field (0-10/2)", () => {
       // Tokenization succeeds; out-of-bounds is a semantic check not done by the scanner
-      const [err] = new Scanner("0 0 0-10/2 * *").scan();
-      expect(err).toBeNull();
+      const fn = () => new Scanner("0 0 0-10/2 * *").scan();
+      expect(fn).not.toThrow();
     });
 
     test("should reject an out-of-bounds step range (70-80/2)", () => {
       // Tokenization succeeds; out-of-bounds is a semantic check not done by the scanner
-      const [err] = new Scanner("70-80/2 * * * *").scan();
-      expect(err).toBeNull();
+      const fn = () => new Scanner("70-80/2 * * * *").scan();
+      expect(fn).not.toThrow();
     });
 
     test("should reject a step range where start > end (30-10/2)", () => {
       // Tokenization succeeds; start > end is a semantic check not done by the scanner
-      const [err] = new Scanner("30-10/2 * * * *").scan();
-      expect(err).toBeNull();
+      const fn = () => new Scanner("30-10/2 * * * *").scan();
+      expect(fn).not.toThrow();
     });
 
     test("should reject a decimal number in a step range (1.5-10/2)", () => {
-      const [err] = new Scanner("1.5-10/2 * * * *").scan();
-      expect(err).not.toBeNull();
-      expect(err?.type).toEqual("CronExpressionError");
+      const fn = () => new Scanner("1.5-10/2 * * * *").scan();
+      expect(fn).toThrow(CronExpressionError);
     });
 
     test("should accept a valid step range expression (10-50/5)", () => {
-      const [err] = new Scanner("10-50/5 * * * *").scan();
-      expect(err).toBeNull();
+      const fn = () => new Scanner("10-50/5 * * * *").scan();
+      expect(fn).not.toThrow();
     });
 
     test("should accept step ranges at all field boundaries", () => {
-      const [err] = new Scanner("0-59/10 0-23/4 1-31/7 1-12/3 0-6/2").scan();
-      expect(err).toBeNull();
+      const fn = () => new Scanner("0-59/10 0-23/4 1-31/7 1-12/3 0-6/2").scan();
+      expect(fn).not.toThrow();
     });
 
     test("should accept a 6-field expression with seconds", () => {
-      const [err] = new Scanner("* * * * * *").scan();
-      expect(err).toBeNull();
+      const fn = () => new Scanner("* * * * * *").scan();
+      expect(fn).not.toThrow();
     });
 
     test("should accept a 6-field expression with specific seconds (30)", () => {
-      const [err] = new Scanner("30 * * * * *").scan();
-      expect(err).toBeNull();
+      const fn = () => new Scanner("30 * * * * *").scan();
+      expect(fn).not.toThrow();
     });
 
     test("should accept a 6-field expression with step in seconds (*/5)", () => {
-      const [err] = new Scanner("*/5 * * * * *").scan();
-      expect(err).toBeNull();
+      const fn = () => new Scanner("*/5 * * * * *").scan();
+      expect(fn).not.toThrow();
     });
 
     test("should reject a 7-field expression", () => {
-      const [err] = new Scanner("* * * * * * *").scan();
-      expect(err).not.toBeNull();
-      expect(err?.type).toEqual("CronLengthError");
+      const fn = () => new Scanner("* * * * * * *").scan();
+
+      expect(fn).toThrow(CronLengthError);
     });
   });
 
   describe("Scientific notation", () => {
     test("should generate a CronExpressionError for scientific notation in minute field", () => {
-      const [err, tokens] = new Scanner("1e1 * * * *").scan();
+      const fn = () => new Scanner("1e1 * * * *").scan();
 
-      expect(err).not.toBeNull();
-      expect(tokens).toBeNull();
-
-      expect(err?.type).toEqual("CronExpressionError");
-      expect(err?.message).toEqual("Invalid number '1e1' for field 'minute'");
+      expect(fn).toThrow(CronExpressionError);
+      expect(fn).toThrow("Invalid number '1e1' for field 'minute'");
     });
 
     test("should generate a CronExpressionError for scientific notation in day field", () => {
-      const [err, tokens] = new Scanner("0 0 1e1 * *").scan();
+      const fn = () => new Scanner("0 0 1e1 * *").scan();
 
-      expect(err).not.toBeNull();
-      expect(tokens).toBeNull();
-
-      expect(err?.type).toEqual("CronExpressionError");
-      expect(err?.message).toEqual("Invalid number '1e1' for field 'day'");
+      expect(fn).toThrow(CronExpressionError);
+      expect(fn).toThrow("Invalid number '1e1' for field 'day'");
     });
   });
 
   describe("Expression token structure", () => {
     describe("wildcard with step", () => {
       test("wildcard-with-step in a list emits a Step token followed by a Number token", () => {
-        // "*/10,30" -> Step(10) for the wildcard step, Number(30) for the list item
-        const [err, tokens] = new Scanner("*/10,30 * * * *").scan();
+        const tokens = new Scanner("*/10,30 * * * *").scan();
 
-        expect(err).toBeNull();
-        expect(tokens?.length).toEqual(6); // 2 minute tokens + 4 wildcards
-
+        expect(tokens.length).toEqual(6);
         expect(
-          tokens?.[0]?.equals(new Token("*/10", "step", 10, "minute")),
+          tokens[0]?.equals(new Token("*/10", "step", 10, "minute")),
         ).toBeTrue();
         expect(
-          tokens?.[1]?.equals(new Token("30", "number", 30, "minute")),
+          tokens[1]?.equals(new Token("30", "number", 30, "minute")),
         ).toBeTrue();
       });
 
       test("wildcard-with-step as standalone field emits a single Step token", () => {
-        // "*/6" in hour -> Step(6)
-        const [err, tokens] = new Scanner("0 */6 * * *").scan();
+        const tokens = new Scanner("0 */6 * * *").scan();
 
-        expect(err).toBeNull();
-        expect(tokens?.length).toEqual(5);
-
+        expect(tokens.length).toEqual(5);
         expect(
-          tokens?.[0]?.equals(new Token("0", "number", 0, "minute")),
+          tokens[0]?.equals(new Token("0", "number", 0, "minute")),
         ).toBeTrue();
         expect(
-          tokens?.[1]?.equals(new Token("*/6", "step", 6, "hour")),
+          tokens[1]?.equals(new Token("*/6", "step", 6, "hour")),
         ).toBeTrue();
       });
     });
 
     describe("number tokens for specific field values", () => {
       test("emits correct Number tokens for day and month fields", () => {
-        // "0 0 15 6 *" -> minute=0, hour=0, day=15, month=6, weekday=*
-        const [err, tokens] = new Scanner("0 0 15 6 *").scan();
+        const tokens = new Scanner("0 0 15 6 *").scan();
 
-        expect(err).toBeNull();
-        expect(tokens?.length).toEqual(5);
-
+        expect(tokens.length).toEqual(5);
         expect(
-          tokens?.[2]?.equals(new Token("15", "number", 15, "day")),
+          tokens[2]?.equals(new Token("15", "number", 15, "day")),
         ).toBeTrue();
         expect(
-          tokens?.[3]?.equals(new Token("6", "number", 6, "month")),
+          tokens[3]?.equals(new Token("6", "number", 6, "month")),
         ).toBeTrue();
       });
 
       test("emits Number token for day 31", () => {
-        const [err, tokens] = new Scanner("0 12 31 * *").scan();
+        const tokens = new Scanner("0 12 31 * *").scan();
 
-        expect(err).toBeNull();
         expect(
-          tokens?.[2]?.equals(new Token("31", "number", 31, "day")),
+          tokens[2]?.equals(new Token("31", "number", 31, "day")),
         ).toBeTrue();
       });
 
       test("emits Number token for month 12 (December)", () => {
-        const [err, tokens] = new Scanner("0 0 1 12 *").scan();
+        const tokens = new Scanner("0 0 1 12 *").scan();
 
-        expect(err).toBeNull();
         expect(
-          tokens?.[3]?.equals(new Token("12", "number", 12, "month")),
+          tokens[3]?.equals(new Token("12", "number", 12, "month")),
         ).toBeTrue();
       });
 
       test("emits Number token for month 1 (January)", () => {
-        const [err, tokens] = new Scanner("0 0 1 1 *").scan();
+        const tokens = new Scanner("0 0 1 1 *").scan();
 
-        expect(err).toBeNull();
         expect(
-          tokens?.[3]?.equals(new Token("1", "number", 1, "month")),
+          tokens[3]?.equals(new Token("1", "number", 1, "month")),
         ).toBeTrue();
       });
 
       test("emits Number token for day 29 and month 2 (Feb 29)", () => {
-        const [err, tokens] = new Scanner("0 0 29 2 *").scan();
+        const tokens = new Scanner("0 0 29 2 *").scan();
 
-        expect(err).toBeNull();
         expect(
-          tokens?.[2]?.equals(new Token("29", "number", 29, "day")),
+          tokens[2]?.equals(new Token("29", "number", 29, "day")),
         ).toBeTrue();
         expect(
-          tokens?.[3]?.equals(new Token("2", "number", 2, "month")),
+          tokens[3]?.equals(new Token("2", "number", 2, "month")),
         ).toBeTrue();
       });
     });
 
     describe("range and step token structure", () => {
       test("degenerate range (5-5) emits a Range token", () => {
-        const [err, tokens] = new Scanner("5-5 * * * *").scan();
+        const tokens = new Scanner("5-5 * * * *").scan();
 
-        expect(err).toBeNull();
         expect(
-          tokens?.[0]?.equals(new Token("5-5", "range", "5-5", "minute")),
+          tokens[0]?.equals(new Token("5-5", "range", "5-5", "minute")),
         ).toBeTrue();
       });
 
       test("step of 1 (*/1) emits a Step token with value 1", () => {
-        const [err, tokens] = new Scanner("*/1 * * * *").scan();
+        const tokens = new Scanner("*/1 * * * *").scan();
 
-        expect(err).toBeNull();
         expect(
-          tokens?.[0]?.equals(new Token("*/1", "step", 1, "minute")),
+          tokens[0]?.equals(new Token("*/1", "step", 1, "minute")),
         ).toBeTrue();
       });
 
       test("range-with-step where step exceeds range width emits a Step token", () => {
-        // "10-15/10" -> Step(10); expansion to only minute 10 is post-scan semantics
-        const [err, tokens] = new Scanner("10-15/10 * * * *").scan();
+        const tokens = new Scanner("10-15/10 * * * *").scan();
 
-        expect(err).toBeNull();
         expect(
-          tokens?.[0]?.equals(new Token("10-15/10", "step", 10, "minute")),
+          tokens[0]?.equals(new Token("10-15/10", "step", 10, "minute")),
         ).toBeTrue();
       });
 
       test("step larger than field width (*/60) emits a Step token with value 60", () => {
-        // Expansion to only minute 0 is post-scan semantics
-        const [err, tokens] = new Scanner("*/60 * * * *").scan();
+        const tokens = new Scanner("*/60 * * * *").scan();
 
-        expect(err).toBeNull();
         expect(
-          tokens?.[0]?.equals(new Token("*/60", "step", 60, "minute")),
+          tokens[0]?.equals(new Token("*/60", "step", 60, "minute")),
         ).toBeTrue();
       });
 
       test("range-with-step inside a list emits Step and Number tokens", () => {
-        // "10-30/5,45" -> Step(5) for the range-step, Number(45) for the list item
-        const [err, tokens] = new Scanner("10-30/5,45 * * * *").scan();
+        const tokens = new Scanner("10-30/5,45 * * * *").scan();
 
-        expect(err).toBeNull();
-        expect(tokens?.length).toEqual(6); // 2 minute tokens + 4 wildcards
-
+        expect(tokens.length).toEqual(6);
         expect(
-          tokens?.[0]?.equals(new Token("10-30/5", "step", 5, "minute")),
+          tokens[0]?.equals(new Token("10-30/5", "step", 5, "minute")),
         ).toBeTrue();
         expect(
-          tokens?.[1]?.equals(new Token("45", "number", 45, "minute")),
+          tokens[1]?.equals(new Token("45", "number", 45, "minute")),
         ).toBeTrue();
       });
 
       test("full minute range (0-59) emits a Range token", () => {
-        const [err, tokens] = new Scanner("0-59 * * * *").scan();
+        const tokens = new Scanner("0-59 * * * *").scan();
 
-        expect(err).toBeNull();
         expect(
-          tokens?.[0]?.equals(new Token("0-59", "range", "0-59", "minute")),
+          tokens[0]?.equals(new Token("0-59", "range", "0-59", "minute")),
         ).toBeTrue();
       });
 
       test("full month range (1-12) emits a Range token in month field", () => {
-        const [err, tokens] = new Scanner("0 0 1 1-12 *").scan();
+        const tokens = new Scanner("0 0 1 1-12 *").scan();
 
-        expect(err).toBeNull();
         expect(
-          tokens?.[3]?.equals(new Token("1-12", "range", "1-12", "month")),
+          tokens[3]?.equals(new Token("1-12", "range", "1-12", "month")),
         ).toBeTrue();
       });
 
       test("zero-length range (0-0) emits a Range token", () => {
-        const [err, tokens] = new Scanner("0-0 * * * *").scan();
+        const tokens = new Scanner("0-0 * * * *").scan();
 
-        expect(err).toBeNull();
         expect(
-          tokens?.[0]?.equals(new Token("0-0", "range", "0-0", "minute")),
+          tokens[0]?.equals(new Token("0-0", "range", "0-0", "minute")),
         ).toBeTrue();
       });
 
       test("6-field expression emits Number token for second field", () => {
-        // "30 0 0 1 1 *" = second=30, minute=0, hour=0, day=1, month=1, weekday=*
-        const [err, tokens] = new Scanner("30 0 0 1 1 *").scan();
+        const tokens = new Scanner("30 0 0 1 1 *").scan();
 
-        expect(err).toBeNull();
-        expect(tokens?.length).toEqual(6);
-
+        expect(tokens.length).toEqual(6);
         expect(
-          tokens?.[0]?.equals(new Token("30", "number", 30, "second")),
+          tokens[0]?.equals(new Token("30", "number", 30, "second")),
         ).toBeTrue();
         expect(
-          tokens?.[1]?.equals(new Token("0", "number", 0, "minute")),
+          tokens[1]?.equals(new Token("0", "number", 0, "minute")),
         ).toBeTrue();
       });
 
       test("dayOfWeek 7 passes scanner (out-of-bounds is a semantic check)", () => {
-        // The scanner accepts any digit sequence; 7 > max(6) is validated post-scan
-        const [err, tokens] = new Scanner("0 0 * * 7").scan();
+        const tokens = new Scanner("0 0 * * 7").scan();
 
-        expect(err).toBeNull();
         expect(
-          tokens?.[4]?.equals(new Token("7", "number", 7, "weekday")),
+          tokens[4]?.equals(new Token("7", "number", 7, "weekday")),
         ).toBeTrue();
       });
     });

--- a/src/lib/cron/core/scanner.ts
+++ b/src/lib/cron/core/scanner.ts
@@ -1,5 +1,8 @@
-import { err, ok } from "../../errors/index.js";
-import type { CronScannerError } from "./types.js";
+import {
+  CronExpressionError,
+  CronLengthError,
+  EmptyCronExpressionError,
+} from "../errors.js";
 
 export const FieldAmount = {
   min: 5,
@@ -86,10 +89,7 @@ export class Scanner {
 
   public scan() {
     if (this.expression.length === 0) {
-      return err<CronScannerError>(
-        "EmptyCronExpressionError",
-        "Cron expression have zero length",
-      );
+      throw new EmptyCronExpressionError("Cron expression have zero length");
     }
 
     const fields = this.expression.trim().split(/\s+/);
@@ -97,8 +97,7 @@ export class Scanner {
     const hasMaxLen = fields.length === FieldAmount.max;
 
     if (!hasMinLen && !hasMaxLen) {
-      return err<CronScannerError>(
-        "CronLengthError",
+      throw new CronLengthError(
         `Invalid number of fields for '${this.expression}'. Expected 5 or 6 fields but got ${fields.length} field(s)`,
       );
     }
@@ -108,19 +107,17 @@ export class Scanner {
     for (let idx = 0; idx < components.length; idx++) {
       const component = components[idx];
       if (!component) {
-        return err<CronScannerError>(
-          "CronExpressionError",
+        throw new CronExpressionError(
           `Invalid cron expression: ${this.expression}`,
         );
       }
 
       this.current = 0;
       this.start = 0;
-      const [error, _] = this.scanComponent(component);
-      if (error) return err<CronScannerError>(error.type, error.message);
+      this.scanComponent(component);
     }
 
-    return ok(this.tokens);
+    return this.tokens;
   }
 
   private scanComponent(component: ComponentType) {
@@ -132,13 +129,11 @@ export class Scanner {
         case "*": {
           const ch = this.peek(content);
           if (this.match(content, "/")) {
-            const [error, _] = this.handleStep(component);
-            if (error) return err<CronScannerError>(error.type, error.message);
+            this.handleStep(component);
           } else if (!ch || ch === ",") {
             this.addToken("*", "any", "*", field);
           } else {
-            return err<CronScannerError>(
-              "CronExpressionError",
+            throw new CronExpressionError(
               `Invalid any expression '${content}' for field '${field}'`,
             );
           }
@@ -147,29 +142,27 @@ export class Scanner {
         }
         case "-": {
           currentCh = this.advance(content);
+
           if (this.isDigit(currentCh)) {
-            const [error, _] = this.handleRangeWithStep(component);
-            if (error) return err<CronScannerError>(error.type, error.message);
+            this.handleRangeWithStep(component);
           } else {
-            return err<CronScannerError>(
-              "CronExpressionError",
+            throw new CronExpressionError(
               `Invalid range expression '${content}' for field '${field}'`,
             );
           }
+
           break;
         }
         case ",": {
           if (this.current === 1 && this.start === 0) {
-            return err<CronScannerError>(
-              "CronExpressionError",
+            throw new CronExpressionError(
               `Invalid list expression '${content}' for field '${field}'`,
             );
           }
 
           const next = this.peek(content);
           if (!next || next === ",") {
-            return err<CronScannerError>(
-              "CronExpressionError",
+            throw new CronExpressionError(
               `Invalid list expression '${content}' for field '${field}'`,
             );
           }
@@ -178,11 +171,9 @@ export class Scanner {
         }
         default: {
           if (this.isDigit(currentCh)) {
-            const [error, _] = this.handleNumber(component);
-            if (error) return err<CronScannerError>(error.type, error.message);
+            this.handleNumber(component);
           } else {
-            return err<CronScannerError>(
-              "CronExpressionError",
+            throw new CronExpressionError(
               `Invalid cron expression '${this.expression}' in field '${field}'`,
             );
           }
@@ -194,7 +185,7 @@ export class Scanner {
       this.start = this.current;
     }
 
-    return ok(true);
+    return true;
   }
 
   private addToken(
@@ -239,8 +230,7 @@ export class Scanner {
     }
 
     if (ch && ch !== ",") {
-      return err<CronScannerError>(
-        "CronExpressionError",
+      throw new CronExpressionError(
         `Invalid step expression '${content}' for field '${field}'`,
       );
     }
@@ -249,14 +239,13 @@ export class Scanner {
     const value = content.slice(slashIdx + 1, this.current);
 
     if (value.length === 0) {
-      return err<CronScannerError>(
-        "CronExpressionError",
+      throw new CronExpressionError(
         `Invalid step expression '${content}' for field '${field}'`,
       );
     }
 
     this.addToken(tokenContent, "step", Number(value), field);
-    return ok(true);
+    return true;
   }
 
   private handleRangeWithStep(component: ComponentType) {
@@ -269,21 +258,18 @@ export class Scanner {
     }
 
     if (!ch) {
-      return err<CronScannerError>(
-        "CronExpressionError",
+      throw new CronExpressionError(
         `Invalid range expression '${content}' for field '${field}'`,
       );
     }
 
     if (this.match(content, "/")) {
-      const [error, _] = this.handleStep(component);
-      if (error) return err<CronScannerError>(error.type, error.message);
+      this.handleStep(component);
 
-      return ok(true);
+      return true;
     }
 
-    return err<CronScannerError>(
-      "CronExpressionError",
+    throw new CronExpressionError(
       `Invalid range expression '${content}' for field '${field}'`,
     );
   }
@@ -302,33 +288,30 @@ export class Scanner {
       // Reached the end of the component
       const item = content.substring(this.start);
       this.addToken(item, "number", Number(item), field);
-      return ok(true);
+      return true;
     }
 
     if (this.match(content, "-")) {
-      const [error, _] = this.handleRange(component);
-      if (error) return err<CronScannerError>(error.type, error.message);
+      this.handleRange(component);
 
-      return ok(true);
+      return true;
     }
 
     if (this.match(content, "/")) {
-      const [error, _] = this.handleStep(component);
-      if (error) return err<CronScannerError>(error.type, error.message);
+      this.handleStep(component);
 
-      return ok(true);
+      return true;
     }
 
     if (!this.isDigit(ch) && ch !== ",") {
-      return err<CronScannerError>(
-        "CronExpressionError",
+      throw new CronExpressionError(
         `Invalid number '${content}' for field '${field}'`,
       );
     }
 
     const item = content.substring(this.start, this.current);
     this.addToken(item, "number", Number(item), field);
-    return ok(true);
+    return true;
   }
 
   private handleRange(component: ComponentType) {
@@ -336,8 +319,7 @@ export class Scanner {
     let ch = this.peek(content);
 
     if (!ch) {
-      return err<CronScannerError>(
-        "CronExpressionError",
+      throw new CronExpressionError(
         `Invalid range expression '${content}' for field '${field}'`,
       );
     }
@@ -352,26 +334,24 @@ export class Scanner {
       const tokenContent = content.substring(this.start);
       this.addToken(tokenContent, "range", tokenContent, field);
 
-      return ok(true);
+      return true;
     }
 
     if (this.match(content, "/")) {
-      const [error, _] = this.handleStep(component);
-      if (error) return err<CronScannerError>(error.type, error.message);
+      this.handleStep(component);
 
-      return ok(true);
+      return true;
     }
 
     if (ch && ch !== ",") {
-      return err<CronScannerError>(
-        "CronExpressionError",
+      throw new CronExpressionError(
         `Invalid range expression '${content}' for field '${field}'`,
       );
     }
 
     const tokenContent = content.substring(this.start, this.current);
     this.addToken(tokenContent, "range", tokenContent, field);
-    return ok(true);
+    return true;
   }
 
   private isDigit(ch: string) {

--- a/src/lib/cron/core/types.ts
+++ b/src/lib/cron/core/types.ts
@@ -8,13 +8,6 @@ export type CronAlias =
 
 export type CronStatus = "idle" | "running" | "paused";
 
-export type CronScannerError =
-  | "EmptyCronExpressionError"
-  | "CronLengthError"
-  | "CronExpressionError";
-
-export type CronParsingError = "InvalidValueError" | "OutOfBoundError";
-
 export type CronOptions = {
   name: string;
   schedule: CronAlias | (string & {});

--- a/src/lib/cron/errors.ts
+++ b/src/lib/cron/errors.ts
@@ -1,0 +1,34 @@
+export class InvalidValueError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "InvalidValueError";
+  }
+}
+
+export class OutOfBoundError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "OutOfBoundError";
+  }
+}
+
+export class CronExpressionError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "CronExpressionError";
+  }
+}
+
+export class EmptyCronExpressionError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "EmptyCronExpressionError";
+  }
+}
+
+export class CronLengthError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "CronLengthError";
+  }
+}

--- a/src/lib/prompts/core/runtime.test.ts
+++ b/src/lib/prompts/core/runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { EventEmitter } from "node:events";
-import { err } from "../../errors/index.js";
+import { PromptEnvironmentError } from "../errors.js";
 import { createNodePromptRuntime, NodePromptRuntime } from "./runtime.js";
 
 class MockStdin extends EventEmitter {
@@ -56,21 +56,17 @@ describe("NodePromptRuntime", () => {
     expect(runtime.isInteractive()).toBe(false);
   });
 
-  test("init should return environment error when not interactive", () => {
+  test("init should throw environment error when not interactive", () => {
     const stdin = new MockStdin();
     const stdout = new MockStdout();
     stdout.isTTY = false;
 
     const runtime = new NodePromptRuntime(stdin, stdout);
+    const fn = () => runtime.init();
 
-    const [error, value] = runtime.init();
-
-    expect(value).toBeNull();
-    expect(error).toEqual(
-      err(
-        "PromptEnvironmentError",
-        "Interactive prompts require a TTY with raw mode support",
-      )[0],
+    expect(fn).toThrow(PromptEnvironmentError);
+    expect(fn).toThrow(
+      "Interactive prompts require a TTY with raw mode support",
     );
   });
 
@@ -80,9 +76,7 @@ describe("NodePromptRuntime", () => {
 
     const runtime = new NodePromptRuntime(stdin, stdout);
 
-    const [initError] = runtime.init();
-
-    expect(initError).toBeNull();
+    runtime.init();
 
     expect(stdin.rawModes).toEqual([true]);
     expect(stdin.encoding).toBe("utf8");
@@ -90,9 +84,7 @@ describe("NodePromptRuntime", () => {
     expect(stdin.listenerCount("data")).toBe(1);
     expect(stdout.writes[0]).toBe("\u001B[?25l");
 
-    const [closeError] = runtime.close();
-
-    expect(closeError).toBeNull();
+    runtime.close();
 
     expect(stdin.rawModes).toEqual([true, false]);
     expect(stdin.listenerCount("data")).toBe(0);
@@ -123,11 +115,9 @@ describe("NodePromptRuntime", () => {
 
     stdin.emit("data", "ab");
 
-    const [keyAError, keyA] = await runtime.readKey();
-    const [keyBError, keyB] = await runtime.readKey();
+    const keyA = await runtime.readKey();
+    const keyB = await runtime.readKey();
 
-    expect(keyAError).toBeNull();
-    expect(keyBError).toBeNull();
     expect(keyA).toEqual({ name: "character", value: "a" });
     expect(keyB).toEqual({ name: "character", value: "b" });
   });
@@ -143,9 +133,8 @@ describe("NodePromptRuntime", () => {
     const pending = runtime.readKey();
     stdin.emit("data", "\u001B[A");
 
-    const [readError, key] = await pending;
+    const key = await pending;
 
-    expect(readError).toBeNull();
     expect(key).toEqual({ name: "up" });
   });
 

--- a/src/lib/prompts/core/runtime.ts
+++ b/src/lib/prompts/core/runtime.ts
@@ -1,6 +1,7 @@
-import { err, mightThrowSync, ok } from "../../errors/index.js";
+import { mightThrowSync } from "../../errors/index.js";
+import { PromptEnvironmentError, PromptIOError } from "../errors.js";
 import { parseKeys } from "./keys.js";
-import type { Key, PromptResultLike, PromptRuntime } from "./types.js";
+import type { Key, PromptRuntime, Waiter } from "./types.js";
 
 const HIDE_CURSOR = "\u001B[?25l";
 const SHOW_CURSOR = "\u001B[?25h";
@@ -36,7 +37,7 @@ export class NodePromptRuntime implements PromptRuntime {
   private readonly stdin: StdinLike;
   private readonly stdout: StdoutLike;
   private readonly queue: Key[] = [];
-  private readonly waiters: Array<(result: PromptResultLike<Key>) => void> = [];
+  private readonly waiters: Waiter[] = [];
   private initialized = false;
   private previousLines = 0;
   private buffer = "";
@@ -59,14 +60,13 @@ export class NodePromptRuntime implements PromptRuntime {
 
   public init() {
     if (!this.isInteractive()) {
-      return err(
-        "PromptEnvironmentError",
+      throw new PromptEnvironmentError(
         "Interactive prompts require a TTY with raw mode support",
       );
     }
 
     if (this.initialized) {
-      return ok(undefined);
+      return;
     }
 
     const [initError] = mightThrowSync(() => {
@@ -78,22 +78,22 @@ export class NodePromptRuntime implements PromptRuntime {
     });
 
     if (initError) {
-      return err("PromptIOError", "Unable to initialize prompt runtime");
+      throw new PromptIOError("Unable to initialize prompt runtime");
     }
 
     this.initialized = true;
-    return ok(undefined);
+    return;
   }
 
-  public readKey(): Promise<PromptResultLike<Key>> {
+  public readKey(): Promise<Key> {
     const queued = this.queue.shift();
 
     if (queued) {
-      return Promise.resolve(ok(queued));
+      return Promise.resolve(queued);
     }
 
-    return new Promise<PromptResultLike<Key>>((resolve) => {
-      this.waiters.push(resolve);
+    return new Promise<Key>((resolve, reject) => {
+      this.waiters.push({ resolve, reject });
     });
   }
 
@@ -110,10 +110,10 @@ export class NodePromptRuntime implements PromptRuntime {
     });
 
     if (renderError) {
-      return err("PromptIOError", "Unable to render prompt frame");
+      throw new PromptIOError("Unable to render prompt frame");
     }
 
-    return ok(undefined);
+    return;
   }
 
   public done(frame: string) {
@@ -128,15 +128,15 @@ export class NodePromptRuntime implements PromptRuntime {
     });
 
     if (doneError) {
-      return err("PromptIOError", "Unable to finalize prompt frame");
+      throw new PromptIOError("Unable to finalize prompt frame");
     }
 
-    return ok(undefined);
+    return;
   }
 
   public close() {
     if (!this.initialized) {
-      return ok(undefined);
+      return;
     }
 
     this.initialized = false;
@@ -149,10 +149,10 @@ export class NodePromptRuntime implements PromptRuntime {
     });
 
     if (closeError) {
-      return err("PromptIOError", "Unable to close prompt runtime");
+      throw new PromptIOError("Unable to close prompt runtime");
     }
 
-    return ok(undefined);
+    return;
   }
 
   public interrupt(): never {
@@ -169,7 +169,7 @@ export class NodePromptRuntime implements PromptRuntime {
 
     if (parseError || !result) {
       for (const waiter of this.waiters.splice(0)) {
-        waiter(err("PromptIOError", "Failed to parse input"));
+        waiter.reject(new PromptIOError("Failed to parse input"));
       }
 
       return;
@@ -181,7 +181,7 @@ export class NodePromptRuntime implements PromptRuntime {
       const waiter = this.waiters.shift();
 
       if (waiter) {
-        waiter(ok(key));
+        waiter.resolve(key);
       } else {
         this.queue.push(key);
       }

--- a/src/lib/prompts/core/session.test.ts
+++ b/src/lib/prompts/core/session.test.ts
@@ -217,6 +217,8 @@ describe("runPromptSession", () => {
       name: "PromptIOError",
       message: "Prompt validate callback failed unexpectedly",
     });
+
+    expect(runtime.closed).toBe(true);
   });
 
   test("should apply transform callback", async () => {

--- a/src/lib/prompts/core/session.test.ts
+++ b/src/lib/prompts/core/session.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from "bun:test";
-import { err, ok } from "../../errors/index.js";
 import type { BasePromptOptions } from "../types.js";
 import { runPromptSession } from "./session.js";
 import type { Key, PromptRuntime } from "./types.js";
@@ -23,56 +22,34 @@ class MockSessionRuntime implements PromptRuntime {
     return true;
   }
 
-  public init() {
-    return ok(undefined);
-  }
+  public init() {}
 
-  public readKey() {
+  public readKey(): Promise<Key> {
     const key = this.keys.shift();
 
     if (!key) {
-      return Promise.resolve(
-        err("PromptIOError", "No more mock keys available"),
-      );
+      throw new Error("No more mock keys available");
     }
 
-    return Promise.resolve(ok(key));
+    return Promise.resolve(key);
   }
 
   public render(frame: string) {
     this.frames.push(frame);
-    return ok(undefined);
   }
 
   public done(frame: string) {
     this.doneFrames.push(frame);
-    return ok(undefined);
   }
 
   public close() {
     this.closed = true;
-    return ok(undefined);
   }
 
   public interrupt(message: string) {
     this.interruptMessage = message;
-    return ok(undefined);
   }
 }
-
-const expectOk = <T>(
-  result: ReturnType<typeof err<string>> | ReturnType<typeof ok<T>>,
-) => {
-  const [resultError, data] = result;
-
-  expect(resultError).toBeNull();
-
-  if (data === null) {
-    throw new Error("Expected prompt session to succeed");
-  }
-
-  return data;
-};
 
 const createSessionOptions = (
   options: BasePromptOptions<string>,
@@ -127,10 +104,9 @@ describe("runPromptSession", () => {
       { name: "enter" },
     ]);
 
-    const result = await runPromptSession(
+    const value = await runPromptSession(
       createSessionOptions({ message: "Name" }, runtime),
     );
-    const value = expectOk(result);
 
     expect(value).toBe("ok");
     expect(runtime.closed).toBe(true);
@@ -144,10 +120,9 @@ describe("runPromptSession", () => {
       { name: "enter" },
     ]);
 
-    const result = await runPromptSession(
+    const value = await runPromptSession(
       createSessionOptions({ message: "Name" }, runtime),
     );
-    const value = expectOk(result);
 
     expect(value).toBe("a");
     const hasSubmitError = runtime.frames.some((frame) =>
@@ -159,13 +134,12 @@ describe("runPromptSession", () => {
   test("should cancel on escape and call interrupt", async () => {
     const runtime = new MockSessionRuntime([{ name: "escape" }]);
 
-    const [resultError, value] = await runPromptSession(
+    const promise = runPromptSession(
       createSessionOptions({ message: "Name" }, runtime),
     );
 
-    expect(value).toBeNull();
-    expect(resultError).toMatchObject({
-      type: "PromptCancelledError",
+    await expect(promise).rejects.toMatchObject({
+      name: "PromptCancelledError",
       message: "Interrupted, bye!",
     });
 
@@ -177,13 +151,12 @@ describe("runPromptSession", () => {
   test("should cancel on ctrl+c", async () => {
     const runtime = new MockSessionRuntime([{ name: "ctrl_c" }]);
 
-    const [resultError, value] = await runPromptSession(
+    const promise = runPromptSession(
       createSessionOptions({ message: "Name" }, runtime),
     );
 
-    expect(value).toBeNull();
-    expect(resultError).toMatchObject({
-      type: "PromptCancelledError",
+    await expect(promise).rejects.toMatchObject({
+      name: "PromptCancelledError",
     });
 
     expect(runtime.closed).toBe(true);
@@ -199,7 +172,7 @@ describe("runPromptSession", () => {
       { name: "enter" },
     ]);
 
-    const result = await runPromptSession(
+    const value = await runPromptSession(
       createSessionOptions(
         {
           message: "Name",
@@ -214,7 +187,6 @@ describe("runPromptSession", () => {
         runtime,
       ),
     );
-    const value = expectOk(result);
 
     expect(value).toBe("ok");
     const hasValidationError = runtime.frames.some((frame) =>
@@ -229,7 +201,7 @@ describe("runPromptSession", () => {
       { name: "enter" },
     ]);
 
-    const [resultError, value] = await runPromptSession(
+    const promise = runPromptSession(
       createSessionOptions(
         {
           message: "Name",
@@ -241,14 +213,10 @@ describe("runPromptSession", () => {
       ),
     );
 
-    expect(value).toBeNull();
-    expect(resultError).toMatchObject({
-      type: "PromptIOError",
+    await expect(promise).rejects.toMatchObject({
+      name: "PromptIOError",
       message: "Prompt validate callback failed unexpectedly",
     });
-
-    expect(runtime.closed).toBe(true);
-    expect(runtime.doneFrames.at(-1)).toBe("✖ Name");
   });
 
   test("should apply transform callback", async () => {
@@ -258,7 +226,7 @@ describe("runPromptSession", () => {
       { name: "enter" },
     ]);
 
-    const result = await runPromptSession(
+    const value = await runPromptSession(
       createSessionOptions(
         {
           message: "Name",
@@ -267,7 +235,6 @@ describe("runPromptSession", () => {
         runtime,
       ),
     );
-    const value = expectOk(result);
 
     expect(value).toBe("AB");
     expect(runtime.doneFrames.at(-1)).toBe("✔ AB");
@@ -279,7 +246,7 @@ describe("runPromptSession", () => {
       { name: "enter" },
     ]);
 
-    const [resultError, value] = await runPromptSession(
+    const promise = runPromptSession(
       createSessionOptions(
         {
           message: "Name",
@@ -291,13 +258,9 @@ describe("runPromptSession", () => {
       ),
     );
 
-    expect(value).toBeNull();
-    expect(resultError).toMatchObject({
-      type: "PromptIOError",
+    await expect(promise).rejects.toMatchObject({
+      name: "PromptIOError",
       message: "Prompt transform callback failed unexpectedly",
     });
-
-    expect(runtime.closed).toBe(true);
-    expect(runtime.doneFrames.at(-1)).toBe("✖ Name");
   });
 });

--- a/src/lib/prompts/core/session.ts
+++ b/src/lib/prompts/core/session.ts
@@ -1,4 +1,5 @@
-import { err, mightThrow, ok } from "../../errors/index.js";
+import { mightThrow } from "../../errors/index.js";
+import { PromptCancelledError, PromptIOError } from "../errors.js";
 import type { BasePromptOptions } from "../types.js";
 import type { Key, PromptRuntime } from "./types.js";
 
@@ -39,7 +40,7 @@ const resolveOutput = async <TValue>(
   value: TValue,
 ) => {
   if (!options.transform) {
-    return ok(value);
+    return value;
   }
 
   const [transformError, transformed] = await mightThrow(
@@ -47,13 +48,10 @@ const resolveOutput = async <TValue>(
   );
 
   if (transformError || transformed === null || transformed === undefined) {
-    return err(
-      "PromptIOError",
-      "Prompt transform callback failed unexpectedly",
-    );
+    throw new PromptIOError("Prompt transform callback failed unexpectedly");
   }
 
-  return ok(transformed);
+  return transformed;
 };
 
 const runValidation = async <TValue>(
@@ -61,7 +59,7 @@ const runValidation = async <TValue>(
   value: TValue,
 ) => {
   if (!options.validate) {
-    return ok(null);
+    return null;
   }
 
   const [validationError, validationMessage] = await mightThrow(
@@ -69,14 +67,14 @@ const runValidation = async <TValue>(
   );
 
   if (validationError) {
-    return err("PromptIOError", "Prompt validate callback failed unexpectedly");
+    throw new PromptIOError("Prompt validate callback failed unexpectedly");
   }
 
   if (typeof validationMessage === "string" && validationMessage.length > 0) {
-    return ok(validationMessage);
+    return validationMessage;
   }
 
-  return ok(null);
+  return null;
 };
 
 const isCancelKey = (key: Key) => {
@@ -93,33 +91,18 @@ export const runPromptSession = async <
 >(
   params: SessionOptions<TState, TValue, TOptions>,
 ) => {
-  const [initError] = params.runtime.init();
-
-  if (initError) {
-    return err(initError.type, initError.message);
-  }
+  params.runtime.init();
 
   let state = params.initialState;
   let errorMessage: string | null = null;
 
   const closeAndDone = (message: string) => {
-    const [closeErr] = params.runtime.close();
-
-    if (closeErr) {
-      return err(closeErr.type, closeErr.message);
-    }
-
-    const [doneErr] = params.runtime.done(message);
-
-    if (doneErr) {
-      return err(doneErr.type, doneErr.message);
-    }
-
-    return null;
+    params.runtime.close();
+    params.runtime.done(message);
   };
 
   while (true) {
-    const [renderError] = params.runtime.render(
+    params.runtime.render(
       params.render({
         options: params.options,
         state,
@@ -127,43 +110,22 @@ export const runPromptSession = async <
       }),
     );
 
-    if (renderError) {
-      params.runtime.close();
-      return err(renderError.type, renderError.message);
-    }
+    const key = await params.runtime.readKey();
 
-    const [readError, key] = await params.runtime.readKey();
-
-    if (readError || !key) {
+    if (!key) {
       params.runtime.close();
-      return err(
-        readError?.type ?? "PromptIOError",
-        readError?.message ?? "Unable to read prompt input",
-      );
+      throw new PromptIOError("Unable to read prompt input");
     }
 
     if (isCancelKey(key)) {
-      const [closeError] = params.runtime.close();
-
-      if (closeError) {
-        return err(closeError.type, closeError.message);
-      }
-
-      const [doneError] = params.runtime.done(`✖ ${CANCEL_MESSAGE}`);
-
-      if (doneError) {
-        return err(doneError.type, doneError.message);
-      }
+      params.runtime.close();
+      params.runtime.done(`✖ ${CANCEL_MESSAGE}`);
 
       if (params.runtime.interrupt) {
-        const [interruptError] = params.runtime.interrupt(CANCEL_MESSAGE);
-
-        if (interruptError) {
-          return err(interruptError.type, interruptError.message);
-        }
+        params.runtime.interrupt(CANCEL_MESSAGE);
       }
 
-      return err("PromptCancelledError", CANCEL_MESSAGE);
+      throw new PromptCancelledError(CANCEL_MESSAGE);
     }
 
     if (key.name !== "enter") {
@@ -181,46 +143,23 @@ export const runPromptSession = async <
 
     const rawValue = submitResult.value;
 
-    const [validationRunError, validationErrorMessage] = await runValidation(
+    const validationErrorMessage = await runValidation(
       params.options,
       rawValue,
     );
-
-    if (validationRunError) {
-      const closeDoneErr = closeAndDone(`✖ ${params.options.message}`);
-
-      if (closeDoneErr) {
-        return closeDoneErr;
-      }
-
-      return err(validationRunError.type, validationRunError.message);
-    }
 
     if (validationErrorMessage) {
       errorMessage = validationErrorMessage;
       continue;
     }
 
-    const [transformError, finalValue] = await resolveOutput(
-      params.options,
-      rawValue,
-    );
-
-    if (transformError) {
-      const closeDoneErr = closeAndDone(`✖ ${params.options.message}`);
-
-      if (closeDoneErr) {
-        return closeDoneErr;
-      }
-
-      return err(transformError.type, transformError.message);
-    }
+    const finalValue = await resolveOutput(params.options, rawValue);
 
     if (finalValue === null) {
-      return err("PromptIOError", "Unable to transform prompt value");
+      throw new PromptIOError("Unable to transform prompt value");
     }
 
-    const closeDoneErr = closeAndDone(
+    closeAndDone(
       params.complete({
         options: params.options,
         state,
@@ -228,10 +167,6 @@ export const runPromptSession = async <
       }),
     );
 
-    if (closeDoneErr) {
-      return closeDoneErr;
-    }
-
-    return ok(finalValue);
+    return finalValue;
   }
 };

--- a/src/lib/prompts/core/session.ts
+++ b/src/lib/prompts/core/session.ts
@@ -101,72 +101,82 @@ export const runPromptSession = async <
     params.runtime.done(message);
   };
 
-  while (true) {
-    params.runtime.render(
-      params.render({
-        options: params.options,
-        state,
-        errorMessage,
-      }),
-    );
+  const [sessionError, finalValue] = await mightThrow(
+    (async () => {
+      while (true) {
+        params.runtime.render(
+          params.render({
+            options: params.options,
+            state,
+            errorMessage,
+          }),
+        );
 
-    const key = await params.runtime.readKey();
+        const key = await params.runtime.readKey();
 
-    if (!key) {
-      params.runtime.close();
-      throw new PromptIOError("Unable to read prompt input");
-    }
+        if (!key) {
+          throw new PromptIOError("Unable to read prompt input");
+        }
 
-    if (isCancelKey(key)) {
-      params.runtime.close();
-      params.runtime.done(`✖ ${CANCEL_MESSAGE}`);
+        if (isCancelKey(key)) {
+          params.runtime.close();
+          params.runtime.done(`✖ ${CANCEL_MESSAGE}`);
 
-      if (params.runtime.interrupt) {
-        params.runtime.interrupt(CANCEL_MESSAGE);
+          if (params.runtime.interrupt) {
+            params.runtime.interrupt(CANCEL_MESSAGE);
+          }
+
+          throw new PromptCancelledError(CANCEL_MESSAGE);
+        }
+
+        if (key.name !== "enter") {
+          state = params.onKey(state, key);
+          errorMessage = null;
+          continue;
+        }
+
+        const submitResult = params.onSubmit(state);
+
+        if ("errorMessage" in submitResult) {
+          errorMessage = submitResult.errorMessage;
+          continue;
+        }
+
+        const rawValue = submitResult.value;
+
+        const validationErrorMessage = await runValidation(
+          params.options,
+          rawValue,
+        );
+
+        if (validationErrorMessage) {
+          errorMessage = validationErrorMessage;
+          continue;
+        }
+
+        const outputValue = await resolveOutput(params.options, rawValue);
+
+        if (outputValue === null) {
+          throw new PromptIOError("Unable to transform prompt value");
+        }
+
+        closeAndDone(
+          params.complete({
+            options: params.options,
+            state,
+            value: outputValue,
+          }),
+        );
+
+        return outputValue;
       }
+    })(),
+  );
 
-      throw new PromptCancelledError(CANCEL_MESSAGE);
-    }
-
-    if (key.name !== "enter") {
-      state = params.onKey(state, key);
-      errorMessage = null;
-      continue;
-    }
-
-    const submitResult = params.onSubmit(state);
-
-    if ("errorMessage" in submitResult) {
-      errorMessage = submitResult.errorMessage;
-      continue;
-    }
-
-    const rawValue = submitResult.value;
-
-    const validationErrorMessage = await runValidation(
-      params.options,
-      rawValue,
-    );
-
-    if (validationErrorMessage) {
-      errorMessage = validationErrorMessage;
-      continue;
-    }
-
-    const finalValue = await resolveOutput(params.options, rawValue);
-
-    if (finalValue === null) {
-      throw new PromptIOError("Unable to transform prompt value");
-    }
-
-    closeAndDone(
-      params.complete({
-        options: params.options,
-        state,
-        value: finalValue,
-      }),
-    );
-
-    return finalValue;
+  if (sessionError) {
+    params.runtime.close();
+    throw sessionError;
   }
+
+  return finalValue;
 };

--- a/src/lib/prompts/core/types.ts
+++ b/src/lib/prompts/core/types.ts
@@ -1,9 +1,3 @@
-import type { err, ok } from "../../errors/index.js";
-
-export type PromptResultLike<T> =
-  | ReturnType<typeof err<string>>
-  | ReturnType<typeof ok<T>>;
-
 export type KeyName =
   | "character"
   | "enter"
@@ -33,12 +27,17 @@ export type Key = {
   value?: string;
 };
 
+export type Waiter = {
+  resolve: (key: Key) => void;
+  reject: (err: unknown) => void;
+};
+
 export type PromptRuntime = {
   isInteractive: () => boolean;
-  init: () => PromptResultLike<void>;
-  readKey: () => Promise<PromptResultLike<Key>>;
-  render: (frame: string) => PromptResultLike<void>;
-  done: (frame: string) => PromptResultLike<void>;
-  close: () => PromptResultLike<void>;
-  interrupt?: (message: string) => PromptResultLike<undefined>;
+  init: () => void;
+  readKey: () => Promise<Key>;
+  render: (frame: string) => void;
+  done: (frame: string) => void;
+  close: () => void;
+  interrupt?: (message: string) => void;
 };

--- a/src/lib/prompts/errors.ts
+++ b/src/lib/prompts/errors.ts
@@ -1,0 +1,20 @@
+export class PromptIOError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "PromptIOError";
+  }
+}
+
+export class PromptEnvironmentError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "PromptEnvironmentError";
+  }
+}
+
+export class PromptCancelledError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "PromptCancelledError";
+  }
+}

--- a/src/lib/prompts/index.test.ts
+++ b/src/lib/prompts/index.test.ts
@@ -1,22 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { err, ok } from "../errors/index.js";
 import type { Key, PromptRuntime } from "./core/types.js";
+import { PromptEnvironmentError } from "./errors.js";
 import {
-  confirm as confirmPrompt,
-  input as inputPrompt,
-  multiselect as multiselectPrompt,
-  number as numberPrompt,
-  password as passwordPrompt,
-  select as selectPrompt,
+  confirm,
+  input,
+  multiselect,
+  number,
+  password,
+  select,
 } from "./index.js";
-import type {
-  ConfirmOptions,
-  InputOptions,
-  MultiselectOptions,
-  NumberOptions,
-  PasswordOptions,
-  SelectOptions,
-} from "./types.js";
 
 const stripAnsi = (value: string) => {
   return Bun.stripANSI(value);
@@ -40,84 +32,34 @@ class MockPromptRuntime implements PromptRuntime {
 
   public init() {
     if (!this.interactive) {
-      return err(
-        "PromptEnvironmentError",
+      throw new PromptEnvironmentError(
         "Interactive prompts require a TTY with raw mode support",
       );
     }
-
-    return ok(undefined);
   }
 
-  public readKey() {
+  public readKey(): Promise<Key> {
     const key = this.keys.shift();
 
     if (!key) {
-      return Promise.resolve(
-        err("PromptIOError", "No more mock keys available"),
-      );
+      throw new Error("No more mock keys available");
     }
 
-    return Promise.resolve(ok(key));
+    return Promise.resolve(key);
   }
 
   public render(frame: string) {
     this.frames.push(frame);
-    return ok(undefined);
   }
 
   public done(frame: string) {
     this.doneFrames.push(frame);
-    return ok(undefined);
   }
 
   public close() {
     this.closed = true;
-    return ok(undefined);
   }
 }
-
-const unwrap = <T>(
-  result: ReturnType<typeof err<string>> | ReturnType<typeof ok<T>>,
-) => {
-  const [resultError, data] = result;
-
-  if (resultError || data === null) {
-    throw new Error(resultError?.message ?? "Expected prompt success result");
-  }
-
-  return data;
-};
-
-const input = async (options: InputOptions, runtime?: PromptRuntime) => {
-  return unwrap(await inputPrompt(options, runtime));
-};
-
-const password = async (options: PasswordOptions, runtime?: PromptRuntime) => {
-  return unwrap(await passwordPrompt(options, runtime));
-};
-
-const confirm = async (options: ConfirmOptions, runtime?: PromptRuntime) => {
-  return unwrap(await confirmPrompt(options, runtime));
-};
-
-const number = async (options: NumberOptions, runtime?: PromptRuntime) => {
-  return unwrap(await numberPrompt(options, runtime));
-};
-
-const select = async <TValue extends string>(
-  options: SelectOptions<TValue>,
-  runtime?: PromptRuntime,
-) => {
-  return unwrap(await selectPrompt(options, runtime));
-};
-
-const multiselect = async <TValue extends string>(
-  options: MultiselectOptions<TValue>,
-  runtime?: PromptRuntime,
-) => {
-  return unwrap(await multiselectPrompt(options, runtime));
-};
 
 describe("prompts", () => {
   test("input should collect characters and submit", async () => {
@@ -254,32 +196,24 @@ describe("prompts", () => {
     expect(value).toEqual(["bun", "ts"]);
   });
 
-  test("should return cancelled error on escape", async () => {
+  test("should throw cancelled error on escape", async () => {
     const runtime = new MockPromptRuntime([{ name: "escape" }]);
 
-    const [resultError, value] = await inputPrompt(
-      { message: "Name" },
-      runtime,
-    );
+    const promise = input({ message: "Name" }, runtime);
 
-    expect(value).toBeNull();
-    expect(resultError).toMatchObject({
-      type: "PromptCancelledError",
+    await expect(promise).rejects.toMatchObject({
+      name: "PromptCancelledError",
       message: "Interrupted, bye!",
     });
   });
 
-  test("should return environment error when runtime is not interactive", async () => {
+  test("should throw environment error when runtime is not interactive", async () => {
     const runtime = new MockPromptRuntime([], false);
 
-    const [resultError, value] = await inputPrompt(
-      { message: "Name" },
-      runtime,
-    );
+    const promise = input({ message: "Name" }, runtime);
 
-    expect(value).toBeNull();
-    expect(resultError).toMatchObject({
-      type: "PromptEnvironmentError",
+    await expect(promise).rejects.toMatchObject({
+      name: "PromptEnvironmentError",
       message: "Interactive prompts require a TTY with raw mode support",
     });
   });

--- a/src/lib/pubsub/errors.ts
+++ b/src/lib/pubsub/errors.ts
@@ -1,0 +1,27 @@
+export class UnsubscribeError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "UnsubscribeError";
+  }
+}
+
+export class SerializationError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "SerializationError";
+  }
+}
+
+export class PublishError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "PublishError";
+  }
+}
+
+export class SubscribeError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "SubscribeError";
+  }
+}

--- a/src/lib/pubsub/index.test.ts
+++ b/src/lib/pubsub/index.test.ts
@@ -138,22 +138,18 @@ describe("PubSub", () => {
 
       const messages: Array<{ userId: string; action: string }> = [];
 
-      const [subscribeError, unsubscribeHandler] = await pubsub.subscribe(
-        async (message) => {
-          messages.push(message);
-        },
-      );
+      const unsubscribeHandler = await pubsub.subscribe(async (message) => {
+        messages.push(message);
+      });
 
-      expect(subscribeError).toBeNull();
       expect(typeof unsubscribeHandler).toBe("function");
       expect(pubsub.isActive()).toBe(true);
 
-      const [publishError, count] = await pubsub.publish({
+      const count = await pubsub.publish({
         userId: "123",
         action: "login",
       });
 
-      expect(publishError).toBeNull();
       expect(count).toBe(1);
 
       // Wait for async message handling
@@ -196,9 +192,8 @@ describe("PubSub", () => {
 
       expect(pubsub.isActive()).toBe(true);
 
-      const [error] = await pubsub.unsubscribe();
+      await pubsub.unsubscribe();
 
-      expect(error).toBeNull();
       expect(pubsub.isActive()).toBe(false);
       expect(redis.getSubscriptions().size).toBe(0);
     });
@@ -214,22 +209,18 @@ describe("PubSub", () => {
       const handler1Messages: string[] = [];
       const handler2Messages: string[] = [];
 
-      const [error1] = await pubsub.subscribe(async (message) => {
+      await pubsub.subscribe(async (message) => {
         handler1Messages.push(message.message);
       });
 
-      const [error2] = await pubsub.subscribe(async (message) => {
+      await pubsub.subscribe(async (message) => {
         handler2Messages.push(message.message);
       });
 
-      expect(error1).toBeNull();
-      expect(error2).toBeNull();
-
-      const [publishError, publishCount] = await pubsub.publish({
+      const publishCount = await pubsub.publish({
         message: "hello",
       });
 
-      expect(publishError).toBeNull();
       expect(publishCount).toBe(1);
 
       await new Promise((resolve) => setTimeout(resolve, 10));
@@ -247,15 +238,12 @@ describe("PubSub", () => {
         channel: "test",
       });
 
-      const [error, unsubscribeHandler] = await pubsub.subscribe(
-        async () => {},
-      );
+      const unsubscribeHandler = await pubsub.subscribe(async () => {});
 
-      expect(error).toBeNull();
       expect(typeof unsubscribeHandler).toBe("function");
     });
 
-    test("should return null unsubscribe function on subscribe error", async () => {
+    test("should throw on subscribe error", async () => {
       const redis = createMockRedis();
       const pubsub = new PubSub<{ message: string }>({
         subscriber: redis,
@@ -265,15 +253,12 @@ describe("PubSub", () => {
 
       redis.setShouldFail(true);
 
-      const [error, unsubscribeHandler] = await pubsub.subscribe(
-        async () => {},
-      );
+      const promise = pubsub.subscribe(async () => {});
 
-      expect(error).toEqual({
-        type: "SubscribeError",
+      await expect(promise).rejects.toMatchObject({
+        name: "SubscribeError",
         message: "Unable to subscribe to test",
       });
-      expect(unsubscribeHandler).toBeNull();
     });
 
     test("should increment subscriber count with multiple PubSub instances", async () => {
@@ -297,20 +282,16 @@ describe("PubSub", () => {
         channel: "shared-channel",
       });
 
-      const [error1] = await pubsub1.subscribe(async () => {});
-      const [error2] = await pubsub2.subscribe(async () => {});
-      const [error3] = await pubsub3.subscribe(async () => {});
-
-      expect(error1).toBeNull();
-      expect(error2).toBeNull();
-      expect(error3).toBeNull();
+      await pubsub1.subscribe(async () => {});
+      await pubsub2.subscribe(async () => {});
+      await pubsub3.subscribe(async () => {});
 
       const subscribers = redis.getSubscriptions().get("shared-channel") ?? [];
 
       expect(subscribers).toHaveLength(3);
     });
 
-    test("should return error when unsubscribing without subscription", async () => {
+    test("should throw when unsubscribing without subscription", async () => {
       const redis = createMockRedis();
       const pubsub = new PubSub<{ message: string }>({
         subscriber: redis,
@@ -318,10 +299,10 @@ describe("PubSub", () => {
         channel: "test",
       });
 
-      const [error] = await pubsub.unsubscribe();
+      const promise = pubsub.unsubscribe();
 
-      expect(error).toEqual({
-        type: "UnsubscribeError",
+      await expect(promise).rejects.toMatchObject({
+        name: "UnsubscribeError",
         message: "Not subscribed",
       });
     });
@@ -525,14 +506,12 @@ describe("PubSub", () => {
 
       circular.self = circular;
 
-      const [error, data] = await pubsub.publish(circular);
+      const promise = pubsub.publish(circular);
 
-      expect(error).toEqual({
-        type: "SerializationError",
+      await expect(promise).rejects.toMatchObject({
+        name: "SerializationError",
         message: "Unable to serialize message",
       });
-
-      expect(data).toBeNull();
     });
 
     test("should handle publish errors", async () => {
@@ -545,14 +524,12 @@ describe("PubSub", () => {
 
       redis.setShouldFail(true);
 
-      const [error, data] = await pubsub.publish({ message: "message" });
+      const promise = pubsub.publish({ message: "message" });
 
-      expect(error).toEqual({
-        type: "PublishError",
+      await expect(promise).rejects.toMatchObject({
+        name: "PublishError",
         message: "Unable to publish to test",
       });
-
-      expect(data).toBeNull();
     });
 
     test("should handle subscribe errors", async () => {
@@ -565,16 +542,13 @@ describe("PubSub", () => {
 
       redis.setShouldFail(true);
 
-      const [error, unsubscribeHandler] = await pubsub.subscribe(
-        async () => {},
-      );
+      const promise = pubsub.subscribe(async () => {});
 
-      expect(error).toEqual({
-        type: "SubscribeError",
+      await expect(promise).rejects.toMatchObject({
+        name: "SubscribeError",
         message: "Unable to subscribe to test",
       });
 
-      expect(unsubscribeHandler).toBeNull();
       expect(pubsub.isActive()).toBe(false);
     });
 
@@ -590,14 +564,12 @@ describe("PubSub", () => {
 
       redis.setShouldFail(true);
 
-      const [error, data] = await pubsub.unsubscribe();
+      const promise = pubsub.unsubscribe();
 
-      expect(error).toEqual({
-        type: "UnsubscribeError",
+      await expect(promise).rejects.toMatchObject({
+        name: "UnsubscribeError",
         message: "Unable to unsubscribe from test",
       });
-
-      expect(data).toBeNull();
     });
 
     test("should handle invalid JSON gracefully", async () => {
@@ -673,11 +645,10 @@ describe("PubSub", () => {
         throw new Error("Synchronous handler error");
       });
 
-      const [publishError, count] = await pubsub.publish({ message: "test" });
+      const count = await pubsub.publish({ message: "test" });
 
       await new Promise((resolve) => setTimeout(resolve, 10));
 
-      expect(publishError).toBeNull();
       expect(count).toBe(1);
 
       // Handler was called and threw error
@@ -816,19 +787,13 @@ describe("PubSub", () => {
       const handler1Messages: string[] = [];
       const handler2Messages: string[] = [];
 
-      const [, unsubscribeHandler1] = await pubsub.subscribe(
-        async (message) => {
-          handler1Messages.push(message.message);
-        },
-      );
+      const unsubscribeHandler1 = await pubsub.subscribe(async (message) => {
+        handler1Messages.push(message.message);
+      });
 
       await pubsub.subscribe(async (message) => {
         handler2Messages.push(message.message);
       });
-
-      if (!unsubscribeHandler1) {
-        throw new Error("Expected unsubscribe handler");
-      }
 
       await unsubscribeHandler1();
 
@@ -848,16 +813,8 @@ describe("PubSub", () => {
         channel: "test",
       });
 
-      const [, unsubscribeHandler1] = await pubsub.subscribe(async () => {});
-      const [, unsubscribeHandler2] = await pubsub.subscribe(async () => {});
-
-      if (!unsubscribeHandler1) {
-        throw new Error("Expected unsubscribe handlers");
-      }
-
-      if (!unsubscribeHandler2) {
-        throw new Error("Expected unsubscribe handlers");
-      }
+      const unsubscribeHandler1 = await pubsub.subscribe(async () => {});
+      const unsubscribeHandler2 = await pubsub.subscribe(async () => {});
 
       expect(redis.getSubscribeCallCount("test")).toBe(1);
       expect(redis.getUnsubscribeCallCount("test")).toBe(0);
@@ -885,18 +842,19 @@ describe("PubSub", () => {
 
       expect(pubsub.isActive()).toBe(true);
 
-      // Attempt two concurrent unsubscribe calls using Promise.all
-      const results = await Promise.all([
+      // Attempt two concurrent unsubscribe calls
+      const results = await Promise.allSettled([
         pubsub.unsubscribe(),
         pubsub.unsubscribe(),
       ]);
 
-      const [error1] = results[0];
-      const [error2] = results[1];
-
-      // Only one should succeed (null error), the other should fail
-      const successCount = [error1, error2].filter((e) => e === null).length;
-      const failureCount = [error1, error2].filter((e) => e !== null).length;
+      // Only one should succeed, the other should throw
+      const successCount = results.filter(
+        (r) => r.status === "fulfilled",
+      ).length;
+      const failureCount = results.filter(
+        (r) => r.status === "rejected",
+      ).length;
 
       expect(successCount).toBe(1);
       expect(failureCount).toBe(1);
@@ -919,18 +877,15 @@ describe("PubSub", () => {
 
       expect(pubsub.isActive()).toBe(false);
 
-      const [unsubscribeError] = await pubsub.unsubscribe();
-
-      expect(unsubscribeError).toEqual({
-        type: "UnsubscribeError",
+      await expect(pubsub.unsubscribe()).rejects.toMatchObject({
+        name: "UnsubscribeError",
         message: "Not subscribed",
       });
 
       redis.unblockNextSubscribe();
 
-      const [subscribeError, unsubscribeHandler] = await subscribePromise;
+      const unsubscribeHandler = await subscribePromise;
 
-      expect(subscribeError).toBeNull();
       expect(typeof unsubscribeHandler).toBe("function");
       expect(pubsub.isActive()).toBe(true);
     });
@@ -945,11 +900,7 @@ describe("PubSub", () => {
 
       const received: string[] = [];
 
-      const [, unsubscribeHandler] = await pubsub.subscribe(async () => {});
-
-      if (!unsubscribeHandler) {
-        throw new Error("Expected unsubscribe handler");
-      }
+      const unsubscribeHandler = await pubsub.subscribe(async () => {});
 
       redis.blockNextUnsubscribe();
 
@@ -970,19 +921,14 @@ describe("PubSub", () => {
 
       redis.unblockNextUnsubscribe();
 
-      const [unsubscribeError] = await unsubscribePromise;
+      await unsubscribePromise;
 
-      expect(unsubscribeError).toBeNull();
+      await subscribePromise;
 
-      const [subscribeError] = await subscribePromise;
-
-      expect(subscribeError).toBeNull();
-
-      const [publishError, count] = await pubsub.publish({
+      const count = await pubsub.publish({
         message: "after-race",
       });
 
-      expect(publishError).toBeNull();
       expect(count).toBe(1);
 
       await new Promise((resolve) => setTimeout(resolve, 10));
@@ -1009,23 +955,20 @@ describe("PubSub", () => {
       redis.setShouldFail(true);
       redis.unblockNextSubscribe();
 
-      const [subscribeError, unsubscribeHandler] = await subscribePromise;
-
-      expect(subscribeError).toEqual({
-        type: "SubscribeError",
+      await expect(subscribePromise).rejects.toMatchObject({
+        name: "SubscribeError",
         message: "Unable to subscribe to test",
       });
-      expect(unsubscribeHandler).toBeNull();
+
       expect(pubsub.isActive()).toBe(false);
       expect(redis.getSubscribeCallCount("test")).toBe(0);
 
       redis.setShouldFail(false);
 
-      const [publishError, count] = await pubsub.publish({
+      const count = await pubsub.publish({
         message: "should-not-deliver",
       });
 
-      expect(publishError).toBeNull();
       expect(count).toBe(0);
     });
   });

--- a/src/lib/pubsub/index.ts
+++ b/src/lib/pubsub/index.ts
@@ -1,4 +1,10 @@
-import { err, mightThrow, mightThrowSync, ok } from "../errors/index.js";
+import { mightThrow, mightThrowSync } from "../errors/index.js";
+import {
+  PublishError,
+  SerializationError,
+  SubscribeError,
+  UnsubscribeError,
+} from "./errors.js";
 import type { MessageHandler, PubSubOptions } from "./types.js";
 
 export class PubSub<T extends Record<string, unknown>> {
@@ -40,13 +46,13 @@ export class PubSub<T extends Record<string, unknown>> {
     const handler = this.handlers.get(handlerId);
 
     if (!handler) {
-      return err("UnsubscribeError", "Not subscribed");
+      throw new UnsubscribeError("Not subscribed");
     }
 
     this.handlers.delete(handlerId);
 
     if (this.handlers.size > 0) {
-      return ok(true);
+      return true;
     }
 
     this.isSubscribed = false;
@@ -61,8 +67,7 @@ export class PubSub<T extends Record<string, unknown>> {
       this.handlers.set(handlerId, handler);
       this.isSubscribed = true;
 
-      return err(
-        "UnsubscribeError",
+      throw new UnsubscribeError(
         `Unable to unsubscribe from ${this.options.channel}`,
       );
     }
@@ -74,15 +79,14 @@ export class PubSub<T extends Record<string, unknown>> {
       this.isSubscribed = true;
       this.unsubscribeInFlight = null;
 
-      return err(
-        "UnsubscribeError",
+      throw new UnsubscribeError(
         `Unable to unsubscribe from ${this.options.channel}`,
       );
     }
 
     this.unsubscribeInFlight = null;
 
-    return ok(true);
+    return true;
   }
 
   public async publish(message: T) {
@@ -91,7 +95,7 @@ export class PubSub<T extends Record<string, unknown>> {
     );
 
     if (stringifyError || !stringified) {
-      return err("SerializationError", "Unable to serialize message");
+      throw new SerializationError("Unable to serialize message");
     }
 
     const [publishError, count] = await mightThrow(
@@ -99,13 +103,10 @@ export class PubSub<T extends Record<string, unknown>> {
     );
 
     if (publishError) {
-      return err(
-        "PublishError",
-        `Unable to publish to ${this.options.channel}`,
-      );
+      throw new PublishError(`Unable to publish to ${this.options.channel}`);
     }
 
-    return ok(count);
+    return count;
   }
 
   public async subscribe(handler: MessageHandler<T>) {
@@ -121,7 +122,7 @@ export class PubSub<T extends Record<string, unknown>> {
     this.handlers.set(handlerId, handler);
 
     if (this.isActive()) {
-      return ok(() => this.unsubscribeHandler(handlerId));
+      return () => this.unsubscribeHandler(handlerId);
     }
 
     const inFlightSubscribe = this.subscribeInFlight;
@@ -132,13 +133,12 @@ export class PubSub<T extends Record<string, unknown>> {
       if (inFlightError || !this.isSubscribed) {
         this.handlers.delete(handlerId);
 
-        return err(
-          "SubscribeError",
+        throw new SubscribeError(
           `Unable to subscribe to ${this.options.channel}`,
         );
       }
 
-      return ok(() => this.unsubscribeHandler(handlerId));
+      return () => this.unsubscribeHandler(handlerId);
     }
 
     this.subscribeInFlight = mightThrow(
@@ -153,8 +153,7 @@ export class PubSub<T extends Record<string, unknown>> {
     if (!subscribeInFlight) {
       this.handlers.delete(handlerId);
 
-      return err(
-        "SubscribeError",
+      throw new SubscribeError(
         `Unable to subscribe to ${this.options.channel}`,
       );
     }
@@ -166,8 +165,7 @@ export class PubSub<T extends Record<string, unknown>> {
     if (subscribeError) {
       this.handlers.delete(handlerId);
 
-      return err(
-        "SubscribeError",
+      throw new SubscribeError(
         `Unable to subscribe to ${this.options.channel}`,
       );
     }
@@ -175,15 +173,14 @@ export class PubSub<T extends Record<string, unknown>> {
     if (!count) {
       this.handlers.delete(handlerId);
 
-      return err(
-        "SubscribeError",
+      throw new SubscribeError(
         `Unable to subscribe to ${this.options.channel}`,
       );
     }
 
     this.isSubscribed = true;
 
-    return ok(() => this.unsubscribeHandler(handlerId));
+    return () => this.unsubscribeHandler(handlerId);
   }
 
   public async unsubscribe() {
@@ -194,7 +191,7 @@ export class PubSub<T extends Record<string, unknown>> {
     }
 
     if (!this.isActive()) {
-      return err("UnsubscribeError", "Not subscribed");
+      throw new UnsubscribeError("Not subscribed");
     }
 
     const handlers = new Map(this.handlers);
@@ -213,8 +210,7 @@ export class PubSub<T extends Record<string, unknown>> {
       this.handlers = handlers;
       this.isSubscribed = true;
 
-      return err(
-        "UnsubscribeError",
+      throw new UnsubscribeError(
         `Unable to unsubscribe from ${this.options.channel}`,
       );
     }
@@ -226,15 +222,14 @@ export class PubSub<T extends Record<string, unknown>> {
       this.isSubscribed = true;
       this.unsubscribeInFlight = null;
 
-      return err(
-        "UnsubscribeError",
+      throw new UnsubscribeError(
         `Unable to unsubscribe from ${this.options.channel}`,
       );
     }
 
     this.unsubscribeInFlight = null;
 
-    return ok(true);
+    return true;
   }
 
   public isActive() {

--- a/src/lib/pubsub/index.ts
+++ b/src/lib/pubsub/index.ts
@@ -52,7 +52,7 @@ export class PubSub<T extends Record<string, unknown>> {
     this.handlers.delete(handlerId);
 
     if (this.handlers.size > 0) {
-      return true;
+      return;
     }
 
     this.isSubscribed = false;
@@ -85,8 +85,6 @@ export class PubSub<T extends Record<string, unknown>> {
     }
 
     this.unsubscribeInFlight = null;
-
-    return true;
   }
 
   public async publish(message: T) {
@@ -228,8 +226,6 @@ export class PubSub<T extends Record<string, unknown>> {
     }
 
     this.unsubscribeInFlight = null;
-
-    return true;
   }
 
   public isActive() {

--- a/src/lib/queue/errors.ts
+++ b/src/lib/queue/errors.ts
@@ -1,0 +1,13 @@
+export class SerializationError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "SerializationError";
+  }
+}
+
+export class EnqueueError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "EnqueueError";
+  }
+}

--- a/src/lib/queue/index.test.ts
+++ b/src/lib/queue/index.test.ts
@@ -60,9 +60,8 @@ describe("Queue", () => {
       const handler = () => {};
       const queue = new Queue({ name: "test", redis, retries: 3, handler });
 
-      const [error, jobId] = await queue.enqueue({ message: "hello" });
+      const jobId = await queue.enqueue({ message: "hello" });
 
-      expect(error).toBeNull();
       expect(jobId).toBeDefined();
       expect(typeof jobId).toBe("string");
 
@@ -76,14 +75,12 @@ describe("Queue", () => {
 
       redis.setShouldFail(true);
 
-      const [error, jobId] = await queue.enqueue({ message: "hello" });
+      const promise = queue.enqueue({ message: "hello" });
 
-      expect(error).toEqual({
-        type: "QueueError",
+      await expect(promise).rejects.toMatchObject({
+        name: "EnqueueError",
         message: "Unable to enqueue job",
       });
-
-      expect(jobId).toBeNull();
 
       await queue.stop();
     });
@@ -99,14 +96,12 @@ describe("Queue", () => {
 
       circular.self = circular;
 
-      const [error, jobId] = await queue.enqueue(circular);
+      const promise = queue.enqueue(circular);
 
-      expect(error).toEqual({
-        type: "QueueError",
+      await expect(promise).rejects.toMatchObject({
+        name: "SerializationError",
         message: "Unable to serialize job data",
       });
-
-      expect(jobId).toBeNull();
 
       await queue.stop();
     });
@@ -176,15 +171,11 @@ describe("Queue", () => {
         onSuccess,
       });
 
-      const [, jobId] = await queue.enqueue({ message: "hello" });
+      const jobId = await queue.enqueue({ message: "hello" });
 
       await sleep(200);
 
-      expect(jobId).not.toBeNull();
-
-      if (jobId) {
-        expect(successJobs).toContain(jobId);
-      }
+      expect(successJobs).toContain(jobId);
 
       await queue.stop();
     });
@@ -226,20 +217,16 @@ describe("Queue", () => {
         onRetry,
       });
 
-      const [, jobId] = await queue.enqueue({ message: "hello" });
+      const jobId = await queue.enqueue({ message: "hello" });
 
       await sleep(2500);
 
-      expect(jobId).not.toBeNull();
       expect(retryContexts.length).toBe(1);
-
-      if (jobId) {
-        expect(retryContexts[0]?.id).toBe(jobId);
-        expect(retryContexts[0]?.error).toBe("First attempt fails");
-        expect(retryContexts[0]?.attempts).toBe(1);
-        expect(retryContexts[0]?.nextRetryDelayMs).toBe(1000);
-        expect(retryContexts[0]?.retriesRemaining).toBe(1);
-      }
+      expect(retryContexts[0]?.id).toBe(jobId);
+      expect(retryContexts[0]?.error).toBe("First attempt fails");
+      expect(retryContexts[0]?.attempts).toBe(1);
+      expect(retryContexts[0]?.nextRetryDelayMs).toBe(1000);
+      expect(retryContexts[0]?.retriesRemaining).toBe(1);
 
       await queue.stop();
     });
@@ -315,16 +302,12 @@ describe("Queue", () => {
         onSuccess,
       });
 
-      const [, jobId] = await queue.enqueue({ message: "hello" });
+      const jobId = await queue.enqueue({ message: "hello" });
 
       await sleep(200);
 
-      expect(jobId).not.toBeNull();
       expect(retryJobs.length).toBe(0);
-
-      if (jobId) {
-        expect(successJobs).toContain(jobId);
-      }
+      expect(successJobs).toContain(jobId);
 
       await queue.stop();
     });
@@ -356,18 +339,14 @@ describe("Queue", () => {
         onError,
       });
 
-      const [, jobId] = await queue.enqueue({ message: "hello" });
+      const jobId = await queue.enqueue({ message: "hello" });
 
       await sleep(4000);
 
-      expect(jobId).not.toBeNull();
       expect(retryJobs.length).toBe(2);
       expect(errorJobs.length).toBe(1);
-
-      if (jobId) {
-        expect(retryJobs).toContain(jobId);
-        expect(errorJobs).toContain(jobId);
-      }
+      expect(retryJobs).toContain(jobId);
+      expect(errorJobs).toContain(jobId);
 
       await queue.stop();
     });
@@ -421,17 +400,12 @@ describe("Queue", () => {
         onError,
       });
 
-      const [, jobId] = await queue.enqueue({ message: "hello" });
+      const jobId = await queue.enqueue({ message: "hello" });
 
       await sleep(4000);
 
       expect(attempts).toBe(3);
-
-      expect(jobId).not.toBeNull();
-
-      if (jobId) {
-        expect(errorJobs).toContain(jobId);
-      }
+      expect(errorJobs).toContain(jobId);
 
       await queue.stop();
     });
@@ -469,21 +443,17 @@ describe("Queue", () => {
         onError,
       });
 
-      const [, jobId] = await queue.enqueue({ message: "hello" });
+      const jobId = await queue.enqueue({ message: "hello" });
 
       await sleep(3000);
 
       expect(errorContexts.length).toBe(1);
-      expect(jobId).not.toBeNull();
-
-      if (jobId) {
-        expect(errorContexts[0]?.id).toBe(jobId);
-        expect(errorContexts[0]?.lastError).toBe("Processing failed");
-        expect(errorContexts[0]?.totalAttempts).toBe(2);
-        expect(errorContexts[0]?.totalDurationMs).toBeGreaterThan(0);
-        expect(errorContexts[0]?.errorHistory).toBeDefined();
-        expect(errorContexts[0]?.errorHistory.length).toBeGreaterThan(0);
-      }
+      expect(errorContexts[0]?.id).toBe(jobId);
+      expect(errorContexts[0]?.lastError).toBe("Processing failed");
+      expect(errorContexts[0]?.totalAttempts).toBe(2);
+      expect(errorContexts[0]?.totalDurationMs).toBeGreaterThan(0);
+      expect(errorContexts[0]?.errorHistory).toBeDefined();
+      expect(errorContexts[0]?.errorHistory.length).toBeGreaterThan(0);
 
       await queue.stop();
     });
@@ -509,15 +479,11 @@ describe("Queue", () => {
         onError,
       });
 
-      const [, jobId] = await queue.enqueue({ message: "hello" });
+      const jobId = await queue.enqueue({ message: "hello" });
 
       await sleep(3000);
 
-      expect(jobId).not.toBeNull();
-
-      if (jobId) {
-        expect(errorJobs).toContain(jobId);
-      }
+      expect(errorJobs).toContain(jobId);
 
       await queue.stop();
     });
@@ -932,17 +898,13 @@ describe("Queue", () => {
         onError,
       });
 
-      const [, jobId] = await queue.enqueue({ message: "hello" });
+      const jobId = await queue.enqueue({ message: "hello" });
 
       await sleep(3000);
 
       // Should have retried once due to timeout
       expect(attempts).toBeGreaterThanOrEqual(2);
-      expect(jobId).not.toBeNull();
-
-      if (jobId) {
-        expect(errorJobs).toContain(jobId);
-      }
+      expect(errorJobs).toContain(jobId);
 
       // Verify signal was received and got aborted after timeout
       expect(signalStates.length).toBeGreaterThan(0);

--- a/src/lib/queue/index.ts
+++ b/src/lib/queue/index.ts
@@ -1,4 +1,5 @@
-import { err, mightThrow, mightThrowSync, ok } from "../errors/index.js";
+import { mightThrow, mightThrowSync } from "../errors/index.js";
+import { EnqueueError, SerializationError } from "./errors.js";
 import type { Job, JobState, QueueOptions } from "./types.js";
 
 const toMinimalJob = <T>(jobState: JobState<T>): Job<T> => ({
@@ -46,16 +47,18 @@ export class Queue<T> {
     };
 
     const [serializeError, serialized] = this.serializeJob(job);
+
     if (serializeError || !serialized) {
-      return err("QueueError", "Unable to serialize job data");
+      throw new SerializationError("Unable to serialize job data");
     }
 
     const [enqueueError] = await this.enqueueJobData(serialized);
+
     if (enqueueError) {
-      return err("QueueError", "Unable to enqueue job");
+      throw new EnqueueError("Unable to enqueue job");
     }
 
-    return ok(job.id);
+    return job.id;
   }
 
   public async stop() {
@@ -82,7 +85,7 @@ export class Queue<T> {
     return mightThrow(this.options.redis.lpush(queueKey, serialized));
   }
 
-  private async moveToDeadLetterQueue(jobData: string, parseError: unknown) {
+  private async moveToDeadLetterQueue(jobData: string, parseError: Error) {
     const deadLetterKey = `queue:${this.options.name}:dead-letter`;
     const deadLetterEntry = JSON.stringify({
       jobData,
@@ -93,8 +96,10 @@ export class Queue<T> {
     return mightThrow(this.options.redis.lpush(deadLetterKey, deadLetterEntry));
   }
 
-  private formatErrorMessage(error: unknown) {
-    return error instanceof Error ? error.message : String(error);
+  private formatErrorMessage(error: Error | null) {
+    if (!error) return "Unknown error";
+
+    return error.message;
   }
 
   private startWorkers() {
@@ -129,7 +134,6 @@ export class Queue<T> {
         // Handle malformed payload: preserve to dead-letter queue and notify
         await this.callOnErrorForParseFailure(jobData, parseError);
         await this.moveToDeadLetterQueue(jobData, parseError);
-
         await this.waitForPollInterval();
         continue;
       }
@@ -248,10 +252,7 @@ export class Queue<T> {
     );
   }
 
-  private async callOnErrorForParseFailure(
-    jobData: string,
-    parseError: unknown,
-  ) {
+  private async callOnErrorForParseFailure(jobData: string, parseError: Error) {
     if (!this.options.onParseError) {
       return;
     }

--- a/src/lib/workflow/errors.ts
+++ b/src/lib/workflow/errors.ts
@@ -1,0 +1,48 @@
+export class WorkflowError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "WorkflowError";
+  }
+}
+
+export class NotFoundError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "NotFoundError";
+  }
+}
+
+export class StateError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "StateError";
+  }
+}
+
+export class SerializationError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "SerializationError";
+  }
+}
+
+export class ExecutionError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "ExecutionError";
+  }
+}
+
+export class LockError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "LockError";
+  }
+}
+
+export class CancelledError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "CancelledError";
+  }
+}

--- a/src/lib/workflow/index.test.ts
+++ b/src/lib/workflow/index.test.ts
@@ -304,9 +304,8 @@ describe("workflow", () => {
       },
     });
 
-    const [error, result] = await workflow.run({ id: 1 });
+    const result = await workflow.run({ id: 1 });
 
-    expect(error).toBeNull();
     expect(result).toBe("done");
   });
 
@@ -319,13 +318,10 @@ describe("workflow", () => {
       handler: async () => "ok",
     });
 
-    const [error, execution] = await workflow.get("unknown");
-
-    expect(error).toEqual({
-      type: "WorkflowNotFoundError",
+    await expect(workflow.get("unknown")).rejects.toMatchObject({
+      name: "NotFoundError",
       message: "Workflow execution unknown not found",
     });
-    expect(execution).toBeNull();
   });
 
   test("rejects duplicate execution ids", async () => {
@@ -337,23 +333,19 @@ describe("workflow", () => {
       handler: async () => "ok",
     });
 
-    const [firstError, firstStart] = await workflow.start(
+    const firstStart = await workflow.start(
       { id: 1 },
       { executionId: "exec-1" },
     );
 
-    const [secondError, secondStart] = await workflow.start(
-      { id: 2 },
-      { executionId: "exec-1" },
-    );
+    expect(firstStart.status).toBe("completed");
 
-    expect(firstError).toBeNull();
-    expect(firstStart?.status).toBe("completed");
-    expect(secondError).toEqual({
-      type: "WorkflowStateError",
+    await expect(
+      workflow.start({ id: 2 }, { executionId: "exec-1" }),
+    ).rejects.toMatchObject({
+      name: "StateError",
       message: "Workflow execution exec-1 already exists",
     });
-    expect(secondStart).toBeNull();
   });
 
   test("resumes from next step after failure", async () => {
@@ -386,17 +378,13 @@ describe("workflow", () => {
       },
     });
 
-    const [startError] = await workflow.start(
-      { id: 10 },
-      { executionId: "exec-1" },
-    );
+    await expect(
+      workflow.start({ id: 10 }, { executionId: "exec-1" }),
+    ).rejects.toMatchObject({ name: "ExecutionError" });
 
-    expect(startError).not.toBeNull();
+    const resumeData = await workflow.resume("exec-1");
 
-    const [resumeError, resumeData] = await workflow.resume("exec-1");
-
-    expect(resumeError).toBeNull();
-    expect(resumeData?.status).toBe("completed");
+    expect(resumeData.status).toBe("completed");
     expect(executedSteps).toEqual(["step-1:10", "step-2:10", "step-2:10"]);
   });
 
@@ -414,10 +402,10 @@ describe("workflow", () => {
     });
 
     await workflow.start({ id: 1 }, { executionId: "complete-1" });
-    const [resumeError, resumeData] = await workflow.resume("complete-1");
 
-    expect(resumeError).toBeNull();
-    expect(resumeData?.status).toBe("completed");
+    const resumeData = await workflow.resume("complete-1");
+
+    expect(resumeData.status).toBe("completed");
     expect(handlerCalls).toBe(1);
   });
 
@@ -444,14 +432,15 @@ describe("workflow", () => {
       },
     });
 
-    await workflow.start({ id: 1 }, { executionId: "cancel-1" });
+    await expect(
+      workflow.start({ id: 1 }, { executionId: "cancel-1" }),
+    ).rejects.toMatchObject({ name: "ExecutionError" });
 
-    const [cancelError] = await workflow.cancel("cancel-1");
-    const [resumeError, resumeData] = await workflow.resume("cancel-1");
+    await workflow.cancel("cancel-1");
 
-    expect(cancelError).toBeNull();
-    expect(resumeError).toBeNull();
-    expect(resumeData?.status).toBe("cancelled");
+    const resumeData = await workflow.resume("cancel-1");
+
+    expect(resumeData.status).toBe("cancelled");
   });
 
   test("rejects cancel for completed workflow", async () => {
@@ -465,13 +454,10 @@ describe("workflow", () => {
 
     await workflow.start({ id: 1 }, { executionId: "done-1" });
 
-    const [cancelError, cancelData] = await workflow.cancel("done-1");
-
-    expect(cancelError).toEqual({
-      type: "WorkflowStateError",
+    await expect(workflow.cancel("done-1")).rejects.toMatchObject({
+      name: "StateError",
       message: "Workflow execution done-1 is already completed",
     });
-    expect(cancelData).toBeNull();
   });
 
   test("fails with lock error when resumed while execution is running", async () => {
@@ -498,20 +484,16 @@ describe("workflow", () => {
 
     await sleep(15);
 
-    const [resumeError, resumeData] = await workflow.resume("lock-1");
-
-    expect(resumeError).toEqual({
-      type: "WorkflowLockError",
+    await expect(workflow.resume("lock-1")).rejects.toMatchObject({
+      name: "LockError",
       message: "Workflow execution lock-1 is already running",
     });
-    expect(resumeData).toBeNull();
 
     release = true;
 
-    const [startError, startData] = await startPromise;
+    const startData = await startPromise;
 
-    expect(startError).toBeNull();
-    expect(startData?.status).toBe("completed");
+    expect(startData.status).toBe("completed");
   });
 
   test("uses custom input and result serializers", async () => {
@@ -546,12 +528,8 @@ describe("workflow", () => {
       },
     });
 
-    const [runError, runData] = await workflow.run(
-      { id: 7 },
-      { executionId: "ser-1" },
-    );
+    const runData = await workflow.run({ id: 7 }, { executionId: "ser-1" });
 
-    expect(runError).toBeNull();
     expect(runData).toEqual({ ok: true });
     expect(serializedInputCalled).toBe(1);
     expect(deserializedInputCalled).toBe(1);
@@ -571,13 +549,10 @@ describe("workflow", () => {
       handler: async () => "ok",
     });
 
-    const [startError, startData] = await workflow.start({ id: 1 });
-
-    expect(startError?.type).toBe("WorkflowSerializationError");
-    expect(
-      startError?.message.includes("Unable to serialize workflow input for"),
-    ).toBe(true);
-    expect(startData).toBeNull();
+    await expect(workflow.start({ id: 1 })).rejects.toMatchObject({
+      name: "SerializationError",
+      message: expect.stringContaining("Unable to serialize workflow input"),
+    });
   });
 
   test("returns workflow error when redis read fails", async () => {
@@ -590,13 +565,10 @@ describe("workflow", () => {
       handler: async () => "ok",
     });
 
-    const [error, data] = await workflow.get("any");
-
-    expect(error).toEqual({
-      type: "WorkflowError",
+    await expect(workflow.get("any")).rejects.toMatchObject({
+      name: "WorkflowError",
       message: "Unable to read status for execution any",
     });
-    expect(data).toBeNull();
   });
 
   test("returns state error when step index is invalid", async () => {
@@ -616,13 +588,10 @@ describe("workflow", () => {
       "{not-json}",
     );
 
-    const [error, data] = await workflow.get("bad-steps-1");
-
-    expect(error).toEqual({
-      type: "WorkflowStateError",
+    await expect(workflow.get("bad-steps-1")).rejects.toMatchObject({
+      name: "StateError",
       message: "Invalid step index for execution bad-steps-1",
     });
-    expect(data).toBeNull();
   });
 
   test("get returns completed steps with timestamps", async () => {
@@ -640,14 +609,13 @@ describe("workflow", () => {
 
     await workflow.start({ id: 1 }, { executionId: "snap-1" });
 
-    const [error, execution] = await workflow.get("snap-1");
+    const execution = await workflow.get("snap-1");
 
-    expect(error).toBeNull();
-    expect(execution?.steps.length).toBe(2);
-    expect(execution?.steps[0]?.name).toBe("one");
-    expect(execution?.steps[1]?.name).toBe("two");
-    expect(typeof execution?.steps[0]?.completedAt).toBe("number");
-    expect(typeof execution?.steps[1]?.completedAt).toBe("number");
+    expect(execution.steps.length).toBe(2);
+    expect(execution.steps[0]?.name).toBe("one");
+    expect(execution.steps[1]?.name).toBe("two");
+    expect(typeof execution.steps[0]?.completedAt).toBe("number");
+    expect(typeof execution.steps[1]?.completedAt).toBe("number");
   });
 
   describe("run matrix", () => {
@@ -656,12 +624,11 @@ describe("workflow", () => {
         const redis = createRedis();
         const workflow = createWorkflowWithEchoResult(`run-matrix-${i}`, redis);
 
-        const [error, result] = await workflow.run(
+        const result = await workflow.run(
           { id: i },
           { executionId: `run-matrix-exec-${i}` },
         );
 
-        expect(error).toBeNull();
         expect(result).toBe(`echo:${i}`);
       });
     }
@@ -681,13 +648,12 @@ describe("workflow", () => {
         const executionId = `resume-matrix-exec-${i}`;
 
         await workflow.start({ id: i }, { executionId });
-        const [resumeError, resumeData] = await workflow.resume(executionId);
-        const [getError, execution] = await workflow.get(executionId);
 
-        expect(resumeError).toBeNull();
-        expect(resumeData?.status).toBe("completed");
-        expect(getError).toBeNull();
-        expect(execution?.result).toBe(`echo:${i}`);
+        const resumeData = await workflow.resume(executionId);
+        const execution = await workflow.get(executionId);
+
+        expect(resumeData.status).toBe("completed");
+        expect(execution.result).toBe(`echo:${i}`);
         expect(calls.value).toBe(1);
       });
     }
@@ -703,15 +669,11 @@ describe("workflow", () => {
         );
         const executionId = `dupe-matrix-exec-${i}`;
 
-        const [firstError] = await workflow.start({ id: i }, { executionId });
-        const [secondError, secondData] = await workflow.start(
-          { id: i + 100 },
-          { executionId },
-        );
+        await workflow.start({ id: i }, { executionId });
 
-        expect(firstError).toBeNull();
-        expect(secondError?.type).toBe("WorkflowStateError");
-        expect(secondData).toBeNull();
+        await expect(
+          workflow.start({ id: i + 100 }, { executionId }),
+        ).rejects.toMatchObject({ name: "StateError" });
       });
     }
   });
@@ -740,21 +702,17 @@ describe("workflow", () => {
         await workflow.start({ id: 1 }, { executionId });
         redis.seedHashField(metaKey, "status", status);
 
-        const [error, data] = await workflow.get(executionId);
-
         if (status.length === 0) {
-          expect(error).toEqual({
-            type: "WorkflowNotFoundError",
+          await expect(workflow.get(executionId)).rejects.toMatchObject({
+            name: "NotFoundError",
             message: `Workflow execution ${executionId} not found`,
           });
         } else {
-          expect(error?.type).toBe("WorkflowStateError");
-          expect(error?.message).toBe(
-            `Workflow execution ${executionId} has invalid status ${status}`,
-          );
+          await expect(workflow.get(executionId)).rejects.toMatchObject({
+            name: "StateError",
+            message: `Workflow execution ${executionId} has invalid status ${status}`,
+          });
         }
-
-        expect(data).toBeNull();
       });
     }
   });
@@ -773,13 +731,10 @@ describe("workflow", () => {
         await workflow.start({ id: 1 }, { executionId });
         redis.seedHashField(metaKey, field, "abc");
 
-        const [error, data] = await workflow.get(executionId);
-
-        expect(error).toEqual({
-          type: "WorkflowStateError",
+        await expect(workflow.get(executionId)).rejects.toMatchObject({
+          name: "StateError",
           message: `Invalid ${field} value for execution ${executionId}`,
         });
-        expect(data).toBeNull();
       });
     }
   });
@@ -820,13 +775,10 @@ describe("workflow", () => {
         redis.seedHashField(metaKey, "steps", JSON.stringify(["one"]));
         redis.seedHashField(stepsKey, "one", payloads[i] ?? "");
 
-        const [error, data] = await workflow.get(executionId);
-
-        expect(error?.type).toBe("WorkflowStateError");
-        expect(error?.message).toBe(
-          `Invalid step payload for one in execution ${executionId}`,
-        );
-        expect(data).toBeNull();
+        await expect(workflow.get(executionId)).rejects.toMatchObject({
+          name: "StateError",
+          message: `Invalid step payload for one in execution ${executionId}`,
+        });
       });
     }
   });
@@ -844,39 +796,34 @@ describe("workflow", () => {
           redis,
         );
 
-        const [error, data] = await workflow.start({ id: 1 });
-
         if (command === "hset") {
-          expect(error?.type).toBe("WorkflowError");
-          expect(
-            error?.message.includes(
-              "Unable to persist metadata for execution ",
+          await expect(workflow.start({ id: 1 })).rejects.toMatchObject({
+            name: "WorkflowError",
+            message: expect.stringContaining(
+              "Unable to persist metadata for execution",
             ),
-          ).toBe(true);
+          });
         } else {
-          expect(error?.type).toBe("WorkflowLockError");
+          await expect(workflow.start({ id: 1 })).rejects.toMatchObject({
+            name: "LockError",
+          });
         }
-
-        expect(data).toBeNull();
       });
     }
   });
 
   describe("execute hset failure matrix", () => {
-    // execute() writes "status":"running" as the 1st hset call
     test("fails when hset fails during running status write", async () => {
       const redis = createRedis() as MockRedisClient & Bun.RedisClient;
       redis.failHsetAfterNCalls(0);
 
       const workflow = createWorkflowWithEchoResult("hset-running-fail", redis);
 
-      const [error, data] = await workflow.start({ id: 1 });
-
-      expect(error?.type).toBe("WorkflowError");
-      expect(data).toBeNull();
+      await expect(workflow.start({ id: 1 })).rejects.toMatchObject({
+        name: "WorkflowError",
+      });
     });
 
-    // 2 running writes + 1 result = 3; 4th is "status":"completed"
     test("fails when hset fails during completed status write", async () => {
       const redis = createRedis() as MockRedisClient & Bun.RedisClient;
       redis.failHsetAfterNCalls(3);
@@ -887,10 +834,9 @@ describe("workflow", () => {
         handler: async () => "done",
       });
 
-      const [error, data] = await workflow.start({ id: 1 });
-
-      expect(error?.type).toBe("WorkflowError");
-      expect(data).toBeNull();
+      await expect(workflow.start({ id: 1 })).rejects.toMatchObject({
+        name: "WorkflowError",
+      });
     });
   });
 
@@ -899,13 +845,10 @@ describe("workflow", () => {
       const redis = createRedis();
       const workflow = createWorkflowWithEchoResult("cancel-unknown", redis);
 
-      const [error, data] = await workflow.cancel("nonexistent");
-
-      expect(error).toEqual({
-        type: "WorkflowNotFoundError",
+      await expect(workflow.cancel("nonexistent")).rejects.toMatchObject({
+        name: "NotFoundError",
         message: "Workflow execution nonexistent not found",
       });
-      expect(data).toBeNull();
     });
 
     test("succeeds silently when cancelling already-cancelled execution", async () => {
@@ -929,25 +872,20 @@ describe("workflow", () => {
         },
       });
 
-      await workflow.start({ id: 1 }, { executionId: "cancel-twice-1" });
-      const [firstCancelError, firstCancelData] =
-        await workflow.cancel("cancel-twice-1");
-      const [secondCancelError, secondCancelData] =
-        await workflow.cancel("cancel-twice-1");
+      await expect(
+        workflow.start({ id: 1 }, { executionId: "cancel-twice-1" }),
+      ).rejects.toMatchObject({ name: "ExecutionError" });
 
-      expect(firstCancelError).toBeNull();
-      expect(firstCancelData).not.toBeNull();
+      const firstCancelData = await workflow.cancel("cancel-twice-1");
+      const secondCancelData = await workflow.cancel("cancel-twice-1");
 
-      expect(secondCancelError).toBeNull();
-      expect(secondCancelData).not.toBeNull();
+      expect(firstCancelData.executionId).toEqual("cancel-twice-1");
+      expect(secondCancelData.executionId).toEqual("cancel-twice-1");
 
-      expect(firstCancelData?.executionId).toEqual("cancel-twice-1");
-      expect(secondCancelData?.executionId).toEqual("cancel-twice-1");
+      expect(firstCancelData.status).toEqual("cancelled");
+      expect(secondCancelData.status).toEqual("cancelled");
 
-      expect(firstCancelData?.status).toEqual("cancelled");
-      expect(secondCancelData?.status).toEqual("cancelled");
-
-      expect(firstCancelData?.createdAt).toEqual(secondCancelData?.createdAt);
+      expect(firstCancelData.createdAt).toEqual(secondCancelData.createdAt);
     });
   });
 
@@ -956,13 +894,10 @@ describe("workflow", () => {
       const redis = createRedis();
       const workflow = createWorkflowWithEchoResult("resume-unknown", redis);
 
-      const [error, data] = await workflow.resume("nonexistent");
-
-      expect(error).toEqual({
-        type: "WorkflowNotFoundError",
+      await expect(workflow.resume("nonexistent")).rejects.toMatchObject({
+        name: "NotFoundError",
         message: "Workflow execution nonexistent not found",
       });
-      expect(data).toBeNull();
     });
   });
 
@@ -978,11 +913,10 @@ describe("workflow", () => {
         },
       });
 
-      const [error, result] = await workflow.run({ id: 1 });
-
-      expect(error?.type).toBe("WorkflowExecutionError");
-      expect(error?.message.includes("handler crashed")).toBe(true);
-      expect(result).toBeNull();
+      await expect(workflow.run({ id: 1 })).rejects.toMatchObject({
+        name: "ExecutionError",
+        message: expect.stringContaining("handler crashed"),
+      });
     });
 
     test("returns WorkflowCancelledError when cancelled during execution", async () => {
@@ -1003,10 +937,9 @@ describe("workflow", () => {
         },
       });
 
-      const [error, result] = await workflow.run({ id: 1 });
-
-      expect(error?.type).toBe("WorkflowCancelledError");
-      expect(result).toBeNull();
+      await expect(workflow.run({ id: 1 })).rejects.toMatchObject({
+        name: "CancelledError",
+      });
     });
   });
 
@@ -1022,16 +955,17 @@ describe("workflow", () => {
         },
       });
 
-      await workflow.start({ id: 1 }, { executionId: "get-failed-1" });
+      await expect(
+        workflow.start({ id: 1 }, { executionId: "get-failed-1" }),
+      ).rejects.toMatchObject({ name: "ExecutionError" });
 
-      const [error, execution] = await workflow.get("get-failed-1");
+      const execution = await workflow.get("get-failed-1");
 
-      expect(error).toBeNull();
-      expect(execution?.status).toBe("failed");
-      expect(execution?.error).toBe("something went wrong");
-      expect(typeof execution?.failedAt).toBe("number");
-      expect(execution?.completedAt).toBeNull();
-      expect(execution?.cancelledAt).toBeNull();
+      expect(execution.status).toBe("failed");
+      expect(execution.error).toBe("something went wrong");
+      expect(typeof execution.failedAt).toBe("number");
+      expect(execution.completedAt).toBeNull();
+      expect(execution.cancelledAt).toBeNull();
     });
 
     test("returns cancelledAt on cancelled workflow", async () => {
@@ -1055,15 +989,17 @@ describe("workflow", () => {
         },
       });
 
-      await workflow.start({ id: 1 }, { executionId: "get-cancelled-1" });
+      await expect(
+        workflow.start({ id: 1 }, { executionId: "get-cancelled-1" }),
+      ).rejects.toMatchObject({ name: "ExecutionError" });
+
       await workflow.cancel("get-cancelled-1");
 
-      const [error, execution] = await workflow.get("get-cancelled-1");
+      const execution = await workflow.get("get-cancelled-1");
 
-      expect(error).toBeNull();
-      expect(execution?.status).toBe("cancelled");
-      expect(typeof execution?.cancelledAt).toBe("number");
-      expect(execution?.completedAt).toBeNull();
+      expect(execution.status).toBe("cancelled");
+      expect(typeof execution.cancelledAt).toBe("number");
+      expect(execution.completedAt).toBeNull();
     });
   });
 
@@ -1101,18 +1037,17 @@ describe("workflow", () => {
 
         const executionId = `falsy-${label}-exec`;
 
-        const [startError] = await workflow.start({ id: 1 }, { executionId });
+        await expect(
+          workflow.start({ id: 1 }, { executionId }),
+        ).rejects.toMatchObject({ name: "ExecutionError" });
 
-        expect(startError).not.toBeNull();
         expect(stepRuns).toBe(1);
 
-        const [resumeError, resumeData] = await workflow.resume(executionId);
-        const [getError, execution] = await workflow.get(executionId);
+        const resumeData = await workflow.resume(executionId);
+        const execution = await workflow.get(executionId);
 
-        expect(resumeError).toBeNull();
-        expect(resumeData?.status).toBe("completed");
-        expect(getError).toBeNull();
-        expect(execution?.result).toStrictEqual(value);
+        expect(resumeData.status).toBe("completed");
+        expect(execution.result).toStrictEqual(value);
         expect(stepRuns).toBe(1);
       });
     }
@@ -1148,14 +1083,15 @@ describe("workflow", () => {
         },
       });
 
-      await workflow.start({ id: 1 }, { executionId: "step-ser-1" });
+      await expect(
+        workflow.start({ id: 1 }, { executionId: "step-ser-1" }),
+      ).rejects.toMatchObject({ name: "ExecutionError" });
 
       expect(serializeCalled).toBe(1);
       expect(deserializeCalled).toBe(0);
 
-      const [resumeError] = await workflow.resume("step-ser-1");
+      await workflow.resume("step-ser-1");
 
-      expect(resumeError).toBeNull();
       expect(serializeCalled).toBe(1);
       expect(deserializeCalled).toBe(1);
     });
@@ -1177,10 +1113,9 @@ describe("workflow", () => {
 
       await workflow.start({ id: 1 }, { executionId: "deser-1" });
 
-      const [error, data] = await workflow.get("deser-1");
-
-      expect(error?.type).toBe("WorkflowSerializationError");
-      expect(data).toBeNull();
+      await expect(workflow.get("deser-1")).rejects.toMatchObject({
+        name: "SerializationError",
+      });
     });
   });
 
@@ -1208,7 +1143,9 @@ describe("workflow", () => {
         },
       });
 
-      await workflow.run({ id: 1 });
+      await expect(workflow.run({ id: 1 })).rejects.toMatchObject({
+        name: "CancelledError",
+      });
 
       expect(signalAborted).toBe(true);
     });

--- a/src/lib/workflow/index.ts
+++ b/src/lib/workflow/index.ts
@@ -1,4 +1,13 @@
-import { err, mightThrow, mightThrowSync, ok } from "../errors/index.js";
+import { mightThrow, mightThrowSync } from "../errors/index.js";
+import {
+  CancelledError,
+  ExecutionError,
+  LockError,
+  NotFoundError,
+  SerializationError,
+  StateError,
+  WorkflowError,
+} from "./errors.js";
 import type {
   StepSnapshot,
   Workflow,
@@ -70,189 +79,80 @@ class WorkflowDefinition<TInput, TResult> {
   public async start(input: TInput, options?: WorkflowStartOptions) {
     const executionId = options?.executionId ?? crypto.randomUUID();
 
-    const [createError] = await this.createExecution(executionId, input);
-
-    if (createError) {
-      return err(createError.type, createError.message);
-    }
+    await this.createExecution(executionId, input);
 
     return this.execute(executionId, input);
   }
 
   public async run(input: TInput, options?: WorkflowStartOptions) {
-    const [startError, startData] = await this.start(input, options);
-
-    if (startError) {
-      return err(startError.type, startError.message);
-    }
-
-    if (!startData) {
-      return err("WorkflowError", "Unexpected empty start result");
-    }
+    const startData = await this.start(input, options);
 
     if (startData.status === "cancelled") {
-      return err(
-        "WorkflowCancelledError",
+      throw new CancelledError(
         `Workflow execution ${startData.executionId} was cancelled`,
       );
     }
 
-    if (startData.status !== "completed") {
-      return err(
-        "WorkflowExecutionError",
-        `Workflow execution ${startData.executionId} did not complete`,
-      );
-    }
+    const execution = await this.get(startData.executionId);
 
-    const [getError, execution] = await this.get(startData.executionId);
-
-    if (getError) {
-      return err(getError.type, getError.message);
-    }
-
-    if (!execution) {
-      return err("WorkflowError", "Unexpected empty execution");
-    }
-
-    return ok(execution.result);
+    return execution.result;
   }
 
   public async resume(executionId: string) {
-    const [getError, execution] = await this.get(executionId);
-
-    if (getError) {
-      return err(getError.type, getError.message);
-    }
-
-    if (!execution) {
-      return err(
-        "WorkflowNotFoundError",
-        `Workflow execution ${executionId} not found`,
-      );
-    }
+    const execution = await this.get(executionId);
 
     if (execution.status === "completed") {
-      return ok({ executionId, status: execution.status });
+      return {
+        executionId,
+        status: execution.status,
+      } satisfies WorkflowStartResult;
     }
 
     if (execution.status === "cancelled") {
-      return ok({ executionId, status: execution.status });
+      return {
+        executionId,
+        status: execution.status,
+      } satisfies WorkflowStartResult;
     }
 
     return this.execute(executionId, execution.input);
   }
 
   public async get(executionId: string) {
-    const [statusError, status] = await this.getMeta(executionId, "status");
-
-    if (statusError) {
-      return err(statusError.type, statusError.message);
-    }
+    const status = await this.getMeta(executionId, "status");
 
     if (!status) {
-      return err(
-        "WorkflowNotFoundError",
-        `Workflow execution ${executionId} not found`,
-      );
+      throw new NotFoundError(`Workflow execution ${executionId} not found`);
     }
 
     const normalizedStatus = this.normalizeStatus(status);
 
     if (!normalizedStatus) {
-      return err(
-        "WorkflowStateError",
+      throw new StateError(
         `Workflow execution ${executionId} has invalid status ${status}`,
       );
     }
 
-    const [inputError, input] = await this.readInput(executionId);
-
-    if (inputError) {
-      return err(inputError.type, inputError.message);
-    }
-
-    if (input === null) {
-      return err(
-        "WorkflowStateError",
-        `Workflow execution ${executionId} has invalid input`,
-      );
-    }
-
-    const [resultError, result] = await this.readResult(executionId);
-
-    if (resultError) {
-      return err(resultError.type, resultError.message);
-    }
-
-    const [stepsError, steps] = await this.readStepSnapshots(executionId);
-
-    if (stepsError) {
-      return err(stepsError.type, stepsError.message);
-    }
-
-    const [createdAtError, createdAt] = await this.readNumberMeta(
-      executionId,
-      "createdAt",
-    );
-
-    if (createdAtError) {
-      return err(createdAtError.type, createdAtError.message);
-    }
+    const input = await this.readInput(executionId);
+    const result = await this.readResult(executionId);
+    const steps = await this.readStepSnapshots(executionId);
+    const createdAt = await this.readNumberMeta(executionId, "createdAt");
+    const updatedAt = await this.readNumberMeta(executionId, "updatedAt");
+    const errorMessage = await this.getMeta(executionId, "error");
+    const completedAt = await this.readNumberMeta(executionId, "completedAt");
+    const failedAt = await this.readNumberMeta(executionId, "failedAt");
+    const cancelledAt = await this.readNumberMeta(executionId, "cancelledAt");
 
     if (createdAt === null) {
-      return err(
-        "WorkflowStateError",
+      throw new StateError(
         `Workflow execution ${executionId} is missing createdAt`,
       );
     }
 
-    const [updatedAtError, updatedAt] = await this.readNumberMeta(
-      executionId,
-      "updatedAt",
-    );
-
-    if (updatedAtError) {
-      return err(updatedAtError.type, updatedAtError.message);
-    }
-
     if (updatedAt === null) {
-      return err(
-        "WorkflowStateError",
+      throw new StateError(
         `Workflow execution ${executionId} is missing updatedAt`,
       );
-    }
-
-    const [metaError, errorMessage] = await this.getMeta(executionId, "error");
-
-    if (metaError) {
-      return err(metaError.type, metaError.message);
-    }
-
-    const [completedAtError, completedAt] = await this.readNumberMeta(
-      executionId,
-      "completedAt",
-    );
-
-    if (completedAtError) {
-      return err(completedAtError.type, completedAtError.message);
-    }
-
-    const [failedAtError, failedAt] = await this.readNumberMeta(
-      executionId,
-      "failedAt",
-    );
-
-    if (failedAtError) {
-      return err(failedAtError.type, failedAtError.message);
-    }
-
-    const [cancelledAtError, cancelledAt] = await this.readNumberMeta(
-      executionId,
-      "cancelledAt",
-    );
-
-    if (cancelledAtError) {
-      return err(cancelledAtError.type, cancelledAtError.message);
     }
 
     const data: WorkflowExecution<TInput, TResult> = {
@@ -270,74 +170,25 @@ class WorkflowDefinition<TInput, TResult> {
       steps,
     };
 
-    return ok(data);
+    return data;
   }
 
   public async cancel(executionId: string) {
-    const [getError, execution] = await this.get(executionId);
-
-    if (getError) {
-      return err(getError.type, getError.message);
-    }
-
-    if (!execution) {
-      return err(
-        "WorkflowNotFoundError",
-        `Workflow execution ${executionId} not found`,
-      );
-    }
+    const execution = await this.get(executionId);
 
     if (execution.status === "completed") {
-      return err(
-        "WorkflowStateError",
+      throw new StateError(
         `Workflow execution ${executionId} is already completed`,
       );
     }
 
     const timestamp = now();
 
-    const [statusError] = await this.setMeta(
-      executionId,
-      "status",
-      "cancelled",
-    );
-    if (statusError) {
-      return err(statusError.type, statusError.message);
-    }
-
-    const [updatedAtError] = await this.setMeta(
-      executionId,
-      "updatedAt",
-      String(timestamp),
-    );
-    if (updatedAtError) {
-      return err(updatedAtError.type, updatedAtError.message);
-    }
-
-    const [cancelledAtError] = await this.setMeta(
-      executionId,
-      "cancelledAt",
-      String(timestamp),
-    );
-    if (cancelledAtError) {
-      return err(cancelledAtError.type, cancelledAtError.message);
-    }
-
-    const [clearErrorError] = await this.setMeta(executionId, "error", "");
-
-    if (clearErrorError) {
-      return err(clearErrorError.type, clearErrorError.message);
-    }
-
-    const [clearFailedAtError] = await this.setMeta(
-      executionId,
-      "failedAt",
-      "",
-    );
-
-    if (clearFailedAtError) {
-      return err(clearFailedAtError.type, clearFailedAtError.message);
-    }
+    await this.setMeta(executionId, "status", "cancelled");
+    await this.setMeta(executionId, "updatedAt", String(timestamp));
+    await this.setMeta(executionId, "cancelledAt", String(timestamp));
+    await this.setMeta(executionId, "error", "");
+    await this.setMeta(executionId, "failedAt", "");
 
     const response: WorkflowCancelResult = {
       executionId,
@@ -347,7 +198,7 @@ class WorkflowDefinition<TInput, TResult> {
       status: "cancelled",
     };
 
-    return ok(response);
+    return response;
   }
 
   private executionKey(executionId: string) {
@@ -367,31 +218,14 @@ class WorkflowDefinition<TInput, TResult> {
   }
 
   private async createExecution(executionId: string, input: TInput) {
-    const [serializeError, serializedInput] = this.serializeInput(input);
-
-    if (serializeError) {
-      return err(
-        "WorkflowSerializationError",
-        `Unable to serialize workflow input for ${executionId}`,
-      );
-    }
+    const serializedInput = this.serializeInput(input);
 
     const timestamp = now();
 
-    const [statusReadError, existingStatus] = await this.getMeta(
-      executionId,
-      "status",
-    );
-
-    if (statusReadError) {
-      return err(statusReadError.type, statusReadError.message);
-    }
+    const existingStatus = await this.getMeta(executionId, "status");
 
     if (existingStatus) {
-      return err(
-        "WorkflowStateError",
-        `Workflow execution ${executionId} already exists`,
-      );
+      throw new StateError(`Workflow execution ${executionId} already exists`);
     }
 
     const metadata: WorkflowMeta = {
@@ -412,65 +246,28 @@ class WorkflowDefinition<TInput, TResult> {
     );
 
     if (writeError) {
-      return err(
-        "WorkflowError",
+      throw new WorkflowError(
         `Unable to persist metadata for execution ${executionId}`,
       );
     }
-
-    return ok(null);
   }
 
   private async execute(executionId: string, input: TInput) {
     const token = crypto.randomUUID();
 
-    const [lockError] = await this.acquireLock(executionId, token);
+    await this.acquireLock(executionId, token);
 
-    if (lockError) {
-      return err(lockError.type, lockError.message);
-    }
-
-    const [statusCheckError, currentStatus] = await this.getMeta(
-      executionId,
-      "status",
-    );
-
-    if (statusCheckError) {
-      await this.releaseLock(executionId, token);
-      return err(statusCheckError.type, statusCheckError.message);
-    }
+    const currentStatus = await this.getMeta(executionId, "status");
 
     if (currentStatus === "cancelled") {
       await this.releaseLock(executionId, token);
-      return err(
-        "WorkflowStateError",
-        `Workflow execution ${executionId} was cancelled`,
-      );
+      throw new StateError(`Workflow execution ${executionId} was cancelled`);
     }
 
     const timestamp = now();
 
-    const [runningStatusError] = await this.setMeta(
-      executionId,
-      "status",
-      "running",
-    );
-
-    if (runningStatusError) {
-      await this.releaseLock(executionId, token);
-      return err(runningStatusError.type, runningStatusError.message);
-    }
-
-    const [runningUpdatedAtError] = await this.setMeta(
-      executionId,
-      "updatedAt",
-      String(timestamp),
-    );
-
-    if (runningUpdatedAtError) {
-      await this.releaseLock(executionId, token);
-      return err(runningUpdatedAtError.type, runningUpdatedAtError.message);
-    }
+    await this.setMeta(executionId, "status", "running");
+    await this.setMeta(executionId, "updatedAt", String(timestamp));
 
     const controller = new AbortController();
 
@@ -479,7 +276,9 @@ class WorkflowDefinition<TInput, TResult> {
     let lockLost = false;
 
     const renewTimer = setInterval(async () => {
-      const [renewError] = await this.extendLock(executionId, token);
+      const [renewError] = await mightThrow(
+        this.extendLock(executionId, token),
+      );
 
       if (renewError) {
         lockLost = true;
@@ -495,25 +294,16 @@ class WorkflowDefinition<TInput, TResult> {
         signal: AbortSignal,
       ) => TStep | Promise<TStep>,
     ) => {
-      const [cancelledError, cancelled] = await this.isCancelled(executionId);
-
-      if (cancelledError) {
-        return Promise.reject(new Error(cancelledError.message));
-      }
+      const cancelled = await this.isCancelled(executionId);
 
       if (cancelled) {
         controller.abort();
-        return Promise.reject(new Error("Workflow cancelled"));
+        throw new CancelledError(
+          `Workflow execution ${executionId} was cancelled`,
+        );
       }
 
-      const [readError, cachedStep] = await this.readStepOutput<TStep>(
-        executionId,
-        name,
-      );
-
-      if (readError) {
-        return Promise.reject(new Error(readError.message));
-      }
+      const cachedStep = await this.readStepOutput<TStep>(executionId, name);
 
       if (cachedStep.found) {
         return cachedStep.value as TStep;
@@ -524,18 +314,10 @@ class WorkflowDefinition<TInput, TResult> {
       );
 
       if (stepError) {
-        return Promise.reject(stepError);
+        throw stepError;
       }
 
-      const [writeError] = await this.writeStepOutput(
-        executionId,
-        name,
-        output,
-      );
-
-      if (writeError) {
-        return Promise.reject(new Error(writeError.message));
-      }
+      await this.writeStepOutput(executionId, name, output);
 
       return output as TStep;
     };
@@ -555,264 +337,73 @@ class WorkflowDefinition<TInput, TResult> {
 
     if (lockLost) {
       await this.releaseLock(executionId, token);
-
-      return err(
-        "WorkflowLockError",
-        `Lock expired during execution ${executionId}`,
-      );
+      throw new LockError(`Lock expired during execution ${executionId}`);
     }
 
-    const [cancelledError, cancelled] = await this.isCancelled(executionId);
-
-    if (cancelledError) {
-      await this.releaseLock(executionId, token);
-      return err(cancelledError.type, cancelledError.message);
-    }
+    const cancelled = await this.isCancelled(executionId);
 
     if (cancelled) {
       const cancelledAt = now();
 
-      const [cancelledStatusError] = await this.setMeta(
-        executionId,
-        "status",
-        "cancelled",
-      );
-
-      if (cancelledStatusError) {
-        await this.releaseLock(executionId, token);
-        return err(cancelledStatusError.type, cancelledStatusError.message);
-      }
-
-      const [cancelledUpdatedAtError] = await this.setMeta(
-        executionId,
-        "updatedAt",
-        String(cancelledAt),
-      );
-
-      if (cancelledUpdatedAtError) {
-        await this.releaseLock(executionId, token);
-        return err(
-          cancelledUpdatedAtError.type,
-          cancelledUpdatedAtError.message,
-        );
-      }
-
-      const [cancelledAtError] = await this.setMeta(
-        executionId,
-        "cancelledAt",
-        String(cancelledAt),
-      );
-
-      if (cancelledAtError) {
-        await this.releaseLock(executionId, token);
-        return err(cancelledAtError.type, cancelledAtError.message);
-      }
+      await this.setMeta(executionId, "status", "cancelled");
+      await this.setMeta(executionId, "updatedAt", String(cancelledAt));
+      await this.setMeta(executionId, "cancelledAt", String(cancelledAt));
 
       await this.releaseLock(executionId, token);
 
-      const response: WorkflowStartResult = {
-        executionId,
-        status: "cancelled",
-      };
-
-      return ok(response);
+      return { executionId, status: "cancelled" } satisfies WorkflowStartResult;
     }
 
     if (handlerError) {
       const failedAt = now();
 
-      const [failedStatusError] = await this.setMeta(
-        executionId,
-        "status",
-        "failed",
-      );
-
-      if (failedStatusError) {
-        await this.releaseLock(executionId, token);
-        return err(failedStatusError.type, failedStatusError.message);
-      }
-
-      const [failedMessageError] = await this.setMeta(
-        executionId,
-        "error",
-        toErrorMessage(handlerError),
-      );
-
-      if (failedMessageError) {
-        await this.releaseLock(executionId, token);
-        return err(failedMessageError.type, failedMessageError.message);
-      }
-
-      const [failedUpdatedAtError] = await this.setMeta(
-        executionId,
-        "updatedAt",
-        String(failedAt),
-      );
-
-      if (failedUpdatedAtError) {
-        await this.releaseLock(executionId, token);
-        return err(failedUpdatedAtError.type, failedUpdatedAtError.message);
-      }
-
-      const [failedAtError] = await this.setMeta(
-        executionId,
-        "failedAt",
-        String(failedAt),
-      );
-
-      if (failedAtError) {
-        await this.releaseLock(executionId, token);
-        return err(failedAtError.type, failedAtError.message);
-      }
+      await this.setMeta(executionId, "status", "failed");
+      await this.setMeta(executionId, "error", toErrorMessage(handlerError));
+      await this.setMeta(executionId, "updatedAt", String(failedAt));
+      await this.setMeta(executionId, "failedAt", String(failedAt));
 
       await this.releaseLock(executionId, token);
 
-      return err(
-        "WorkflowExecutionError",
+      throw new ExecutionError(
         `Workflow execution ${executionId} failed: ${toErrorMessage(handlerError)}`,
       );
     }
 
-    const [serializeResultError, serializedResult] =
-      this.serializeResult(result);
+    const [serializeResultError, serializedResult] = mightThrowSync(() =>
+      this.serializeResult(result),
+    );
 
     if (serializeResultError) {
       const failedAt = now();
 
-      const [failedStatusError] = await this.setMeta(
-        executionId,
-        "status",
-        "failed",
-      );
-
-      if (failedStatusError) {
-        await this.releaseLock(executionId, token);
-        return err(failedStatusError.type, failedStatusError.message);
-      }
-
-      const [failedMessageError] = await this.setMeta(
+      await this.setMeta(executionId, "status", "failed");
+      await this.setMeta(
         executionId,
         "error",
-        serializeResultError.message,
+        toErrorMessage(serializeResultError),
       );
-
-      if (failedMessageError) {
-        await this.releaseLock(executionId, token);
-        return err(failedMessageError.type, failedMessageError.message);
-      }
-
-      const [failedUpdatedAtError] = await this.setMeta(
-        executionId,
-        "updatedAt",
-        String(failedAt),
-      );
-
-      if (failedUpdatedAtError) {
-        await this.releaseLock(executionId, token);
-        return err(failedUpdatedAtError.type, failedUpdatedAtError.message);
-      }
-
-      const [failedAtError] = await this.setMeta(
-        executionId,
-        "failedAt",
-        String(failedAt),
-      );
-
-      if (failedAtError) {
-        await this.releaseLock(executionId, token);
-        return err(failedAtError.type, failedAtError.message);
-      }
+      await this.setMeta(executionId, "updatedAt", String(failedAt));
+      await this.setMeta(executionId, "failedAt", String(failedAt));
 
       await this.releaseLock(executionId, token);
 
-      return err(
-        "WorkflowSerializationError",
+      throw new SerializationError(
         `Unable to serialize workflow result for ${executionId}`,
       );
     }
 
     const completedAt = now();
 
-    const [completedResultError] = await this.setMeta(
-      executionId,
-      "result",
-      serializedResult,
-    );
-
-    if (completedResultError) {
-      await this.releaseLock(executionId, token);
-      return err(completedResultError.type, completedResultError.message);
-    }
-
-    const [completedStatusError] = await this.setMeta(
-      executionId,
-      "status",
-      "completed",
-    );
-
-    if (completedStatusError) {
-      await this.releaseLock(executionId, token);
-      return err(completedStatusError.type, completedStatusError.message);
-    }
-
-    const [completedClearErrorError] = await this.setMeta(
-      executionId,
-      "error",
-      "",
-    );
-
-    if (completedClearErrorError) {
-      await this.releaseLock(executionId, token);
-      return err(
-        completedClearErrorError.type,
-        completedClearErrorError.message,
-      );
-    }
-
-    const [completedClearFailedAtError] = await this.setMeta(
-      executionId,
-      "failedAt",
-      "",
-    );
-
-    if (completedClearFailedAtError) {
-      await this.releaseLock(executionId, token);
-      return err(
-        completedClearFailedAtError.type,
-        completedClearFailedAtError.message,
-      );
-    }
-
-    const [completedUpdatedAtError] = await this.setMeta(
-      executionId,
-      "updatedAt",
-      String(completedAt),
-    );
-
-    if (completedUpdatedAtError) {
-      await this.releaseLock(executionId, token);
-      return err(completedUpdatedAtError.type, completedUpdatedAtError.message);
-    }
-
-    const [completedAtError] = await this.setMeta(
-      executionId,
-      "completedAt",
-      String(completedAt),
-    );
-
-    if (completedAtError) {
-      await this.releaseLock(executionId, token);
-      return err(completedAtError.type, completedAtError.message);
-    }
+    await this.setMeta(executionId, "result", serializedResult);
+    await this.setMeta(executionId, "status", "completed");
+    await this.setMeta(executionId, "error", "");
+    await this.setMeta(executionId, "failedAt", "");
+    await this.setMeta(executionId, "updatedAt", String(completedAt));
+    await this.setMeta(executionId, "completedAt", String(completedAt));
 
     await this.releaseLock(executionId, token);
 
-    const response: WorkflowStartResult = {
-      executionId,
-      status: "completed",
-    };
-
-    return ok(response);
+    return { executionId, status: "completed" } satisfies WorkflowStartResult;
   }
 
   private async acquireLock(executionId: string, token: string) {
@@ -827,27 +418,23 @@ class WorkflowDefinition<TInput, TResult> {
     );
 
     if (lockError) {
-      return err(
-        "WorkflowLockError",
+      throw new LockError(
         `Unable to acquire lock for execution ${executionId}`,
       );
     }
 
     if (lockResult !== "OK") {
-      return err(
-        "WorkflowLockError",
+      throw new LockError(
         `Workflow execution ${executionId} is already running`,
       );
     }
-
-    return ok(null);
   }
 
   private async releaseLock(executionId: string, token: string) {
     const script =
       "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end";
 
-    const [evalError] = await mightThrow(
+    await mightThrow(
       this.options.redis.send("EVAL", [
         script,
         "1",
@@ -855,22 +442,13 @@ class WorkflowDefinition<TInput, TResult> {
         token,
       ]),
     );
-
-    if (evalError) {
-      return err(
-        "WorkflowLockError",
-        `Unable to release lock for execution ${executionId}`,
-      );
-    }
-
-    return ok(null);
   }
 
   private async extendLock(executionId: string, token: string) {
     const script =
       "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('PEXPIRE', KEYS[1], ARGV[2]) else return 0 end";
 
-    const [evalError, result] = await mightThrow(
+    const [evalError, extendResult] = await mightThrow(
       this.options.redis.send("EVAL", [
         script,
         "1",
@@ -881,30 +459,18 @@ class WorkflowDefinition<TInput, TResult> {
     );
 
     if (evalError) {
-      return err(
-        "WorkflowLockError",
-        `Unable to extend lock for execution ${executionId}`,
-      );
+      throw new LockError(`Unable to extend lock for execution ${executionId}`);
     }
 
-    if (result === 0) {
-      return err(
-        "WorkflowLockError",
-        `Lock ownership lost for execution ${executionId}`,
-      );
+    if (extendResult === 0) {
+      throw new LockError(`Lock ownership lost for execution ${executionId}`);
     }
-
-    return ok(null);
   }
 
   private async isCancelled(executionId: string) {
-    const [statusError, status] = await this.getMeta(executionId, "status");
+    const status = await this.getMeta(executionId, "status");
 
-    if (statusError) {
-      return err(statusError.type, statusError.message);
-    }
-
-    return ok(status === "cancelled");
+    return status === "cancelled";
   }
 
   private async setMeta(
@@ -917,13 +483,10 @@ class WorkflowDefinition<TInput, TResult> {
     );
 
     if (writeError) {
-      return err(
-        "WorkflowError",
+      throw new WorkflowError(
         `Unable to persist ${field} for execution ${executionId}`,
       );
     }
-
-    return ok(null);
   }
 
   private async getMeta(executionId: string, field: WorkflowMetaField) {
@@ -932,51 +495,44 @@ class WorkflowDefinition<TInput, TResult> {
     );
 
     if (readError) {
-      return err(
-        "WorkflowError",
+      throw new WorkflowError(
         `Unable to read ${field} for execution ${executionId}`,
       );
     }
 
     if (value === null || value === undefined) {
-      return ok(null);
+      return null;
     }
 
     if (typeof value !== "string") {
-      return err(
-        "WorkflowStateError",
+      throw new StateError(
         `Invalid ${field} value for execution ${executionId}`,
       );
     }
 
     if (value.length === 0) {
-      return ok(null);
+      return null;
     }
 
-    return ok(value);
+    return value;
   }
 
   private async readNumberMeta(executionId: string, field: WorkflowMetaField) {
-    const [readError, value] = await this.getMeta(executionId, field);
-
-    if (readError) {
-      return err(readError.type, readError.message);
-    }
+    const value = await this.getMeta(executionId, field);
 
     if (!value) {
-      return ok(null);
+      return null;
     }
 
     const parsed = Number(value);
 
     if (!Number.isFinite(parsed)) {
-      return err(
-        "WorkflowStateError",
+      throw new StateError(
         `Invalid ${field} value for execution ${executionId}`,
       );
     }
 
-    return ok(parsed);
+    return parsed;
   }
 
   private runSerializer<T>(
@@ -989,20 +545,16 @@ class WorkflowDefinition<TInput, TResult> {
     );
 
     if (serializeError) {
-      return err(
-        "WorkflowSerializationError",
+      throw new SerializationError(
         `Unable to serialize ${label}: ${toErrorMessage(serializeError)}`,
       );
     }
 
     if (typeof serialized !== "string") {
-      return err(
-        "WorkflowSerializationError",
-        `${label} serializer must return a string`,
-      );
+      throw new SerializationError(`${label} serializer must return a string`);
     }
 
-    return ok(serialized);
+    return serialized;
   }
 
   private runDeserializer<T>(
@@ -1010,16 +562,15 @@ class WorkflowDefinition<TInput, TResult> {
     deserializer: (v: string) => T,
     label: string,
   ) {
-    const [deserializeError, value] = mightThrowSync(() => deserializer(raw));
+    const result = mightThrowSync(() => deserializer(raw));
 
-    if (deserializeError) {
-      return err(
-        "WorkflowSerializationError",
-        `Unable to deserialize ${label}: ${toErrorMessage(deserializeError)}`,
+    if (result[0]) {
+      throw new SerializationError(
+        `Unable to deserialize ${label}: ${toErrorMessage(result[0])}`,
       );
     }
 
-    return ok(value);
+    return result[1];
   }
 
   private serializeInput(input: TInput) {
@@ -1040,7 +591,7 @@ class WorkflowDefinition<TInput, TResult> {
 
   private serializeResult(result: TResult | null) {
     if (result === null) {
-      return ok(envelopeSerialize(null));
+      return envelopeSerialize(null);
     }
 
     return this.runSerializer(
@@ -1075,40 +626,23 @@ class WorkflowDefinition<TInput, TResult> {
   }
 
   private async readInput(executionId: string) {
-    const [readError, raw] = await this.getMeta(executionId, "input");
-
-    if (readError) {
-      return err(readError.type, readError.message);
-    }
+    const raw = await this.getMeta(executionId, "input");
 
     if (!raw) {
-      return err(
-        "WorkflowStateError",
-        `Workflow execution ${executionId} input not found`,
-      );
+      throw new StateError(`Workflow execution ${executionId} input not found`);
     }
 
     return this.deserializeInput(raw);
   }
 
   private async readResult(executionId: string) {
-    const [readError, raw] = await this.getMeta(executionId, "result");
-
-    if (readError) {
-      return err(readError.type, readError.message);
-    }
+    const raw = await this.getMeta(executionId, "result");
 
     if (!raw) {
-      return ok(null);
+      return null;
     }
 
-    const [deserializeError, result] = this.deserializeResult(raw);
-
-    if (deserializeError) {
-      return err(deserializeError.type, deserializeError.message);
-    }
-
-    return ok(result);
+    return this.deserializeResult(raw);
   }
 
   private async writeStepOutput(
@@ -1116,14 +650,7 @@ class WorkflowDefinition<TInput, TResult> {
     stepName: string,
     output: unknown,
   ) {
-    const [serializeError, serializedOutput] = this.serializeStepOutput(output);
-
-    if (serializeError) {
-      return err(
-        "WorkflowSerializationError",
-        `Unable to serialize step ${stepName} output`,
-      );
-    }
+    const serializedOutput = this.serializeStepOutput(output);
 
     const payload = {
       output: serializedOutput,
@@ -1135,10 +662,7 @@ class WorkflowDefinition<TInput, TResult> {
     );
 
     if (payloadError || typeof payloadRaw !== "string") {
-      return err(
-        "WorkflowSerializationError",
-        `Unable to persist step ${stepName} output`,
-      );
+      throw new SerializationError(`Unable to persist step ${stepName} output`);
     }
 
     const [writeError] = await mightThrow(
@@ -1146,17 +670,12 @@ class WorkflowDefinition<TInput, TResult> {
     );
 
     if (writeError) {
-      return err(
-        "WorkflowError",
+      throw new WorkflowError(
         `Unable to persist step ${stepName} for execution ${executionId}`,
       );
     }
 
-    const [stepNamesError, stepNames] = await this.readStepNames(executionId);
-
-    if (stepNamesError) {
-      return err(stepNamesError.type, stepNamesError.message);
-    }
+    const stepNames = await this.readStepNames(executionId);
 
     if (!stepNames.includes(stepName)) {
       const nextStepNames = [...stepNames, stepName];
@@ -1166,34 +685,15 @@ class WorkflowDefinition<TInput, TResult> {
       );
 
       if (serializeStepsError || typeof serializedSteps !== "string") {
-        return err(
-          "WorkflowSerializationError",
+        throw new SerializationError(
           `Unable to persist step history for execution ${executionId}`,
         );
       }
 
-      const [updateStepsError] = await this.setMeta(
-        executionId,
-        "steps",
-        serializedSteps,
-      );
-
-      if (updateStepsError) {
-        return err(updateStepsError.type, updateStepsError.message);
-      }
+      await this.setMeta(executionId, "steps", serializedSteps);
     }
 
-    const [updatedError] = await this.setMeta(
-      executionId,
-      "updatedAt",
-      String(now()),
-    );
-
-    if (updatedError) {
-      return err(updatedError.type, updatedError.message);
-    }
-
-    return ok(null);
+    await this.setMeta(executionId, "updatedAt", String(now()));
   }
 
   private async readStepOutput<TStep>(executionId: string, stepName: string) {
@@ -1202,19 +702,17 @@ class WorkflowDefinition<TInput, TResult> {
     );
 
     if (readError) {
-      return err(
-        "WorkflowError",
+      throw new WorkflowError(
         `Unable to read step ${stepName} for execution ${executionId}`,
       );
     }
 
     if (!payloadRaw) {
-      return ok({ found: false, value: null });
+      return { found: false, value: null };
     }
 
     if (typeof payloadRaw !== "string") {
-      return err(
-        "WorkflowStateError",
+      throw new StateError(
         `Invalid step payload for ${stepName} in execution ${executionId}`,
       );
     }
@@ -1222,48 +720,35 @@ class WorkflowDefinition<TInput, TResult> {
     const [parseError, parsed] = mightThrowSync(() => JSON.parse(payloadRaw));
 
     if (parseError || parsed === null || typeof parsed !== "object") {
-      return err(
-        "WorkflowStateError",
+      throw new StateError(
         `Invalid step payload for ${stepName} in execution ${executionId}`,
       );
     }
 
     if (typeof parsed.output !== "string") {
-      return err(
-        "WorkflowStateError",
+      throw new StateError(
         `Invalid step output for ${stepName} in execution ${executionId}`,
       );
     }
 
     const outputRaw = parsed.output;
 
-    const [deserializeError, value] = this.deserializeStepOutput(outputRaw);
+    const value = this.deserializeStepOutput(outputRaw);
 
-    if (deserializeError) {
-      return err(deserializeError.type, deserializeError.message);
-    }
-
-    return ok({ found: true, value: value as TStep });
+    return { found: true, value: value as TStep };
   }
 
   private async readStepNames(executionId: string) {
-    const [readError, stepsRaw] = await this.getMeta(executionId, "steps");
-
-    if (readError) {
-      return [readError, []] as const;
-    }
+    const stepsRaw = await this.getMeta(executionId, "steps");
 
     if (!stepsRaw) {
-      return ok([] as string[]);
+      return [] as string[];
     }
 
     const [parseError, values] = mightThrowSync(() => JSON.parse(stepsRaw));
 
     if (parseError || !Array.isArray(values)) {
-      return err(
-        "WorkflowStateError",
-        `Invalid step index for execution ${executionId}`,
-      );
+      throw new StateError(`Invalid step index for execution ${executionId}`);
     }
 
     const stepNames: string[] = [];
@@ -1274,15 +759,11 @@ class WorkflowDefinition<TInput, TResult> {
       }
     }
 
-    return ok(stepNames);
+    return stepNames;
   }
 
   private async readStepSnapshots(executionId: string) {
-    const [stepNamesError, stepNames] = await this.readStepNames(executionId);
-
-    if (stepNamesError) {
-      return [stepNamesError, []] as const;
-    }
+    const stepNames = await this.readStepNames(executionId);
 
     const steps: StepSnapshot[] = [];
 
@@ -1292,8 +773,7 @@ class WorkflowDefinition<TInput, TResult> {
       );
 
       if (readError) {
-        return err(
-          "WorkflowError",
+        throw new WorkflowError(
           `Unable to read step ${stepName} for execution ${executionId}`,
         );
       }
@@ -1303,8 +783,7 @@ class WorkflowDefinition<TInput, TResult> {
       }
 
       if (typeof payloadRaw !== "string") {
-        return err(
-          "WorkflowStateError",
+        throw new StateError(
           `Invalid step payload for ${stepName} in execution ${executionId}`,
         );
       }
@@ -1312,28 +791,24 @@ class WorkflowDefinition<TInput, TResult> {
       const [parseError, parsed] = mightThrowSync(() => JSON.parse(payloadRaw));
 
       if (parseError || parsed === null || typeof parsed !== "object") {
-        return err(
-          "WorkflowStateError",
+        throw new StateError(
           `Invalid step payload for ${stepName} in execution ${executionId}`,
         );
       }
 
       if (typeof parsed.completedAt !== "number") {
-        return err(
-          "WorkflowStateError",
+        throw new StateError(
           `Invalid step payload for ${stepName} in execution ${executionId}`,
         );
       }
 
-      const completedAt = parsed.completedAt;
-
       steps.push({
         name: stepName,
-        completedAt,
+        completedAt: parsed.completedAt,
       });
     }
 
-    return ok(steps);
+    return steps;
   }
 
   private normalizeStatus(value: string) {
@@ -1361,10 +836,18 @@ export const defineWorkflow = <TInput, TResult = void>(
   };
 };
 
+export {
+  CancelledError,
+  ExecutionError,
+  LockError,
+  NotFoundError,
+  SerializationError,
+  StateError,
+  WorkflowError,
+} from "./errors.js";
 export type {
   StepHandler,
   Workflow,
-  WorkflowError,
   WorkflowExecution,
   WorkflowHandlerContext,
   WorkflowMeta,

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -5,20 +5,6 @@ export type WorkflowStatus =
   | "failed"
   | "cancelled";
 
-export type WorkflowErrorType =
-  | "WorkflowError"
-  | "WorkflowNotFoundError"
-  | "WorkflowStateError"
-  | "WorkflowSerializationError"
-  | "WorkflowLockError"
-  | "WorkflowExecutionError"
-  | "WorkflowCancelledError";
-
-export type WorkflowError = {
-  type: WorkflowErrorType;
-  message: string;
-};
-
 export type StepSnapshot = {
   name: string;
   completedAt: number;
@@ -108,20 +94,12 @@ export type Workflow<TInput, TResult> = {
   start: (
     input: TInput,
     options?: WorkflowStartOptions,
-  ) => Promise<readonly [WorkflowError | null, WorkflowStartResult | null]>;
+  ) => Promise<WorkflowStartResult>;
   run: (
     input: TInput,
     options?: WorkflowStartOptions,
-  ) => Promise<readonly [WorkflowError | null, TResult | null]>;
-  resume: (
-    executionId: string,
-  ) => Promise<readonly [WorkflowError | null, WorkflowStartResult | null]>;
-  get: (
-    executionId: string,
-  ) => Promise<
-    readonly [WorkflowError | null, WorkflowExecution<TInput, TResult> | null]
-  >;
-  cancel: (
-    executionId: string,
-  ) => Promise<readonly [WorkflowError | null, WorkflowCancelResult | null]>;
+  ) => Promise<TResult | null>;
+  resume: (executionId: string) => Promise<WorkflowStartResult>;
+  get: (executionId: string) => Promise<WorkflowExecution<TInput, TResult>>;
+  cancel: (executionId: string) => Promise<WorkflowCancelResult>;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * APIs now consistently throw errors on failure and return values directly, preventing unhandled/silent failures.

* **Documentation**
  * Examples and guides updated to use direct returns and try/catch/mightThrow patterns instead of result-tuple handling.

* **Chores**
  * Added and standardized error types across subsystems to unify exception-based behavior.

* **Tests**
  * Test suites updated to assert thrown errors and direct-return contracts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/leonardodipace/semola/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->