### PR TITLE
Add `in` and `notIn` operators to where clauses

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -148,13 +148,15 @@ const deletedUsers = await db.users.deleteMany({
 
 Pass a direct value for equality or an operator object for other comparisons.
 
-String operators: `equals`, `startsWith`, `endsWith`, `contains`
+String operators: `equals`, `startsWith`, `endsWith`, `contains`, `in`, `notIn`
 
-Number and date operators: `equals`, `gt`, `gte`, `lt`, `lte`
+Number and date operators: `equals`, `gt`, `gte`, `lt`, `lte`, `in`, `notIn`
 
-Boolean operators: `equals`
+Boolean operators: `equals`, `in`, `notIn`
 
-JSON operators: `equals`
+Enum operators: `equals`, `in`, `notIn`
+
+JSON operators: `equals`, `in`, `notIn`
 
 Logical operators:
 

--- a/src/lib/orm/dialect/clauses.test.ts
+++ b/src/lib/orm/dialect/clauses.test.ts
@@ -216,6 +216,128 @@ describe("clauses", () => {
     expect(nullWhere.params).toEqual([]);
   });
 
+  test("builds in and notIn operators with serialization", () => {
+    const createdAt = new Date("2025-01-01T00:00:00.000Z");
+    const where = buildWhereClause({
+      nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+      table: usersTable,
+      where: {
+        id: { in: ["u-1", "u-2", "u-3"] },
+        firstName: { notIn: ["Blocked", "Deleted"] },
+        createdAt: { in: [createdAt] },
+        isActive: { notIn: [false] },
+      },
+    });
+
+    expect(where.sql).toBe(
+      '"id" IN (?, ?, ?) AND "first_name" NOT IN (?, ?) AND "created_at" IN (?) AND "is_active" NOT IN (?)',
+    );
+    expect(where.params).toEqual([
+      "u-1",
+      "u-2",
+      "u-3",
+      "Blocked",
+      "Deleted",
+      createdAt.toISOString(),
+      false,
+    ]);
+  });
+
+  test("builds in and notIn for enum and json columns", () => {
+    const eventsTable = defineTable("events", {
+      id: uuid("id").primaryKey().notNull(),
+      status: enumType("status", ["active", "inactive"]).notNull(),
+      payload: json("payload").notNull(),
+      meta: jsonb("meta").notNull(),
+    });
+    const payload = { type: "click" };
+    const meta = { source: "web" };
+    const where = buildWhereClause({
+      nextPlaceholder: createNextPlaceholder(POSTGRES_SPEC),
+      table: eventsTable,
+      where: {
+        status: { in: ["active", "inactive"], notIn: ["inactive"] },
+        payload: { in: [payload] },
+        meta: { notIn: [meta] },
+      },
+    });
+
+    expect(where.sql).toBe(
+      '"status" IN ($1, $2) AND "status" NOT IN ($3) AND "payload" IN ($4) AND "meta" NOT IN ($5)',
+    );
+    expect(where.params).toEqual([
+      "active",
+      "inactive",
+      "inactive",
+      JSON.stringify(payload),
+      JSON.stringify(meta),
+    ]);
+  });
+
+  test("treats empty in as unsatisfiable and empty notIn as a no-op", () => {
+    const emptyIn = buildWhereClause({
+      nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+      table: usersTable,
+      where: {
+        id: { in: [] },
+      },
+    });
+
+    expect(emptyIn.sql).toBe("(1 = 0)");
+    expect(emptyIn.params).toEqual([]);
+
+    const emptyNotIn = buildWhereClause({
+      nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+      table: usersTable,
+      where: {
+        id: { notIn: [] },
+      },
+    });
+
+    expect(emptyNotIn.sql).toBe("");
+    expect(emptyNotIn.params).toEqual([]);
+
+    const combined = buildWhereClause({
+      nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+      table: usersTable,
+      where: {
+        id: "u-1",
+        firstName: { notIn: [] },
+      },
+    });
+
+    expect(combined.sql).toBe('"id" = ?');
+    expect(combined.params).toEqual(["u-1"]);
+  });
+
+  test("rejects non-array operands for in and notIn", () => {
+    expect(() =>
+      buildWhereClause({
+        nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+        table: usersTable,
+        where: {
+          id: {
+            // @ts-expect-error runtime guard
+            in: "u-1",
+          },
+        },
+      }),
+    ).toThrow("Expected array for where operator: in for field id");
+
+    expect(() =>
+      buildWhereClause({
+        nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+        table: usersTable,
+        where: {
+          id: {
+            // @ts-expect-error runtime guard
+            notIn: "u-1",
+          },
+        },
+      }),
+    ).toThrow("Expected array for where operator: notIn for field id");
+  });
+
   test("rejects unknown where keys and operators", () => {
     expect(() =>
       buildWhereClause({

--- a/src/lib/orm/dialect/clauses.ts
+++ b/src/lib/orm/dialect/clauses.ts
@@ -148,6 +148,34 @@ const appendOperatorWhereClauses = (input: AppendOperatorWhereClausesInput) => {
   }
 
   for (const [op, operand] of entries) {
+    if (op === "in" || op === "notIn") {
+      if (!Array.isArray(operand)) {
+        throw new Error(
+          `Expected array for where operator: ${op} for field ${jsKey}`,
+        );
+      }
+
+      if (op === "in" && operand.length === 0) {
+        clauses.push(FALSE_WHERE_SQL);
+        continue;
+      }
+
+      if (op === "notIn" && operand.length === 0) {
+        continue;
+      }
+
+      const placeholders = operand.map(() => nextPlaceholder());
+      const keyword = op === "in" ? "IN" : "NOT IN";
+
+      clauses.push(`${sqlName} ${keyword} (${placeholders.join(", ")})`);
+
+      for (const item of operand) {
+        params.push(serializeColumnValue(column, item));
+      }
+
+      continue;
+    }
+
     const operator = OPERATORS[op as keyof typeof OPERATORS];
 
     if (!operator) {

--- a/src/lib/orm/orm/index.test.ts
+++ b/src/lib/orm/orm/index.test.ts
@@ -293,13 +293,38 @@ describe("relation helpers", () => {
     const invalidWhereOperator: Parameters<typeof orm.users.findMany>[0] = {
       where: {
         status: {
-          // @ts-expect-error enumType supports equals only
+          // @ts-expect-error enumType supports equals, in, and notIn only
           startsWith: "a",
         },
       },
     };
 
     expect(invalidWhereOperator).toBeDefined();
+
+    acceptCreateOptions<Parameters<typeof orm.users.findMany>[0]>({
+      where: {
+        status: { in: ["active", "inactive"] },
+      },
+    });
+
+    acceptCreateOptions<Parameters<typeof orm.users.findMany>[0]>({
+      where: {
+        status: { notIn: ["inactive"] },
+      },
+    });
+
+    const invalidInValue: Parameters<typeof orm.users.findMany>[0] = {
+      where: {
+        status: {
+          in: [
+            // @ts-expect-error status only accepts active or inactive
+            "pending",
+          ],
+        },
+      },
+    };
+
+    expect(invalidInValue).toBeDefined();
 
     await orm.$raw.close();
   });

--- a/src/lib/orm/orm/types.ts
+++ b/src/lib/orm/orm/types.ts
@@ -128,14 +128,19 @@ type ColumnValue<T extends Column> = T["_meta"]["isNullable"] extends false
 
 type NonNullableColumnValue<T extends Column> = Exclude<ColumnValue<T>, null>;
 
-type StringWhereOperators<T extends Column> = {
+type InWhereOperators<T extends Column> = {
+  in?: NonNullableColumnValue<T>[];
+  notIn?: NonNullableColumnValue<T>[];
+};
+
+type StringWhereOperators<T extends Column> = InWhereOperators<T> & {
   equals?: ColumnValue<T>;
   startsWith?: NonNullableColumnValue<T>;
   endsWith?: NonNullableColumnValue<T>;
   contains?: NonNullableColumnValue<T>;
 };
 
-type NumberWhereOperators<T extends Column> = {
+type NumberWhereOperators<T extends Column> = InWhereOperators<T> & {
   equals?: ColumnValue<T>;
   gt?: NonNullableColumnValue<T>;
   gte?: NonNullableColumnValue<T>;
@@ -143,11 +148,11 @@ type NumberWhereOperators<T extends Column> = {
   lte?: NonNullableColumnValue<T>;
 };
 
-type BooleanWhereOperators<T extends Column> = {
+type BooleanWhereOperators<T extends Column> = InWhereOperators<T> & {
   equals?: ColumnValue<T>;
 };
 
-type DateWhereOperators<T extends Column> = {
+type DateWhereOperators<T extends Column> = InWhereOperators<T> & {
   equals?: ColumnValue<T>;
   gt?: NonNullableColumnValue<T>;
   gte?: NonNullableColumnValue<T>;
@@ -155,11 +160,11 @@ type DateWhereOperators<T extends Column> = {
   lte?: NonNullableColumnValue<T>;
 };
 
-type EnumWhereOperators<T extends Column> = {
+type EnumWhereOperators<T extends Column> = InWhereOperators<T> & {
   equals?: ColumnValue<T>;
 };
 
-type JsonWhereOperators<T extends Column> = {
+type JsonWhereOperators<T extends Column> = InWhereOperators<T> & {
   equals?: ColumnValue<T>;
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `in` and `notIn` membership filter operators across all column types (strings, numbers, dates, enums, booleans, JSON), enabling queries to filter records matching any value within a specified list.

* **Documentation**
  * Updated operator documentation to reflect expanded filtering capabilities with new membership operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->