### PR TITLE
Add support for relation filtering (`every` / `some` / `none`)

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -204,6 +204,34 @@ const users = await db.users.findMany({
 });
 ```
 
+Relation filters filter parent rows based on related records. Use exactly one of `every`, `some`, or `none` per relation:
+
+- `every`: all related records match the nested filter (parents with no related records also match)
+- `some`: at least one related record matches
+- `none`: no related records match (`none: {}` matches parents with no related records)
+
+```typescript
+const users = await db.users.findMany({
+  where: {
+    posts: { every: { published: true } },
+  },
+});
+
+const popularAuthors = await db.users.findMany({
+  where: {
+    posts: { some: { views: { gt: 100 } } },
+  },
+});
+
+const usersWithoutPosts = await db.users.findMany({
+  where: {
+    posts: { none: {} },
+  },
+});
+```
+
+Relation filters compose with column filters and logical operators.
+
 ---
 
 ## Select

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -204,7 +204,7 @@ const users = await db.users.findMany({
 });
 ```
 
-Relation filters filter parent rows based on related records. Use exactly one of `every`, `some`, or `none` per relation:
+Relation filters filter parent rows based on related records. Use one or more of `every`, `some`, and `none` per relation; multiple quantifiers are combined with AND:
 
 - `every`: all related records match the nested filter (parents with no related records also match)
 - `some`: at least one related record matches
