### PR TITLE
Add $or, $and and $not logic to where clauses

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -156,6 +156,14 @@ Boolean operators: `equals`
 
 JSON operators: `equals`
 
+Logical operators:
+
+- `$and`: all nested filters must match. Accepts a single `where` object or an array of `where` objects.
+- `$or`: at least one nested filter must match. Accepts an array of `where` objects.
+- `$not`: nested filters must not match. Accepts a single `where` object or an array of `where` objects.
+
+Logical operators can be nested recursively and can be combined with column filters at any level.
+
 ```typescript
 const users = await db.users.findMany({
   where: {
@@ -165,6 +173,26 @@ const users = await db.users.findMany({
   orderBy: { name: "desc" },
   take: 50,
   skip: 0,
+});
+```
+
+```typescript
+const users = await db.users.findMany({
+  where: {
+    active: true,
+    $or: [
+      { name: { contains: "Ada" } },
+      {
+        $and: [
+          { age: { gte: 18 } },
+          { createdAt: { gt: new Date("2025-01-01") } },
+        ],
+      },
+    ],
+    $not: {
+      email: { endsWith: "@example.test" },
+    },
+  },
 });
 ```
 
@@ -187,7 +215,9 @@ const users = await db.users.findMany({
 ```typescript
 const tasks = defineTable("tasks", {
   id: uuid("id").primaryKey().notNull(),
-  assigneeId: uuid("assignee_id").notNull(),
+  assigneeId: uuid("assignee_id")
+    .references(() => users.columns.id)
+    .notNull(),
   title: string("title").notNull(),
 });
 
@@ -211,6 +241,37 @@ const withTasks = await db.users.findMany({
 ```
 
 `include` produces SQL joins. Pass `true` to include a relation, omit or pass `false` to exclude it.
+
+You can also pass relation query options. Nested `include` is recursive, and every nested relation can define its own `where`, `orderBy`, `take`, `skip`, `select`, and `include`.
+
+```typescript
+const usersWithOpenTasks = await db.users.findMany({
+  where: {
+    active: true,
+  },
+  include: {
+    tasks: {
+      where: {
+        $or: [
+          { title: { contains: "release" } },
+          { title: { startsWith: "fix" } },
+        ],
+      },
+      orderBy: { title: "asc" },
+      take: 10,
+      select: { id: true, title: true },
+      include: {
+        assignee: {
+          where: {
+            $not: { active: false },
+          },
+          select: { id: true, name: true },
+        },
+      },
+    },
+  },
+});
+```
 
 ---
 

--- a/src/lib/orm/dialect/clauses.test.ts
+++ b/src/lib/orm/dialect/clauses.test.ts
@@ -68,6 +68,33 @@ describe("clauses", () => {
     ]);
   });
 