@@ -226,6 +226,15 @@ const popularAuthors = await db.users.findMany({
 const usersWithoutPosts = await db.users.findMany({
   where: {
     posts: { none: {} },
+  },
+});
+
+const carefulAuthors = await db.users.findMany({
+  where: {
+    posts: {
+      none: { views: { gt: 100 } },
+      every: { likes: { lte: 50 } },
+    },
   },
 });
 ```

--- a/src/lib/orm/dialect/clauses.test.ts
+++ b/src/lib/orm/dialect/clauses.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { enumType, json, jsonb, uuid } from "../column/index.js";
+import { many } from "../orm/index.js";
 import { defineTable } from "../table/index.js";
 import {
   buildOrderByClause,
@@ -15,7 +16,7 @@ import {
 } from "./clauses.js";
 import { POSTGRES_SPEC } from "./postgres.js";
 import { SQLITE_SPEC } from "./sqlite.js";
-import { usersTable } from "./test-fixtures.js";
+import { postsTable, usersTable } from "./test-fixtures.js";
 
 describe("clauses", () => {
   test("creates dialect placeholders", () => {
@@ -362,6 +363,93 @@ describe("clauses", () => {
     ).toThrow("Unknown where operator: near for field firstName");
   });
 
+  test("builds relation where filters with every, some, and none", () => {
+    const postsRelations = { posts: many(() => postsTable) };
+    const nextPlaceholder = createNextPlaceholder(SQLITE_SPEC);
+
+    const everyWhere = buildWhereClause({
+      nextPlaceholder,
+      table: usersTable,
+      relations: postsRelations,
+      parentAlias: '"users"',
+      where: {
+        posts: { every: { title: "Published" } },
+      },
+    });
+
+    expect(everyWhere.sql).toBe(
+      'NOT EXISTS (SELECT 1 FROM "posts" AS where_posts__posts WHERE where_posts__posts."author_id" = "users"."id" AND NOT ("title" = ?))',
+    );
+    expect(everyWhere.params).toEqual(["Published"]);
+
+    const someWhere = buildWhereClause({
+      nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+      table: usersTable,
+      relations: postsRelations,
+      parentAlias: '"users"',
+      where: {
+        posts: { some: { title: "Hello" } },
+      },
+    });
+
+    expect(someWhere.sql).toBe(
+      'EXISTS (SELECT 1 FROM "posts" AS where_posts__posts WHERE where_posts__posts."author_id" = "users"."id" AND ("title" = ?))',
+    );
+    expect(someWhere.params).toEqual(["Hello"]);
+
+    const noneWhere = buildWhereClause({
+      nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+      table: usersTable,
+      relations: postsRelations,
+      parentAlias: '"users"',
+      where: {
+        posts: { none: {} },
+      },
+    });
+
+    expect(noneWhere.sql).toBe(
+      'NOT EXISTS (SELECT 1 FROM "posts" AS where_posts__posts WHERE where_posts__posts."author_id" = "users"."id" AND ((1 = 1)))',
+    );
+    expect(noneWhere.params).toEqual([]);
+  });
+
+  test("composes relation where filters with column filters", () => {
+    const postsRelations = { posts: many(() => postsTable) };
+    const where = buildWhereClause({
+      nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+      table: usersTable,
+      relations: postsRelations,
+      parentAlias: '"users"',
+      where: {
+        isActive: true,
+        posts: { some: { title: "Hello" } },
+      },
+    });
+
+    expect(where.sql).toBe(
+      '"is_active" = ? AND EXISTS (SELECT 1 FROM "posts" AS where_posts__posts WHERE where_posts__posts."author_id" = "users"."id" AND ("title" = ?))',
+    );
+    expect(where.params).toEqual([true, "Hello"]);
+  });
+
+  test("rejects invalid relation where filters", () => {
+    const postsRelations = { posts: many(() => postsTable) };
+
+    expect(() =>
+      buildWhereClause({
+        nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+        table: usersTable,
+        relations: postsRelations,
+        parentAlias: '"users"',
+        where: {
+          posts: { every: { title: "A" }, some: { title: "B" } },
+        },
+      }),
+    ).toThrow(
+      "Relation where filter for posts must include exactly one of every, some, or none",
+    );
+  });
+
   test("rejects invalid logical where values", () => {
     expect(() =>
       buildWhereClause({
@@ -379,10 +467,7 @@ describe("clauses", () => {
         nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
         table: usersTable,
         where: {
-          $or: [
-            // @ts-expect-error runtime guard
-            "bad",
-          ],
+          $or: ["bad"],
         },
       }),
     ).toThrow("$or where value must contain object filters");

--- a/src/lib/orm/dialect/clauses.test.ts
+++ b/src/lib/orm/dialect/clauses.test.ts
@@ -475,6 +475,27 @@ describe("clauses", () => {
     expect(relationWhere.params).toEqual(["alpha"]);
   });
 
+  test("combines multiple relation where filters on the same relation", () => {
+    const postsRelations = { posts: many(() => postsTable) };
+    const where = buildWhereClause({
+      nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+      table: usersTable,
+      relations: postsRelations,
+      parentAlias: '"users"',
+      where: {
+        posts: {
+          none: { title: "Spam" },
+          every: { title: "Published" },
+        },
+      },
+    });
+
+    expect(where.sql).toBe(
+      'NOT EXISTS (SELECT 1 FROM "posts" AS where_posts__posts WHERE where_posts__posts."author_id" = "users"."id" AND NOT ("title" = ?)) AND NOT EXISTS (SELECT 1 FROM "posts" AS where_posts__posts WHERE where_posts__posts."author_id" = "users"."id" AND ("title" = ?))',
+    );
+    expect(where.params).toEqual(["Published", "Spam"]);
+  });
+
   test("rejects invalid relation where filters", () => {
     const postsRelations = { posts: many(() => postsTable) };
 
@@ -485,11 +506,12 @@ describe("clauses", () => {
         relations: postsRelations,
         parentAlias: '"users"',
         where: {
-          posts: { every: { title: "A" }, some: { title: "B" } },
+          // @ts-expect-error relation filter must include a quantifier
+          posts: {},
         },
       }),
     ).toThrow(
-      "Relation where filter for posts must include exactly one of every, some, or none",
+      "Relation where filter for posts must include at least one of every, some, or none",
     );
   });
 

--- a/src/lib/orm/dialect/clauses.test.ts
+++ b/src/lib/orm/dialect/clauses.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { enumType, json, jsonb, uuid } from "../column/index.js";
+import { enumType, json, jsonb, string, uuid } from "../column/index.js";
 import { many } from "../orm/index.js";
 import { defineTable } from "../table/index.js";
 import {
@@ -430,6 +430,49 @@ describe("clauses", () => {
       '"is_active" = ? AND EXISTS (SELECT 1 FROM "posts" AS where_posts__posts WHERE where_posts__posts."author_id" = "users"."id" AND ("title" = ?))',
     );
     expect(where.params).toEqual([true, "Hello"]);
+  });
+
+  test("prefers column filters when a relation shares the same key", () => {
+    const itemsTable = defineTable("items", {
+      id: uuid("id").primaryKey().notNull(),
+      tags: json<string[]>("tags").notNull(),
+    });
+    const tagsTable = defineTable("tags", {
+      id: uuid("id").primaryKey().notNull(),
+      name: string("name").notNull(),
+      itemId: uuid("item_id")
+        .notNull()
+        .references(() => itemsTable.columns.id),
+    });
+    const itemRelations = { tags: many(() => tagsTable) };
+
+    const columnWhere = buildWhereClause({
+      nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+      table: itemsTable,
+      relations: itemRelations,
+      parentAlias: '"items"',
+      where: {
+        tags: ["alpha", "beta"],
+      },
+    });
+
+    expect(columnWhere.sql).toBe('"tags" = ?');
+    expect(columnWhere.params).toEqual(['["alpha","beta"]']);
+
+    const relationWhere = buildWhereClause({
+      nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+      table: itemsTable,
+      relations: itemRelations,
+      parentAlias: '"items"',
+      where: {
+        tags: { some: { name: "alpha" } },
+      },
+    });
+
+    expect(relationWhere.sql).toBe(
+      'EXISTS (SELECT 1 FROM "tags" AS where_tags__tags WHERE where_tags__tags."item_id" = "items"."id" AND ("name" = ?))',
+    );
+    expect(relationWhere.params).toEqual(["alpha"]);
   });
 
   test("rejects invalid relation where filters", () => {

--- a/src/lib/orm/dialect/clauses.ts
+++ b/src/lib/orm/dialect/clauses.ts
@@ -240,6 +240,18 @@ const getRelationFilter = (
   return { key, where: nestedWhere as TableWhere<Table> };
 };
 
+const isRelationFilterValue = (value: unknown) => {
+  if (!isPlainObject(value)) return false;
+
+  const filter = value as Record<string, unknown>;
+
+  for (const key of RELATION_FILTER_KEYS) {
+    if (key in filter) return true;
+  }
+
+  return false;
+};
+
 const buildRelationForeignKeyCondition = (
   input: BuildRelationForeignKeyConditionInput,
 ) => {
@@ -400,7 +412,7 @@ export const buildWhereClause = <
 
     const relation = relations?.[jsKey];
 
-    if (relation) {
+    if (relation && isRelationFilterValue(value)) {
       appendRelationWhereClause({
         ...input,
         clauses,

--- a/src/lib/orm/dialect/clauses.ts
+++ b/src/lib/orm/dialect/clauses.ts
@@ -1,13 +1,24 @@
 import type { Column } from "../column/types.js";
-import type { TableOrderBy, TableSelect, TableWhere } from "../orm/types.js";
+import type {
+  TableOrderBy,
+  TableRelations,
+  TableSelect,
+  TableWhere,
+} from "../orm/types.js";
 import type { Table } from "../table/types.js";
 import { quoteIdentifier } from "../utils.js";
+import {
+  resolveHasManyForeignKeyColumn,
+  resolveHasOneForeignKeyColumn,
+} from "./relation-fk.js";
 import type {
   AppendDirectWhereClauseInput,
   AppendLogicalWhereClauseInput,
   AppendOperatorWhereClausesInput,
+  AppendRelationWhereClauseInput,
   AppendWhereClauseInput,
   BuildPaginationClauseInput,
+  BuildRelationForeignKeyConditionInput,
   BuildSelectStatementInput,
   BuildSetClausesInput,
   BuildWhereClauseInput,
@@ -19,12 +30,13 @@ import type {
   LogicalNotOperator,
   LogicalWhereJoinKey,
   LogicalWhereKey,
+  ParsedRelationFilter,
   SqlFragment,
 } from "./types.js";
 
 const FALSE_WHERE_SQL = "(1 = 0)";
-
 const TRUE_WHERE_SQL = "(1 = 1)";
+const RELATION_FILTER_KEYS = ["every", "some", "none"] as const;
 
 export const EMPTY_INCLUDE: IncludeClause = {
   sql: "",
@@ -192,8 +204,133 @@ const appendOperatorWhereClauses = (input: AppendOperatorWhereClausesInput) => {
   }
 };
 
-const appendWhereClause = <T extends Table>(
-  input: AppendWhereClauseInput<T>,
+const getRelationFilter = (
+  relationName: string,
+  value: unknown,
+): ParsedRelationFilter => {
+  if (!isPlainObject(value)) {
+    throw new Error(
+      `Relation where filter for ${relationName} must be an object`,
+    );
+  }
+
+  const filter = value as Record<string, unknown>;
+  const keys = RELATION_FILTER_KEYS.filter((key) => key in filter);
+
+  if (keys.length !== 1) {
+    throw new Error(
+      `Relation where filter for ${relationName} must include exactly one of every, some, or none`,
+    );
+  }
+
+  const key = keys[0];
+
+  if (!key) {
+    throw new Error(
+      `Relation where filter for ${relationName} must include exactly one of every, some, or none`,
+    );
+  }
+
+  const nestedWhere = filter[key];
+
+  if (!isPlainObject(nestedWhere)) {
+    throw new Error(`Relation where filter ${key} must be an object`);
+  }
+
+  return { key, where: nestedWhere as TableWhere<Table> };
+};
+
+const buildRelationForeignKeyCondition = (
+  input: BuildRelationForeignKeyConditionInput,
+) => {
+  const { parentTable, parentAlias, relation, relationTable, relationAlias } =
+    input;
+
+  if (relation._type === "hasMany") {
+    const { fk: foreignKey, source: sourceColumn } =
+      resolveHasManyForeignKeyColumn(parentTable, relationTable);
+
+    return `${relationAlias}.${quoteIdentifier(foreignKey.sqlName)} = ${parentAlias}.${quoteIdentifier(sourceColumn.sqlName)}`;
+  }
+
+  if (relation._type !== "hasOne") {
+    throw new Error("Expected hasOne relation");
+  }
+
+  const { localForeignKey, target } = resolveHasOneForeignKeyColumn({
+    sourceTable: parentTable,
+    relationTable,
+    relationForeignKey: relation._foreignKey,
+  });
+
+  return `${relationAlias}.${quoteIdentifier(target.sqlName)} = ${parentAlias}.${quoteIdentifier(localForeignKey.sqlName)}`;
+};
+
+const appendRelationWhereClause = <
+  T extends Table,
+  R extends TableRelations = Record<never, never>,
+>(
+  input: AppendRelationWhereClauseInput<T, R>,
+) => {
+  const {
+    clauses,
+    params,
+    nextPlaceholder,
+    parentAlias,
+    table,
+    relation,
+    relationName,
+    value,
+  } = input;
+
+  if (!parentAlias) {
+    throw new Error("parentAlias is required for relation where filters");
+  }
+
+  const { key, where: nestedWhere } = getRelationFilter(relationName, value);
+  const relationTable = relation._table;
+  const relationAlias = `where_${relationName}__${relationTable.sqlName}`;
+  const fkCondition = buildRelationForeignKeyCondition({
+    parentTable: table,
+    parentAlias,
+    relation,
+    relationTable,
+    relationAlias,
+  });
+  const nested = buildWhereClause({
+    nextPlaceholder,
+    table: relationTable,
+    where: nestedWhere,
+  });
+  const nestedCondition = nested.sql ? nested.sql : TRUE_WHERE_SQL;
+
+  params.push(...nested.params);
+
+  const relationFrom = `${quoteIdentifier(relationTable.sqlName)} AS ${relationAlias}`;
+
+  if (key === "some") {
+    clauses.push(
+      `EXISTS (SELECT 1 FROM ${relationFrom} WHERE ${fkCondition} AND (${nestedCondition}))`,
+    );
+
+    return;
+  }
+
+  if (key === "none") {
+    clauses.push(
+      `NOT EXISTS (SELECT 1 FROM ${relationFrom} WHERE ${fkCondition} AND (${nestedCondition}))`,
+    );
+
+    return;
+  }
+
+  clauses.push(
+    `NOT EXISTS (SELECT 1 FROM ${relationFrom} WHERE ${fkCondition} AND NOT (${nestedCondition}))`,
+  );
+};
+
+const appendWhereClause = <T extends Table, R extends TableRelations>(
+  input: AppendWhereClauseInput<T, R>,
 ) => {
   const { clauses, params, nextPlaceholder, table, jsKey, value } = input;
 
@@ -232,10 +369,13 @@ const appendWhereClause = <T extends Table>(
   });
 };
 
-export const buildWhereClause = <T extends Table>(
-  input: BuildWhereClauseInput<T>,
+export const buildWhereClause = <
+  T extends Table,
+  R extends TableRelations = Record<never, never>,
+>(
+  input: BuildWhereClauseInput<T, R>,
 ): SqlFragment => {
-  const { where } = input;
+  const { where, relations, parentAlias } = input;
 
   const clauses: string[] = [];
   const params: unknown[] = [];
@@ -254,6 +394,22 @@ export const buildWhereClause = <T extends Table>(
         params,
         jsKey: logicalWhereKey,
         value,
+      });
+      continue;
+    }
+
+    const relation = relations?.[jsKey];
+
+    if (relation) {
+      appendRelationWhereClause({
+        ...input,
+        clauses,
+        params,
+        jsKey,
+        value,
+        relation,
+        relationName: jsKey,
+        parentAlias: parentAlias ?? quoteIdentifier(input.table.sqlName),
       });
       continue;
     }
@@ -292,8 +448,11 @@ const getLogicalWhereValues = (jsKey: LogicalWhereKey, value: unknown) => {
   return [value];
 };
 
-const appendLogicalWhereClause = <T extends Table>(
-  input: AppendLogicalWhereClauseInput<T>,
+const appendLogicalWhereClause = <
+  T extends Table,
+  R extends TableRelations = Record<never, never>,
+>(
+  input: AppendLogicalWhereClauseInput<T, R>,
 ) => {
   const { clauses, params, jsKey } = input;
 
@@ -326,8 +485,11 @@ const appendLogicalWhereClause = <T extends Table>(
   clauses.push(`(${collected.nestedClauses.join(` ${operator} `)})`);
 };
 
-const collectLogicalWhereClauses = <T extends Table>(
-  input: CollectLogicalWhereClausesInput<T>,
+const collectLogicalWhereClauses = <
+  T extends Table,
+  R extends TableRelations = Record<never, never>,
+>(
+  input: CollectLogicalWhereClausesInput<T, R>,
 ): CollectedLogicalWhere => {
   const { jsKey, value } = input;
 

--- a/src/lib/orm/dialect/clauses.ts
+++ b/src/lib/orm/dialect/clauses.ts
@@ -204,10 +204,10 @@ const appendOperatorWhereClauses = (input: AppendOperatorWhereClausesInput) => {
   }
 };
 
-const getRelationFilter = (
+const parseRelationFilters = (
   relationName: string,
   value: unknown,
-): ParsedRelationFilter => {
+): ParsedRelationFilter[] => {
   if (!isPlainObject(value)) {
     throw new Error(
       `Relation where filter for ${relationName} must be an object`,
@@ -215,29 +215,27 @@ const getRelationFilter = (
   }
 
   const filter = value as Record<string, unknown>;
-  const keys = RELATION_FILTER_KEYS.filter((key) => key in filter);
+  const filters: ParsedRelationFilter[] = [];
 
-  if (keys.length !== 1) {
+  for (const filterKey of RELATION_FILTER_KEYS) {
+    if (!(filterKey in filter)) continue;
+
+    const nestedWhere = filter[filterKey];
+
+    if (!isPlainObject(nestedWhere)) {
+      throw new Error(`Relation where filter ${filterKey} must be an object`);
+    }
+
+    filters.push({ key: filterKey, where: nestedWhere as TableWhere<Table> });
+  }
+
+  if (filters.length === 0) {
     throw new Error(
-      `Relation where filter for ${relationName} must include exactly one of every, some, or none`,
+      `Relation where filter for ${relationName} must include at least one of every, some, or none`,
     );
   }
 
-  const key = keys[0];
-
-  if (!key) {
-    throw new Error(
-      `Relation where filter for ${relationName} must include exactly one of every, some, or none`,
-    );
-  }
-
-  const nestedWhere = filter[key];
-
-  if (!isPlainObject(nestedWhere)) {
-    throw new Error(`Relation where filter ${key} must be an object`);
-  }
-
-  return { key, where: nestedWhere as TableWhere<Table> };
+  return filters;
 };
 
 const isRelationFilterValue = (value: unknown) => {
@@ -249,7 +247,7 @@ const isRelationFilterValue = (value: unknown) => {
     if (key in filter) return true;
   }
 
-  return false;
+  return Object.keys(filter).length === 0;
 };
 
 const buildRelationForeignKeyCondition = (
@@ -278,11 +276,11 @@ const buildRelationForeignKeyCondition = (
   return `${relationAlias}.${quoteIdentifier(target.sqlName)} = ${parentAlias}.${quoteIdentifier(localForeignKey.sqlName)}`;
 };
 
-const appendRelationWhereClause = <
+const appendRelationFilterClause = <
   T extends Table,
   R extends TableRelations = Record<never, never>,
 >(
-  input: AppendRelationWhereClauseInput<T, R>,
+  input: AppendRelationWhereClauseInput<T, R> & ParsedRelationFilter,
 ) => {
   const {
     clauses,
@@ -292,14 +290,14 @@ const appendRelationWhereClause = <
     table,
     relation,
     relationName,
-    value,
+    key,
+    where: nestedWhere,
   } = input;
 
   if (!parentAlias) {
     throw new Error("parentAlias is required for relation where filters");
   }
 
-  const { key, where: nestedWhere } = getRelationFilter(relationName, value);
   const relationTable = relation._table;
   const relationAlias = `where_${relationName}__${relationTable.sqlName}`;
   const fkCondition = buildRelationForeignKeyCondition({
@@ -339,6 +337,25 @@ const appendRelationWhereClause = <
   clauses.push(
     `NOT EXISTS (SELECT 1 FROM ${relationFrom} WHERE ${fkCondition} AND NOT (${nestedCondition}))`,
   );
+};
+
+const appendRelationWhereClause = <
+  T extends Table,
+  R extends TableRelations = Record<never, never>,
+>(
+  input: AppendRelationWhereClauseInput<T, R>,
+) => {
+  const { parentAlias, relationName, value } = input;
+
+  if (!parentAlias) {
+    throw new Error("parentAlias is required for relation where filters");
+  }
+
+  const filters = parseRelationFilters(relationName, value);
+
+  for (const filter of filters) {
+    appendRelationFilterClause({ ...input, ...filter, parentAlias });
+  }
 };
 
 const appendWhereClause = <T extends Table, R extends TableRelations>(

--- a/src/lib/orm/dialect/query-builder.test.ts
+++ b/src/lib/orm/dialect/query-builder.test.ts
@@ -41,6 +41,25 @@ describe("DialectQueryBuilder", () => {
     ]);
   });
 
+  test("builds findMany with relation where filters", () => {
+    const builder = new DialectQueryBuilder({
+      spec: SQLITE_SPEC,
+      table: usersTable,
+      relations: { posts: many(() => postsTable) },
+    });
+    const query = builder.buildFindMany({
+      where: {
+        posts: { none: {} },
+        isActive: true,
+      },
+    });
+
+    expect(query.statement).toBe(
+      'SELECT "id" AS "id", "first_name" AS "firstName", "created_at" AS "createdAt", "is_active" AS "isActive" FROM "users" WHERE NOT EXISTS (SELECT 1 FROM "posts" AS where_posts__posts WHERE where_posts__posts."author_id" = "users"."id" AND ((1 = 1))) AND "is_active" = ?',
+    );
+    expect(query.params).toEqual([true]);
+  });
+
   test("builds findUnique and findFirst with LIMIT 1", () => {
     const builder = new DialectQueryBuilder({
       spec: SQLITE_SPEC,

--- a/src/lib/orm/dialect/query-builder.ts
+++ b/src/lib/orm/dialect/query-builder.ts
@@ -8,8 +8,6 @@ import type {
   FindUniqueOptions,
   TableInclude,
   TableRelations,
-  TableSelect,
-  TableWhere,
   UpdateManyOptions,
   UpdateOptions,
 } from "../orm/types.js";
@@ -29,26 +27,13 @@ import {
   validateFindUniqueWhere,
 } from "./clauses.js";
 import { buildIncludeClause } from "./relations.js";
-import type { DialectSpec, ReturningQuery } from "./types.js";
-
-type QueryBuilderInput<T extends Table, R extends TableRelations> = {
-  spec: DialectSpec;
-  table: T;
-  relations: R;
-  tableRelationsMap?: Map<Table, TableRelations>;
-};
-
-type SelectInput<T extends Table, R extends TableRelations> = {
-  where?: TableWhere<T>;
-  select?: TableSelect<T>;
-  include?: TableInclude<R>;
-};
-
-type ReturningInput<T extends Table, R extends TableRelations> = {
-  where: TableWhere<T>;
-  select?: TableSelect<T>;
-  include?: TableInclude<R>;
-};
+import type {
+  DialectSpec,
+  QueryBuilderInput,
+  QueryBuilderReturningInput,
+  QueryBuilderSelectInput,
+  ReturningQuery,
+} from "./types.js";
 
 export class DialectQueryBuilder<T extends Table, R extends TableRelations> {
   public readonly spec: DialectSpec;
@@ -257,7 +242,7 @@ export class DialectQueryBuilder<T extends Table, R extends TableRelations> {
     return { statement, params, includeDescriptors: [] };
   }
 
-  public buildUpdateMany(options: UpdateManyOptions<T>): ReturningQuery {
+  public buildUpdateMany(options: UpdateManyOptions<T, R>): ReturningQuery {
     const nextPlaceholder = createNextPlaceholder(this.spec);
     const { setClauses, params } = buildSetClauses({
       nextPlaceholder,
@@ -273,6 +258,8 @@ export class DialectQueryBuilder<T extends Table, R extends TableRelations> {
       nextPlaceholder,
       table: this.table,
       where: options.where,
+      relations: this.relations,
+      parentAlias: quoteIdentifier(this.table.sqlName),
     });
 
     let statement = `UPDATE ${quoteIdentifier(this.table.sqlName)} SET ${setClauses.join(", ")}`;
@@ -289,12 +276,14 @@ export class DialectQueryBuilder<T extends Table, R extends TableRelations> {
     return { statement, params, includeDescriptors: [] };
   }
 
-  public buildDeleteMany(options: DeleteManyOptions<T>): ReturningQuery {
+  public buildDeleteMany(options: DeleteManyOptions<T, R>): ReturningQuery {
     const nextPlaceholder = createNextPlaceholder(this.spec);
     const where = buildWhereClause({
       nextPlaceholder,
       table: this.table,
       where: options.where,
+      relations: this.relations,
+      parentAlias: quoteIdentifier(this.table.sqlName),
     });
 
     let statement = `DELETE FROM ${quoteIdentifier(this.table.sqlName)}`;
@@ -330,13 +319,15 @@ export class DialectQueryBuilder<T extends Table, R extends TableRelations> {
 
   private buildSelectIncludeWhere(
     nextPlaceholder: () => string,
-    input: SelectInput<T, R>,
+    input: QueryBuilderSelectInput<T, R>,
   ) {
     const include = this.buildInclude(nextPlaceholder, input.include);
     const where = buildWhereClause({
       nextPlaceholder,
       table: this.table,
       where: input.where,
+      relations: this.relations,
+      parentAlias: quoteIdentifier(this.table.sqlName),
     });
     const columns = buildSelectColumns(this.table, input.select);
     const selectColumns = buildSelectList(columns, include);
@@ -346,12 +337,14 @@ export class DialectQueryBuilder<T extends Table, R extends TableRelations> {
 
   private buildWhereIncludeReturning(
     nextPlaceholder: () => string,
-    input: ReturningInput<T, R>,
+    input: QueryBuilderReturningInput<T, R>,
   ) {
     const where = buildWhereClause({
       nextPlaceholder,
       table: this.table,
       where: input.where,
+      relations: this.relations,
+      parentAlias: quoteIdentifier(this.table.sqlName),
     });
     const columns = buildSelectColumns(this.table, input.select);
     const include = this.buildInclude(nextPlaceholder, input.include);

--- a/src/lib/orm/dialect/relation-fk.ts
+++ b/src/lib/orm/dialect/relation-fk.ts
@@ -1,0 +1,87 @@
+import type { Table } from "../table/types.js";
+import type {
+  HasManyCandidate,
+  HasOneCandidate,
+  ResolveHasOneForeignKeyColumnInput,
+} from "./types.js";
+
+export const resolveHasManyForeignKeyColumn = (
+  sourceTable: Table,
+  targetTable: Table,
+) => {
+  const sourceColumnValues = Object.values(sourceTable.columns);
+
+  const candidates: HasManyCandidate[] = [];
+
+  for (const [, column] of Object.entries(targetTable.columns)) {
+    if (!column.references) continue;
+
+    const getReferencedColumn = column.references.tableColumn;
+
+    if (!getReferencedColumn) continue;
+
+    const referencedColumn = getReferencedColumn();
+
+    const referencesSourceColumn = sourceColumnValues.some((sourceCol) => {
+      return sourceCol === referencedColumn;
+    });
+
+    if (referencesSourceColumn) {
+      candidates.push({ fk: column, source: referencedColumn });
+    }
+  }
+
+  if (candidates.length > 1) {
+    throw new Error(
+      `Ambiguous hasMany foreign key from ${targetTable.sqlName} to ${sourceTable.sqlName}`,
+    );
+  }
+
+  const [candidate] = candidates;
+
+  if (!candidate) {
+    throw new Error(
+      `Missing hasMany foreign key from ${targetTable.sqlName} to ${sourceTable.sqlName}`,
+    );
+  }
+
+  return candidate;
+};
+
+export const resolveHasOneForeignKeyColumn = (
+  input: ResolveHasOneForeignKeyColumnInput,
+): HasOneCandidate => {
+  const { sourceTable, relationTable, relationForeignKey } = input;
+
+  const localForeignKey = sourceTable.columns[relationForeignKey];
+
+  if (!localForeignKey) {
+    throw new Error(
+      `Missing hasOne foreign key column ${relationForeignKey} on ${sourceTable.sqlName}`,
+    );
+  }
+
+  if (!localForeignKey.references?.tableColumn) {
+    throw new Error(
+      `Column ${relationForeignKey} on ${sourceTable.sqlName} is not a foreign key - call .references() on it`,
+    );
+  }
+
+  const referencedColumn = localForeignKey.references.tableColumn();
+  const relationColumns = Object.values(relationTable.columns);
+
+  const referencesRelationTable = relationColumns.some((column) => {
+    return column === referencedColumn;
+  });
+
+  if (!referencesRelationTable) {
+    throw new Error(
+      `Column ${relationForeignKey} on ${sourceTable.sqlName} does not reference ${relationTable.sqlName}`,
+    );
+  }
+
+  return {
+    localForeignKey,
+    target: referencedColumn,
+  };
+};

--- a/src/lib/orm/dialect/relations.ts
+++ b/src/lib/orm/dialect/relations.ts
@@ -7,98 +7,18 @@ import {
   buildWhereClause,
   EMPTY_INCLUDE,
 } from "./clauses.js";
+import {
+  resolveHasManyForeignKeyColumn,
+  resolveHasOneForeignKeyColumn,
+} from "./relation-fk.js";
 import type {
   BuildIncludeClauseInput,
   BuildJsonObjectExpressionInput,
   BuildRelationSubqueryInput,
-  HasManyCandidate,
-  HasOneCandidate,
   IncludeDescriptor,
   RelationQueryOptions,
   RelationSubqueryResult,
-  ResolveHasOneForeignKeyColumnInput,
 } from "./types.js";
-
-const resolveHasManyForeignKeyColumn = (
-  sourceTable: Table,
-  targetTable: Table,
-) => {
-  const sourceColumnValues = Object.values(sourceTable.columns);
-
-  const candidates: HasManyCandidate[] = [];
-
-  for (const [, column] of Object.entries(targetTable.columns)) {
-    if (!column.references) continue;
-
-    const getReferencedColumn = column.references.tableColumn;
-
-    if (!getReferencedColumn) continue;
-
-    const referencedColumn = getReferencedColumn();
-
-    const referencesSourceColumn = sourceColumnValues.some((sourceCol) => {
-      return sourceCol === referencedColumn;
-    });
-
-    if (referencesSourceColumn) {
-      candidates.push({ fk: column, source: referencedColumn });
-    }
-  }
-
-  if (candidates.length > 1) {
-    throw new Error(
-      `Ambiguous hasMany foreign key from ${targetTable.sqlName} to ${sourceTable.sqlName}`,
-    );
-  }
-
-  const [candidate] = candidates;
-
-  if (!candidate) {
-    throw new Error(
-      `Missing hasMany foreign key from ${targetTable.sqlName} to ${sourceTable.sqlName}`,
-    );
-  }
-
-  return candidate;
-};
-
-const resolveHasOneForeignKeyColumn = (
-  input: ResolveHasOneForeignKeyColumnInput,
-): HasOneCandidate => {
-  const { sourceTable, relationTable, relationForeignKey } = input;
-
-  const localForeignKey = sourceTable.columns[relationForeignKey];
-
-  if (!localForeignKey) {
-    throw new Error(
-      `Missing hasOne foreign key column ${relationForeignKey} on ${sourceTable.sqlName}`,
-    );
-  }
-
-  if (!localForeignKey.references?.tableColumn) {
-    throw new Error(
-      `Column ${relationForeignKey} on ${sourceTable.sqlName} is not a foreign key - call .references() on it`,
-    );
-  }
-
-  const referencedColumn = localForeignKey.references.tableColumn();
-  const relationColumns = Object.values(relationTable.columns);
-
-  const referencesRelationTable = relationColumns.some((column) => {
-    return column === referencedColumn;
-  });
-
-  if (!referencesRelationTable) {
-    throw new Error(
-      `Column ${relationForeignKey} on ${sourceTable.sqlName} does not reference ${relationTable.sqlName}`,
-    );
-  }
-
-  return {
-    localForeignKey,
-    target: referencedColumn,
-  };
-};
 
 const buildJsonObjectExpression = (input: BuildJsonObjectExpressionInput) => {
   const { spec, alias, table, extraPairs = [], select } = input;

--- a/src/lib/orm/dialect/types.ts
+++ b/src/lib/orm/dialect/types.ts
@@ -17,6 +17,7 @@ import type {
   TableInclude,
   TableRelations,
   TableRow,
+  TableSelect,
   TableWhere,
   UpdateManyOptions,
   UpdateOptions,
@@ -82,27 +83,33 @@ export type AppendOperatorWhereClausesInput = {
   value: Record<string, unknown>;
 };
 
-export type AppendWhereClauseInput<T extends Table> =
-  BuildWhereClauseInput<T> & {
-    clauses: string[];
-    params: unknown[];
-    jsKey: string;
-    value: unknown;
-  };
+export type AppendWhereClauseInput<
+  T extends Table,
+  R extends TableRelations = Record<never, never>,
+> = BuildWhereClauseInput<T, R> & {
+  clauses: string[];
+  params: unknown[];
+  jsKey: string;
+  value: unknown;
+};
 
-export type AppendLogicalWhereClauseInput<T extends Table> =
-  BuildWhereClauseInput<T> & {
-    clauses: string[];
-    params: unknown[];
-    jsKey: LogicalWhereKey;
-    value: unknown;
-  };
+export type AppendLogicalWhereClauseInput<
+  T extends Table,
+  R extends TableRelations = Record<never, never>,
+> = BuildWhereClauseInput<T, R> & {
+  clauses: string[];
+  params: unknown[];
+  jsKey: LogicalWhereKey;
+  value: unknown;
+};
 
-export type CollectLogicalWhereClausesInput<T extends Table> =
-  BuildWhereClauseInput<T> & {
-    jsKey: LogicalWhereKey;
-    value: unknown;
-  };
+export type CollectLogicalWhereClausesInput<
+  T extends Table,
+  R extends TableRelations = Record<never, never>,
+> = BuildWhereClauseInput<T, R> & {
+  jsKey: LogicalWhereKey;
+  value: unknown;
+};
 
 export type IncludeDescriptor = {
   name: string;
@@ -183,10 +190,38 @@ export type BuildSetClausesInput<T extends Table> = {
   data: Record<string, unknown>;
 };
 
-export type BuildWhereClauseInput<T extends Table> = {
+export type BuildWhereClauseInput<
+  T extends Table,
+  R extends TableRelations = Record<never, never>,
+> = {
   nextPlaceholder: () => string;
   table: T;
-  where?: TableWhere<T>;
+  where?: TableWhere<T, R>;
+  relations?: R;
+  parentAlias?: string;
+};
+
+export type RelationFilterKey = "every" | "none" | "some";
+
+export type ParsedRelationFilter = {
+  key: RelationFilterKey;
+  where: TableWhere<Table>;
+};
+
+export type BuildRelationForeignKeyConditionInput = {
+  parentTable: Table;
+  parentAlias: string;
+  relation: HasMany<Table> | HasOne<Table>;
+  relationTable: Table;
+  relationAlias: string;
+};
+
+export type AppendRelationWhereClauseInput<
+  T extends Table,
+  R extends TableRelations = Record<never, never>,
+> = AppendWhereClauseInput<T, R> & {
+  relation: HasMany<Table> | HasOne<Table>;
+  relationName: string;
 };
 
 export type ResolveHasOneForeignKeyColumnInput = {
@@ -242,6 +277,31 @@ export type BuildSelectStatementInput = {
   pagination: string;
 };
 
+export type QueryBuilderInput<T extends Table, R extends TableRelations> = {
+  spec: DialectSpec;
+  table: T;
+  relations: R;
+  tableRelationsMap?: Map<Table, TableRelations>;
+};
+
+export type QueryBuilderSelectInput<
+  T extends Table,
+  R extends TableRelations,
+> = {
+  where?: TableWhere<T, R>;
+  select?: TableSelect<T>;
+  include?: TableInclude<R>;
+};
+
+export type QueryBuilderReturningInput<
+  T extends Table,
+  R extends TableRelations,
+> = {
+  where: TableWhere<T, R>;
+  select?: TableSelect<T>;
+  include?: TableInclude<R>;
+};
+
 export type CoerceRelationItemsInput = {
   value: unknown;
   table: Table;
@@ -291,7 +351,7 @@ export type Dialect<
 
   updateMany(
     sql: Bun.SQL,
-    options: UpdateManyOptions<T>,
+    options: UpdateManyOptions<T, TRelations>,
   ): Promise<Array<TableRow<T>>>;
 
   delete<const TOptions extends DeleteOptions<T, TRelations>>(
@@ -301,6 +361,6 @@ export type Dialect<
 
   deleteMany(
     sql: Bun.SQL,
-    options: DeleteManyOptions<T>,
+    options: DeleteManyOptions<T, TRelations>,
   ): Promise<Array<TableRow<T>>>;
 };

--- a/src/lib/orm/orm/index.test.ts
+++ b/src/lib/orm/orm/index.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { date, enumType, string, uuid } from "../column/index.js";
+import {
+  boolean,
+  date,
+  enumType,
+  number,
+  string,
+  uuid,
+} from "../column/index.js";
 import type { Column } from "../column/types.js";
 import { defineTable } from "../table/index.js";
 import type { Table } from "../table/types.js";
@@ -626,6 +633,181 @@ describe("relation helpers", () => {
     const rows = await orm.users.findMany();
 
     expect(rows).toHaveLength(1);
+
+    await orm.$raw.close();
+  });
+});
+
+describe("relation where filters", () => {
+  const postsTable = defineTable("posts", {
+    id: uuid("id").primaryKey().notNull(),
+    title: string("title").notNull(),
+    published: boolean("published")
+      .notNull()
+      .default(() => false),
+    views: number("views")
+      .notNull()
+      .default(() => 0),
+    authorId: uuid("author_id")
+      .notNull()
+      .references(() => usersTable.columns.id),
+  });
+
+  const createOrmWithPosts = () =>
+    createOrm({
+      adapter: "sqlite",
+      url: ":memory:",
+      tables: { users: usersTable, posts: postsTable },
+      relations: {
+        users: { posts: many(() => postsTable) },
+      },
+    });
+
+  const seedRelationFilterData = async (sql: Bun.SQL) => {
+    await sql.unsafe(
+      "CREATE TABLE users (id TEXT PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL UNIQUE)",
+    );
+    await sql.unsafe(
+      "CREATE TABLE posts (id TEXT PRIMARY KEY, title TEXT NOT NULL, published INTEGER NOT NULL, views INTEGER NOT NULL, author_id TEXT NOT NULL)",
+    );
+    await sql.unsafe(
+      "INSERT INTO users VALUES (?, ?, ?), (?, ?, ?), (?, ?, ?)",
+      [
+        "u1",
+        "Alice",
+        "alice@example.com",
+        "u2",
+        "Bob",
+        "bob@example.com",
+        "u3",
+        "Carol",
+        "carol@example.com",
+      ],
+    );
+    await sql.unsafe(
+      "INSERT INTO posts (id, title, published, views, author_id) VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?), (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)",
+      [
+        "p1",
+        "Draft",
+        0,
+        10,
+        "u1",
+        "p2",
+        "Published",
+        1,
+        150,
+        "u1",
+        "p3",
+        "Popular",
+        1,
+        200,
+        "u2",
+        "p4",
+        "Quiet",
+        1,
+        5,
+        "u2",
+      ],
+    );
+  };
+
+  test("filters users where every post is published", async () => {
+    const orm = createOrmWithPosts();
+
+    await seedRelationFilterData(orm.$raw);
+
+    const users = await orm.users.findMany({
+      where: {
+        posts: { every: { published: true } },
+      },
+      select: { id: true },
+    });
+
+    expect(users.map((user) => user.id).sort()).toEqual(["u2", "u3"]);
+
+    await orm.$raw.close();
+  });
+
+  test("filters users where some post has more than 100 views", async () => {
+    const orm = createOrmWithPosts();
+
+    await seedRelationFilterData(orm.$raw);
+
+    const users = await orm.users.findMany({
+      where: {
+        posts: { some: { views: { gt: 100 } } },
+      },
+      select: { id: true },
+    });
+
+    expect(users.map((user) => user.id).sort()).toEqual(["u1", "u2"]);
+
+    await orm.$raw.close();
+  });
+
+  test("filters users with no posts", async () => {
+    const orm = createOrmWithPosts();
+
+    await seedRelationFilterData(orm.$raw);
+
+    const users = await orm.users.findMany({
+      where: {
+        posts: { none: {} },
+      },
+      select: { id: true },
+    });
+
+    expect(users).toEqual([{ id: "u3" }]);
+
+    await orm.$raw.close();
+  });
+
+  test("composes relation filters with column filters", async () => {
+    const orm = createOrmWithPosts();
+
+    await seedRelationFilterData(orm.$raw);
+
+    const users = await orm.users.findMany({
+      where: {
+        name: { startsWith: "A" },
+        posts: { some: { published: true } },
+      },
+      select: { id: true },
+    });
+
+    expect(users).toEqual([{ id: "u1" }]);
+
+    await orm.$raw.close();
+  });
+
+  test("relation where filters are typed on findMany", async () => {
+    const orm = createOrmWithPosts();
+
+    const valid: Parameters<typeof orm.users.findMany>[0] = {
+      where: {
+        posts: { none: { published: false } },
+      },
+    };
+
+    const invalidRelation: Parameters<typeof orm.users.findMany>[0] = {
+      where: {
+        // @ts-expect-error tasks is not a relation on users
+        tasks: { some: {} },
+      },
+    };
+
+    const invalidFilter: Parameters<typeof orm.users.findMany>[0] = {
+      where: {
+        posts: {
+          // @ts-expect-error views is not a column on users
+          views: { gt: 1 },
+        },
+      },
+    };
+
+    expect(valid).toBeDefined();
+    expect(invalidRelation).toBeDefined();
+    expect(invalidFilter).toBeDefined();
 
     await orm.$raw.close();
   });

--- a/src/lib/orm/orm/index.ts
+++ b/src/lib/orm/orm/index.ts
@@ -89,7 +89,7 @@ const createTableClient = <T extends Table, TRelations extends TableRelations>(
       return await dialect.update<TOptions>(sql, options);
     },
 
-    updateMany: async (options: UpdateManyOptions<T>) => {
+    updateMany: async (options: UpdateManyOptions<T, TRelations>) => {
       return await dialect.updateMany(sql, options);
     },
 
@@ -99,7 +99,7 @@ const createTableClient = <T extends Table, TRelations extends TableRelations>(
       return await dialect.delete<TOptions>(sql, options);
     },
 
-    deleteMany: async (options: DeleteManyOptions<T>) => {
+    deleteMany: async (options: DeleteManyOptions<T, TRelations>) => {
       return await dialect.deleteMany(sql, options);
     },
   };

--- a/src/lib/orm/orm/types.ts
+++ b/src/lib/orm/orm/types.ts
@@ -186,15 +186,39 @@ type ColumnWhere<T extends Column> =
     ? ColumnWhereOperators<T>
     : ColumnValue<T> | ColumnWhereOperators<T>;
 
-type TableLogicalWhere<T extends Table> = {
-  [TKey in "$or"]?: TableWhere<T>[];
+type TableLogicalWhere<
+  T extends Table,
+  TRelations extends TableRelations = Record<never, never>,
+> = {
+  [TKey in "$or"]?: TableWhere<T, TRelations>[];
 } & {
-  [TKey in "$and" | "$not"]?: TableWhere<T> | TableWhere<T>[];
+  [TKey in "$and" | "$not"]?:
+    | TableWhere<T, TRelations>
+    | TableWhere<T, TRelations>[];
 };
 
-export type TableWhere<T extends Table> = TableLogicalWhere<T> & {
-  [TColumnName in keyof T["columns"]]?: ColumnWhere<T["columns"][TColumnName]>;
+type RelationWhereFilter<R extends HasMany<Table> | HasOne<Table>> = {
+  every?: TableWhere<RelationTable<R>>;
+  some?: TableWhere<RelationTable<R>>;
+  none?: TableWhere<RelationTable<R>>;
 };
+
+type IsOpenTableRelations<TRelations extends TableRelations> =
+  string extends keyof TRelations ? true : false;
+
+type TableRelationWhere<TRelations extends TableRelations> =
+  IsOpenTableRelations<TRelations> extends true
+    ? Record<never, never>
+    : {
+        [K in keyof TRelations]?: RelationWhereFilter<TRelations[K]>;
+      };
+
+export type TableWhere<
+  T extends Table,
+  TRelations extends TableRelations = Record<never, never>,
+> = TableLogicalWhere<T, TRelations> & {
+  [TColumnName in keyof T["columns"]]?: ColumnWhere<T["columns"][TColumnName]>;
+} & TableRelationWhere<TRelations>;
 
 export type TableSelect<T extends Table> = {
   [TColumnName in keyof T["columns"]]?: true;
@@ -257,7 +281,7 @@ export type FindManyOptions<
   TAllTables extends Record<string, Table> = Record<string, Table>,
   TAllRelations = Record<string, unknown>,
 > = {
-  where?: TableWhere<T>;
+  where?: TableWhere<T, TRelations>;
   select?: TableSelect<T>;
   orderBy?: TableOrderBy<T>;
   include?: TableInclude<TRelations, TAllTables, TAllRelations>;
@@ -440,13 +464,19 @@ export type CreateManyOptions<T extends Table> = {
   data: CreateData<T>[];
 };
 
-export type UpdateManyOptions<T extends Table> = {
-  where?: TableWhere<T>;
+export type UpdateManyOptions<
+  T extends Table,
+  TRelations extends TableRelations = TableRelations,
+> = {
+  where?: TableWhere<T, TRelations>;
   data: UpdateData<T>;
 };
 
-export type DeleteManyOptions<T extends Table> = {
-  where?: TableWhere<T>;
+export type DeleteManyOptions<
+  T extends Table,
+  TRelations extends TableRelations = TableRelations,
+> = {
+  where?: TableWhere<T, TRelations>;
 };
 
 type IncludedKeys<TInclude> = keyof {
@@ -646,7 +676,9 @@ export type TableClient<
     options: TOptions,
   ): Promise<UpdateResult<T, TRelations, TOptions, TAllTables, TAllRelations>>;
 
-  updateMany(options: UpdateManyOptions<T>): Promise<Array<TableRow<T>>>;
+  updateMany(
+    options: UpdateManyOptions<T, TRelations>,
+  ): Promise<Array<TableRow<T>>>;
 
   delete<
     const TOptions extends DeleteOptions<
@@ -659,5 +691,7 @@ export type TableClient<
     options: TOptions,
   ): Promise<DeleteResult<T, TRelations, TOptions, TAllTables, TAllRelations>>;
 
-  deleteMany(options: DeleteManyOptions<T>): Promise<Array<TableRow<T>>>;
+  deleteMany(
+    options: DeleteManyOptions<T, TRelations>,
+  ): Promise<Array<TableRow<T>>>;
 };

--- a/src/lib/orm/orm/types.ts
+++ b/src/lib/orm/orm/types.ts
@@ -201,7 +201,11 @@ type RelationWhereFilter<R extends HasMany<Table> | HasOne<Table>> = {
   every?: TableWhere<RelationTable<R>>;
   some?: TableWhere<RelationTable<R>>;
   none?: TableWhere<RelationTable<R>>;
-};
+} & (
+  | { every: TableWhere<RelationTable<R>> }
+  | { some: TableWhere<RelationTable<R>> }
+  | { none: TableWhere<RelationTable<R>> }
+);
 
 type IsOpenTableRelations<TRelations extends TableRelations> =
   string extends keyof TRelations ? true : false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for relation-based WHERE filters using `every`, `some`, and `none` operators, enabling queries to filter records based on related data.

* **Documentation**
  * Updated ORM documentation with a "Relation filters" section, including examples and usage guidelines for filtering by relations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->