+  test("builds logical where clauses with nested params in order", () => {
+    const createdBefore = new Date("2025-02-01T00:00:00.000Z");
+    const createdAfter = new Date("2025-01-01T00:00:00.000Z");
+    const where = buildWhereClause({
+      nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+      table: usersTable,
+      where: {
+        firstName: { startsWith: "A" },
+        $or: [{ firstName: { contains: "da" } }, { isActive: false }],
+        $not: { createdAt: { lt: createdBefore } },
+        $and: [{ id: "u-1" }, { createdAt: { gte: createdAfter } }],
+      },
+    });
+
+    expect(where.sql).toBe(
+      '"first_name" LIKE ? ESCAPE \'\\\' AND (("first_name" LIKE ? ESCAPE \'\\\') OR ("is_active" = ?)) AND NOT (("created_at" < ?)) AND (("id" = ?) AND ("created_at" >= ?))',
+    );
+    expect(where.params).toEqual([
+      "A%",
+      "%da%",
+      false,
+      createdBefore.toISOString(),
+      "u-1",
+      createdAfter.toISOString(),
+    ]);
+  });
+
   test("handles direct equality, null, JSON columns, and enum values", () => {
     const eventsTable = defineTable("events", {
       id: uuid("id").primaryKey().notNull(),

--- a/src/lib/orm/dialect/clauses.test.ts
+++ b/src/lib/orm/dialect/clauses.test.ts
@@ -94,6 +94,35 @@ describe("clauses", () => {
     expect(where.params).toEqual([]);
   });
 
+  test("accepts $and and $not as single objects", () => {
+    const where = buildWhereClause({
+      nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+      table: usersTable,
+      where: {
+        $and: { id: "u-1", isActive: true },
+        $not: { firstName: "Blocked" },
+      },
+    });
+
+    expect(where.sql).toBe(
+      '(("id" = ? AND "is_active" = ?)) AND NOT (("first_name" = ?))',
+    );
+    expect(where.params).toEqual(["u-1", true, "Blocked"]);
+  });
+
+  test("negates each $not array entry separately", () => {
+    const where = buildWhereClause({
+      nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+      table: usersTable,
+      where: {
+        $not: [{ id: "u-1" }, { isActive: false }],
+      },
+    });
+
+    expect(where.sql).toBe('NOT (("id" = ?)) AND NOT (("is_active" = ?))');
+    expect(where.params).toEqual(["u-1", false]);
+  });
+
   test("builds logical where clauses with nested params in order", () => {
     const createdBefore = new Date("2025-02-01T00:00:00.000Z");
     const createdAfter = new Date("2025-01-01T00:00:00.000Z");
@@ -182,6 +211,32 @@ describe("clauses", () => {
         },
       }),
     ).toThrow("Unknown where operator: near for field firstName");
+  });
+
+  test("rejects invalid logical where values", () => {
+    expect(() =>
+      buildWhereClause({
+        nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+        table: usersTable,
+        where: {
+          // @ts-expect-error runtime guard
+          $or: { id: "u-1" },
+        },
+      }),
+    ).toThrow("$or where value must be an array");
+
+    expect(() =>
+      buildWhereClause({
+        nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+        table: usersTable,
+        where: {
+          $or: [
+            // @ts-expect-error runtime guard
+            "bad",
+          ],
+        },
+      }),
+    ).toThrow("$or where value must contain object filters");
   });
 
   test("builds order and pagination fragments", () => {

--- a/src/lib/orm/dialect/clauses.test.ts
+++ b/src/lib/orm/dialect/clauses.test.ts
@@ -68,6 +68,32 @@ describe("clauses", () => {
     ]);
   });
 
+  test("treats empty $or as unsatisfiable", () => {
+    const where = buildWhereClause({
+      nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+      table: usersTable,
+      where: {
+        $or: [],
+      },
+    });
+
+    expect(where.sql).toBe("(1 = 0)");
+    expect(where.params).toEqual([]);
+  });
+
+  test("treats tautological $or branches as always true", () => {
+    const where = buildWhereClause({
+      nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+      table: usersTable,
+      where: {
+        $or: [{}, { id: "u-1" }],
+      },
+    });
+
+    expect(where.sql).toBe("(1 = 1)");
+    expect(where.params).toEqual([]);
+  });
+
   test("builds logical where clauses with nested params in order", () => {
     const createdBefore = new Date("2025-02-01T00:00:00.000Z");
     const createdAfter = new Date("2025-01-01T00:00:00.000Z");

--- a/src/lib/orm/dialect/clauses.ts
+++ b/src/lib/orm/dialect/clauses.ts
@@ -223,7 +223,12 @@ export const buildWhereClause = <T extends Table>(
   for (const [jsKey, value] of Object.entries(where)) {
     if (value === undefined) continue;
 
-    if (jsKey === "$or" || jsKey === "$and" || jsKey === "$not") {
+    const isAnd = jsKey === "$and";
+    const isNot = jsKey === "$not";
+    const isOr = jsKey === "$or";
+    const isLogicalOperator = isAnd || isNot || isOr;
+
+    if (isLogicalOperator) {
       appendLogicalWhereClause({ ...input, clauses, params, jsKey, value });
       continue;
     }

--- a/src/lib/orm/dialect/clauses.ts
+++ b/src/lib/orm/dialect/clauses.ts
@@ -1,5 +1,5 @@
 import type { Column } from "../column/types.js";
-import type { TableOrderBy, TableSelect } from "../orm/types.js";
+import type { TableOrderBy, TableSelect, TableWhere } from "../orm/types.js";
 import type { Table } from "../table/types.js";
 import { quoteIdentifier } from "../utils.js";
 import type {
@@ -223,10 +223,79 @@ export const buildWhereClause = <T extends Table>(
   for (const [jsKey, value] of Object.entries(where)) {
     if (value === undefined) continue;
 
+    if (jsKey === "$or" || jsKey === "$and" || jsKey === "$not") {
+      appendLogicalWhereClause({ ...input, clauses, params, jsKey, value });
+      continue;
+    }
+
     appendWhereClause({ ...input, clauses, params, jsKey, value });
   }
 
   return { sql: clauses.join(" AND "), params };
+};
+
+const appendLogicalWhereClause = <T extends Table>(
+  input: BuildWhereClauseInput<T> & {
+    clauses: string[];
+    params: unknown[];
+    jsKey: "$or" | "$and" | "$not";
+    value: unknown;
+  },
+) => {
+  const { clauses, jsKey } = input;
+
+  const nestedClauses = collectLogicalWhereClauses(input);
+
+  if (!nestedClauses.length) return;
+
+  if (jsKey === "$not") {
+    clauses.push(
+      nestedClauses
+        .map((nestedClause) => `NOT (${nestedClause})`)
+        .join(" AND "),
+    );
+
+    return;
+  }
+
+  const operator = jsKey === "$or" ? "OR" : "AND";
+
+  clauses.push(`(${nestedClauses.join(` ${operator} `)})`);
+};
+
+const collectLogicalWhereClauses = <T extends Table>(
+  input: BuildWhereClauseInput<T> & {
+    params: unknown[];
+    jsKey: "$or" | "$and" | "$not";
+    value: unknown;
+  },
+) => {
+  const { params, jsKey, value } = input;
+
+  if (jsKey === "$or" && !Array.isArray(value)) {
+    throw new Error("$or where value must be an array");
+  }
+
+  const values = Array.isArray(value) ? value : [value];
+  const nestedClauses: string[] = [];
+
+  for (const nestedValue of values) {
+    if (!isPlainObject(nestedValue)) {
+      throw new Error(`${jsKey} where value must contain object filters`);
+    }
+
+    const nested = buildWhereClause({
+      ...input,
+      where: nestedValue as TableWhere<T>,
+    });
+
+    if (!nested.sql) continue;
+
+    nestedClauses.push(`(${nested.sql})`);
+    params.push(...nested.params);
+  }
+
+  return nestedClauses;
 };
 
 const getColumnAlias = (sqlName: string, jsKey: string) => {

--- a/src/lib/orm/dialect/clauses.ts
+++ b/src/lib/orm/dialect/clauses.ts
@@ -9,6 +9,10 @@ import type {
   BuildWhereClauseInput,
   DialectSpec,
   IncludeClause,
+  LogicalJoinOperator,
+  LogicalNotOperator,
+  LogicalWhereJoinKey,
+  LogicalWhereKey,
   SqlFragment,
 } from "./types.js";
 
@@ -223,27 +227,58 @@ export const buildWhereClause = <T extends Table>(
   for (const [jsKey, value] of Object.entries(where)) {
     if (value === undefined) continue;
 
-    const isAnd = jsKey === "$and";
-    const isNot = jsKey === "$not";
-    const isOr = jsKey === "$or";
-    const isLogicalOperator = isAnd || isNot || isOr;
+    const logicalWhereKey = getLogicalWhereKey(jsKey);
 
-    if (isLogicalOperator) {
-      appendLogicalWhereClause({ ...input, clauses, params, jsKey, value });
+    if (logicalWhereKey) {
+      appendLogicalWhereClause({
+        ...input,
+        clauses,
+        params,
+        jsKey: logicalWhereKey,
+        value,
+      });
       continue;
     }
 
     appendWhereClause({ ...input, clauses, params, jsKey, value });
   }
 
-  return { sql: clauses.join(" AND "), params };
+  const operator: LogicalJoinOperator = "AND";
+
+  return { sql: clauses.join(` ${operator} `), params };
+};
+
+const getLogicalWhereKey = (jsKey: string): LogicalWhereKey | null => {
+  if (jsKey === "$and") return jsKey;
+  if (jsKey === "$not") return jsKey;
+  if (jsKey === "$or") return jsKey;
+
+  return null;
+};
+
+const getLogicalOperator = (
+  jsKey: LogicalWhereJoinKey,
+): LogicalJoinOperator => {
+  if (jsKey === "$or") return "OR";
+
+  return "AND";
+};
+
+const getLogicalWhereValues = (jsKey: LogicalWhereKey, value: unknown) => {
+  if (jsKey === "$or" && !Array.isArray(value)) {
+    throw new Error("$or where value must be an array");
+  }
+
+  if (Array.isArray(value)) return value;
+
+  return [value];
 };
 
 const appendLogicalWhereClause = <T extends Table>(
   input: BuildWhereClauseInput<T> & {
     clauses: string[];
     params: unknown[];
-    jsKey: "$or" | "$and" | "$not";
+    jsKey: LogicalWhereKey;
     value: unknown;
   },
 ) => {
@@ -254,16 +289,19 @@ const appendLogicalWhereClause = <T extends Table>(
   if (!nestedClauses.length) return;
 
   if (jsKey === "$not") {
-    clauses.push(
-      nestedClauses
-        .map((nestedClause) => `NOT (${nestedClause})`)
-        .join(" AND "),
+    const operator: LogicalNotOperator = "NOT";
+    const joinOperator: LogicalJoinOperator = "AND";
+    const negatedClauses = nestedClauses.map(
+      (nestedClause) => `${operator} (${nestedClause})`,
     );
+    const combinedNegatedClause = negatedClauses.join(` ${joinOperator} `);
+
+    clauses.push(combinedNegatedClause);
 
     return;
   }
 
-  const operator = jsKey === "$or" ? "OR" : "AND";
+  const operator = getLogicalOperator(jsKey);
 
   clauses.push(`(${nestedClauses.join(` ${operator} `)})`);
 };
@@ -271,17 +309,13 @@ const appendLogicalWhereClause = <T extends Table>(
 const collectLogicalWhereClauses = <T extends Table>(
   input: BuildWhereClauseInput<T> & {
     params: unknown[];
-    jsKey: "$or" | "$and" | "$not";
+    jsKey: LogicalWhereKey;
     value: unknown;
   },
 ) => {
   const { params, jsKey, value } = input;
 
-  if (jsKey === "$or" && !Array.isArray(value)) {
-    throw new Error("$or where value must be an array");
-  }
-
-  const values = Array.isArray(value) ? value : [value];
+  const values = getLogicalWhereValues(jsKey, value);
   const nestedClauses: string[] = [];
 
   for (const nestedValue of values) {
@@ -312,9 +346,12 @@ export const buildSelectColumns = <T extends Table>(
   select?: TableSelect<T>,
 ) => {
   if (!select || Object.keys(select).length === 0) {
-    return Object.entries(table.columns)
-      .map(([k, col]) => getColumnAlias(col.sqlName, k))
-      .join(", ");
+    const columnEntries = Object.entries(table.columns);
+    const columnAliases = columnEntries.map(([key, column]) =>
+      getColumnAlias(column.sqlName, key),
+    );
+
+    return columnAliases.join(", ");
   }
 
   const selectedColumns: string[] = [];

--- a/src/lib/orm/dialect/clauses.ts
+++ b/src/lib/orm/dialect/clauses.ts
@@ -3,10 +3,16 @@ import type { TableOrderBy, TableSelect, TableWhere } from "../orm/types.js";
 import type { Table } from "../table/types.js";
 import { quoteIdentifier } from "../utils.js";
 import type {
+  AppendDirectWhereClauseInput,
+  AppendLogicalWhereClauseInput,
+  AppendOperatorWhereClausesInput,
+  AppendWhereClauseInput,
   BuildPaginationClauseInput,
   BuildSelectStatementInput,
   BuildSetClausesInput,
   BuildWhereClauseInput,
+  CollectedLogicalWhere,
+  CollectLogicalWhereClausesInput,
   DialectSpec,
   IncludeClause,
   LogicalJoinOperator,
@@ -16,15 +22,9 @@ import type {
   SqlFragment,
 } from "./types.js";
 
-export const createNextPlaceholder = (spec: DialectSpec) => {
-  let index = 0;
+const FALSE_WHERE_SQL = "(1 = 0)";
 
-  return () => {
-    index += 1;
-
-    return spec.formatPlaceholder(index);
-  };
-};
+const TRUE_WHERE_SQL = "(1 = 1)";
 
 export const EMPTY_INCLUDE: IncludeClause = {
   sql: "",
@@ -32,25 +32,10 @@ export const EMPTY_INCLUDE: IncludeClause = {
   descriptors: [],
 };
 
-export const buildSelectList = (columns: string, include: IncludeClause) => {
-  if (include.sql) return `${columns}, ${include.sql}`;
-
-  return columns;
-};
-
 const serializeParam = (value: unknown) => {
   if (value instanceof Date) return value.toISOString();
 
   return value;
-};
-
-export const serializeColumnValue = (column: Column, value: unknown) => {
-  if (column.type !== "json" && column.type !== "jsonb")
-    return serializeParam(value);
-  if (value === null) return value;
-  if (value === undefined) return null;
-
-  return JSON.stringify(value);
 };
 
 const escapeLikeValue = (value: unknown) => {
@@ -97,6 +82,31 @@ const OPERATORS = {
   },
 } as const;
 
+export const createNextPlaceholder = (spec: DialectSpec) => {
+  let index = 0;
+
+  return () => {
+    index += 1;
+
+    return spec.formatPlaceholder(index);
+  };
+};
+
+export const buildSelectList = (columns: string, include: IncludeClause) => {
+  if (include.sql) return `${columns}, ${include.sql}`;
+
+  return columns;
+};
+
+export const serializeColumnValue = (column: Column, value: unknown) => {
+  if (column.type !== "json" && column.type !== "jsonb")
+    return serializeParam(value);
+  if (value === null) return value;
+  if (value === undefined) return null;
+
+  return JSON.stringify(value);
+};
+
 const isPlainObject = (value: unknown) => {
   if (value === null) return false;
 
@@ -115,14 +125,7 @@ const isPlainObject = (value: unknown) => {
   return false;
 };
 
-const appendDirectWhereClause = (input: {
-  clauses: string[];
-  params: unknown[];
-  nextPlaceholder: () => string;
-  column: Column;
-  sqlName: string;
-  value: unknown;
-}) => {
+const appendDirectWhereClause = (input: AppendDirectWhereClauseInput) => {
   const { clauses, params, nextPlaceholder, column, sqlName, value } = input;
 
   if (value === null) {
@@ -134,15 +137,7 @@ const appendDirectWhereClause = (input: {
   params.push(serializeColumnValue(column, value));
 };
 
-const appendOperatorWhereClauses = (input: {
-  clauses: string[];
-  params: unknown[];
-  nextPlaceholder: () => string;
-  column: Column;
-  sqlName: string;
-  jsKey: string;
-  value: Record<string, unknown>;
-}) => {
+const appendOperatorWhereClauses = (input: AppendOperatorWhereClausesInput) => {
   const { clauses, params, nextPlaceholder, column, sqlName, jsKey, value } =
     input;
 
@@ -170,12 +165,7 @@ const appendOperatorWhereClauses = (input: {
 };
 
 const appendWhereClause = <T extends Table>(
-  input: BuildWhereClauseInput<T> & {
-    clauses: string[];
-    params: unknown[];
-    jsKey: string;
-    value: unknown;
-  },
+  input: AppendWhereClauseInput<T>,
 ) => {
   const { clauses, params, nextPlaceholder, table, jsKey, value } = input;
 
@@ -275,23 +265,25 @@ const getLogicalWhereValues = (jsKey: LogicalWhereKey, value: unknown) => {
 };
 
 const appendLogicalWhereClause = <T extends Table>(
-  input: BuildWhereClauseInput<T> & {
-    clauses: string[];
-    params: unknown[];
-    jsKey: LogicalWhereKey;
-    value: unknown;
-  },
+  input: AppendLogicalWhereClauseInput<T>,
 ) => {
-  const { clauses, jsKey } = input;
+  const { clauses, params, jsKey } = input;
 
-  const nestedClauses = collectLogicalWhereClauses(input);
+  const collected = collectLogicalWhereClauses(input);
 
-  if (!nestedClauses.length) return;
+  if (typeof collected === "string") {
+    clauses.push(collected);
+    return;
+  }
+
+  if (!collected.nestedClauses.length) return;
+
+  params.push(...collected.nestedParams);
 
   if (jsKey === "$not") {
     const operator: LogicalNotOperator = "NOT";
     const joinOperator: LogicalJoinOperator = "AND";
-    const negatedClauses = nestedClauses.map(
+    const negatedClauses = collected.nestedClauses.map(
       (nestedClause) => `${operator} (${nestedClause})`,
     );
     const combinedNegatedClause = negatedClauses.join(` ${joinOperator} `);
@@ -303,20 +295,17 @@ const appendLogicalWhereClause = <T extends Table>(
 
   const operator = getLogicalOperator(jsKey);
 
-  clauses.push(`(${nestedClauses.join(` ${operator} `)})`);
+  clauses.push(`(${collected.nestedClauses.join(` ${operator} `)})`);
 };
 
 const collectLogicalWhereClauses = <T extends Table>(
-  input: BuildWhereClauseInput<T> & {
-    params: unknown[];
-    jsKey: LogicalWhereKey;
-    value: unknown;
-  },
-) => {
-  const { params, jsKey, value } = input;
+  input: CollectLogicalWhereClausesInput<T>,
+): CollectedLogicalWhere => {
+  const { jsKey, value } = input;
 
   const values = getLogicalWhereValues(jsKey, value);
   const nestedClauses: string[] = [];
+  const nestedParams: unknown[] = [];
 
   for (const nestedValue of values) {
     if (!isPlainObject(nestedValue)) {
@@ -328,13 +317,19 @@ const collectLogicalWhereClauses = <T extends Table>(
       where: nestedValue as TableWhere<T>,
     });
 
-    if (!nested.sql) continue;
+    if (!nested.sql) {
+      if (jsKey === "$or") return TRUE_WHERE_SQL;
+
+      continue;
+    }
 
     nestedClauses.push(`(${nested.sql})`);
-    params.push(...nested.params);
+    nestedParams.push(...nested.params);
   }
 
-  return nestedClauses;
+  if (jsKey === "$or" && !nestedClauses.length) return FALSE_WHERE_SQL;
+
+  return { nestedClauses, nestedParams };
 };
 
 const getColumnAlias = (sqlName: string, jsKey: string) => {

--- a/src/lib/orm/dialect/postgres.test.ts
+++ b/src/lib/orm/dialect/postgres.test.ts
@@ -44,6 +44,26 @@ describe("postgres dialect", () => {
     expect(query.params).toEqual(["Jo%", createdAfter.toISOString(), 5]);
   });
 
+  test("numbers placeholders through logical where clauses", () => {
+    const builder = new DialectQueryBuilder({
+      spec: POSTGRES_SPEC,
+      table: usersTable,
+      relations: {},
+    });
+    const createdAfter = new Date("2025-01-01T00:00:00.000Z");
+    const query = builder.buildFindMany({
+      where: {
+        $or: [{ firstName: { startsWith: "Jo" } }, { isActive: false }],
+        $not: { createdAt: { lt: createdAfter } },
+      },
+    });
+
+    expect(query.statement).toBe(
+      'SELECT "id" AS "id", "first_name" AS "firstName", "created_at" AS "createdAt", "is_active" AS "isActive" FROM "users" WHERE (("first_name" LIKE $1 ESCAPE \'\\\') OR ("is_active" = $2)) AND NOT (("created_at" < $3))',
+    );
+    expect(query.params).toEqual(["Jo%", false, createdAfter.toISOString()]);
+  });
+
   test("uses jsonb functions for hasMany and hasOne includes", () => {
     const usersBuilder = new DialectQueryBuilder({
       spec: POSTGRES_SPEC,

--- a/src/lib/orm/dialect/postgres.test.ts
+++ b/src/lib/orm/dialect/postgres.test.ts
@@ -44,6 +44,24 @@ describe("postgres dialect", () => {
     expect(query.params).toEqual(["Jo%", createdAfter.toISOString(), 5]);
   });
 
+  test("uses unsatisfiable sql for empty $or", () => {
+    const builder = new DialectQueryBuilder({
+      spec: POSTGRES_SPEC,
+      table: usersTable,
+      relations: {},
+    });
+    const query = builder.buildFindMany({
+      where: {
+        $or: [],
+      },
+    });
+
+    expect(query.statement).toBe(
+      'SELECT "id" AS "id", "first_name" AS "firstName", "created_at" AS "createdAt", "is_active" AS "isActive" FROM "users" WHERE (1 = 0)',
+    );
+    expect(query.params).toEqual([]);
+  });
+
   test("numbers placeholders through logical where clauses", () => {
     const builder = new DialectQueryBuilder({
       spec: POSTGRES_SPEC,

--- a/src/lib/orm/dialect/relations.test.ts
+++ b/src/lib/orm/dialect/relations.test.ts
@@ -71,6 +71,31 @@ describe("relations", () => {
     );
   });
 
+  test("builds include SQL with logical where clauses", () => {
+    const include = buildIncludeClause({
+      spec: SQLITE_SPEC,
+      nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+      table: usersTable,
+      parentAlias: '"users"',
+      relations: { posts: many(() => postsTable) },
+      tableRelationsMap: new Map(),
+      include: {
+        posts: {
+          where: {
+            $or: [
+              { title: { contains: "release" } },
+              { title: { startsWith: "fix" } },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(include.sql).toContain(" OR ");
+    expect(include.sql).toContain("LIKE ? ESCAPE");
+    expect(include.params).toEqual(["%release%", "fix%"]);
+  });
+
   test("ignores disabled include flags", () => {
     const include = buildIncludeClause({
       spec: SQLITE_SPEC,

--- a/src/lib/orm/dialect/sqlite.test.ts
+++ b/src/lib/orm/dialect/sqlite.test.ts
@@ -210,6 +210,94 @@ describe("sqlite dialect", () => {
     await sql.close();
   });
 
+  test("findMany filters rows with logical where clauses", async () => {
+    const sql = createMemorySql();
+
+    await createUsersTable(sql);
+    await insertUser(sql, "user-1", "John", "2025-01-01T00:00:00.000Z", true);
+    await insertUser(sql, "user-2", "Jane", "2025-01-02T00:00:00.000Z", false);
+    await insertUser(sql, "user-3", "Joao", "2025-01-03T00:00:00.000Z", true);
+
+    const dialect = createSqliteDialect({ table: usersTable, relations: {} });
+    const rows = await dialect.findMany(sql, {
+      where: {
+        $or: [{ firstName: { startsWith: "Jo" } }, { isActive: false }],
+        $not: { firstName: "Jane" },
+      },
+      orderBy: { id: "asc" },
+    });
+
+    expect(rows.map((row) => row.id)).toEqual(["user-1", "user-3"]);
+
+    await sql.close();
+  });
+
+  test("updateMany and deleteMany with empty $or affect no rows", async () => {
+    const sql = createMemorySql();
+
+    await createUsersTable(sql);
+    await insertUser(sql, "user-1", "Ada", "2025-01-01T00:00:00.000Z");
+    await insertUser(sql, "user-2", "Grace", "2025-01-02T00:00:00.000Z");
+
+    const dialect = createSqliteDialect({ table: usersTable, relations: {} });
+    const updatedMany = await dialect.updateMany(sql, {
+      where: { $or: [] },
+      data: { firstName: "Changed" },
+    });
+    const deletedMany = await dialect.deleteMany(sql, {
+      where: { $or: [] },
+    });
+    const rows = await dialect.findMany(sql, {
+      orderBy: { firstName: "asc" },
+    });
+
+    expect(updatedMany).toHaveLength(0);
+    expect(deletedMany).toHaveLength(0);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.firstName).toBe("Ada");
+    expect(rows[1]?.firstName).toBe("Grace");
+
+    await sql.close();
+  });
+
+  test("findMany applies logical where clauses in nested includes", async () => {
+    const sql = createMemorySql();
+
+    await createUsersTable(sql);
+    await createPostsTable(sql);
+    await insertUser(sql, "user-1", "Ada", "2025-01-01T00:00:00.000Z");
+    await insertPost(sql, "post-1", "Hello", "user-1");
+    await insertPost(sql, "post-2", "World", "user-1");
+    await insertPost(sql, "post-3", "release notes", "user-1");
+
+    const dialect = createSqliteDialect({
+      table: usersTable,
+      relations: { posts: many(() => postsTable) },
+    });
+    const rows = await dialect.findMany(sql, {
+      where: { id: "user-1" },
+      include: {
+        posts: {
+          where: {
+            $or: [
+              { title: { contains: "release" } },
+              { title: { startsWith: "Hello" } },
+            ],
+          },
+          orderBy: { title: "asc" },
+        },
+      },
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.posts?.map((post) => post.title)).toEqual([
+      "Hello",
+      "release notes",
+    ]);
+
+    await sql.close();
+  });
+
   test("hasOne includes execute and return null when missing", async () => {
     const sql = createMemorySql();
 

--- a/src/lib/orm/dialect/types.ts
+++ b/src/lib/orm/dialect/types.ts
@@ -59,6 +59,51 @@ export type LogicalJoinOperator = Exclude<LogicalSqlOperator, "NOT">;
 
 export type LogicalNotOperator = Extract<LogicalSqlOperator, "NOT">;
 
+export type CollectedLogicalWhere =
+  | { nestedClauses: string[]; nestedParams: unknown[] }
+  | string;
+
+export type AppendDirectWhereClauseInput = {
+  clauses: string[];
+  params: unknown[];
+  nextPlaceholder: () => string;
+  column: Column;
+  sqlName: string;
+  value: unknown;
+};
+
+export type AppendOperatorWhereClausesInput = {
+  clauses: string[];
+  params: unknown[];
+  nextPlaceholder: () => string;
+  column: Column;
+  sqlName: string;
+  jsKey: string;
+  value: Record<string, unknown>;
+};
+
+export type AppendWhereClauseInput<T extends Table> =
+  BuildWhereClauseInput<T> & {
+    clauses: string[];
+    params: unknown[];
+    jsKey: string;
+    value: unknown;
+  };
+
+export type AppendLogicalWhereClauseInput<T extends Table> =
+  BuildWhereClauseInput<T> & {
+    clauses: string[];
+    params: unknown[];
+    jsKey: LogicalWhereKey;
+    value: unknown;
+  };
+
+export type CollectLogicalWhereClausesInput<T extends Table> =
+  BuildWhereClauseInput<T> & {
+    jsKey: LogicalWhereKey;
+    value: unknown;
+  };
+
 export type IncludeDescriptor = {
   name: string;
   type: "hasMany" | "hasOne";

--- a/src/lib/orm/dialect/types.ts
+++ b/src/lib/orm/dialect/types.ts
@@ -49,6 +49,16 @@ export type SqlFragment = {
   params: unknown[];
 };
 
+export type LogicalWhereKey = "$and" | "$not" | "$or";
+
+export type LogicalWhereJoinKey = Exclude<LogicalWhereKey, "$not">;
+
+export type LogicalSqlOperator = "AND" | "NOT" | "OR";
+
+export type LogicalJoinOperator = Exclude<LogicalSqlOperator, "NOT">;
+
+export type LogicalNotOperator = Extract<LogicalSqlOperator, "NOT">;
+
 export type IncludeDescriptor = {
   name: string;
   type: "hasMany" | "hasOne";

--- a/src/lib/orm/orm/index.test.ts
+++ b/src/lib/orm/orm/index.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { date, enumType, string, uuid } from "../column/index.js";
+import type { Column } from "../column/types.js";
 import { defineTable } from "../table/index.js";
+import type { Table } from "../table/types.js";
 import { createOrm, many, one } from "./index.js";
 
 const usersTable = defineTable("users", {
@@ -45,6 +47,23 @@ const seedTwoUsers = async (sql: Bun.SQL) => {
     "bob@example.com",
   ]);
 };
+
+type TableWithId = Table<{ id: Column }>;
+
+const defineStudentsToExamsTable = (
+  studentTable: TableWithId,
+  examsTable: TableWithId,
+) =>
+  defineTable("students_to_exams", {
+    studentId: uuid("student_id")
+      .primaryKey()
+      .notNull()
+      .references(() => studentTable.columns.id),
+    examId: uuid("exam_id")
+      .primaryKey()
+      .notNull()
+      .references(() => examsTable.columns.id),
+  });
 
 describe("relation helpers", () => {
   test("many() returns a hasMany descriptor", () => {
@@ -1056,16 +1075,10 @@ describe("many to many relation", () => {
       name: string("name").notNull(),
     });
 
-    const studentsToExamsTable = defineTable("students_to_exams", {
-      studentId: uuid("student_id")
-        .primaryKey()
-        .notNull()
-        .references(() => studentTable.columns.id),
-      examId: uuid("exam_id")
-        .primaryKey()
-        .notNull()
-        .references(() => examsTable.columns.id),
-    });
+    const studentsToExamsTable = defineStudentsToExamsTable(
+      studentTable,
+      examsTable,
+    );
 
     const orm = createOrm({
       adapter: "sqlite",
@@ -1199,16 +1212,10 @@ describe("many to many relation", () => {
       name: string("name").notNull(),
     });
 
-    const studentsToExamsTable = defineTable("students_to_exams", {
-      studentId: uuid("student_id")
-        .primaryKey()
-        .notNull()
-        .references(() => studentTable.columns.id),
-      examId: uuid("exam_id")
-        .primaryKey()
-        .notNull()
-        .references(() => examsTable.columns.id),
-    });
+    const studentsToExamsTable = defineStudentsToExamsTable(
+      studentTable,
+      examsTable,
+    );
 
     const orm = createOrm({
       adapter: "sqlite",

--- a/src/lib/orm/orm/index.test.ts
+++ b/src/lib/orm/orm/index.test.ts
@@ -208,6 +208,8 @@ describe("relation helpers", () => {
         name: {
           startsWith: "J",
         },
+        $or: [{ email: { endsWith: "@example.com" } }, { name: "Jane" }],
+        $not: { name: "Blocked" },
       },
       orderBy: {
         name: "asc",
@@ -699,9 +701,14 @@ describe("nested include options", () => {
     const orm = createOrmWithPosts();
 
     const _valid: Parameters<typeof orm.users.findMany>[0] = {
+      where: {
+        $and: [{ name: { contains: "Jo" } }],
+      },
       include: {
         posts: {
-          where: { title: "Hello" },
+          where: {
+            $or: [{ title: "Hello" }, { content: { contains: "World" } }],
+          },
           orderBy: { title: "asc" },
           take: 5,
           skip: 0,
@@ -714,8 +721,12 @@ describe("nested include options", () => {
       include: {
         posts: {
           where: {
-            // @ts-expect-error "badCol" is not a column on posts
-            badCol: "x",
+            $or: [
+              {
+                // @ts-expect-error "badCol" is not a column on posts
+                badCol: "x",
+              },
+            ],
           },
         },
       },

--- a/src/lib/orm/orm/types.ts
+++ b/src/lib/orm/orm/types.ts
@@ -151,7 +151,13 @@ type ColumnWhere<T extends Column> =
     ? ColumnWhereOperators<T>
     : ColumnValue<T> | ColumnWhereOperators<T>;
 
-export type TableWhere<T extends Table> = {
+type TableLogicalWhere<T extends Table> = {
+  [TKey in "$or"]?: TableWhere<T>[];
+} & {
+  [TKey in "$and" | "$not"]?: TableWhere<T> | TableWhere<T>[];
+};
+
+export type TableWhere<T extends Table> = TableLogicalWhere<T> & {
   [TColumnName in keyof T["columns"]]?: ColumnWhere<T["columns"][TColumnName]>;
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for logical operators (`$or`, `$and`, `$not`) in `where` clauses, including nested combinations and correct SQL parenthesization/parameter ordering.
  * Ensures edge cases like empty `$or` behave deterministically (e.g., yield unsatisfiable/always-true predicates as appropriate).
* **Bug Fixes**
  * Improved handling of logical filters inside included relations’ `where` clauses.
* **Documentation**
  * Updated ORM docs with examples for logical operators and richer relation query options.
* **Tests**
  * Expanded Bun test coverage across SQL dialects to validate generated SQL and bound parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->