### PR TITLE
Add `between` operator for where clauses

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -150,7 +150,9 @@ Pass a direct value for equality or an operator object for other comparisons.
 
 String operators: `equals`, `startsWith`, `endsWith`, `contains`, `in`, `notIn`
 
-Number and date operators: `equals`, `gt`, `gte`, `lt`, `lte`, `in`, `notIn`
+Number and date operators: `equals`, `gt`, `gte`, `lt`, `lte`, `between`, `in`, `notIn`
+
+`between` accepts a 2-element tuple `[min, max]` for an inclusive range on number and date columns.
 
 Boolean operators: `equals`, `in`, `notIn`
 
@@ -175,7 +177,8 @@ Edge cases:
 ```typescript
 const users = await db.users.findMany({
   where: {
-    age: { gte: 18 },
+    age: { between: [18, 65] },
+    createdAt: { between: [startDate, endDate] },
     name: { startsWith: "A" },
   },
   orderBy: { name: "desc" },

--- a/src/lib/orm/dialect/clauses.test.ts
+++ b/src/lib/orm/dialect/clauses.test.ts
@@ -388,9 +388,7 @@ describe("clauses", () => {
           },
         },
       }),
-    ).toThrow(
-      "Expected array for where operator: between for field createdAt",
-    );
+    ).toThrow("Expected array for where operator: between for field createdAt");
 
     const start = new Date("2025-01-01T00:00:00.000Z");
     const end = new Date("2025-12-31T23:59:59.999Z");

--- a/src/lib/orm/dialect/clauses.test.ts
+++ b/src/lib/orm/dialect/clauses.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { enumType, json, jsonb, string, uuid } from "../column/index.js";
+import {
+  enumType,
+  json,
+  jsonb,
+  number,
+  string,
+  uuid,
+} from "../column/index.js";
 import { many } from "../orm/index.js";
 import { defineTable } from "../table/index.js";
 import {
@@ -337,6 +344,86 @@ describe("clauses", () => {
         },
       }),
     ).toThrow("Expected array for where operator: notIn for field id");
+  });
+
+  test("builds between operator with serialization", () => {
+    const start = new Date("2025-01-01T00:00:00.000Z");
+    const end = new Date("2025-12-31T23:59:59.999Z");
+    const scoresTable = defineTable("scores", {
+      id: uuid("id").primaryKey().notNull(),
+      score: number("score").notNull(),
+    });
+    const where = buildWhereClause({
+      nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+      table: usersTable,
+      where: {
+        createdAt: { between: [start, end] },
+      },
+    });
+
+    expect(where.sql).toBe('"created_at" BETWEEN ? AND ?');
+    expect(where.params).toEqual([start.toISOString(), end.toISOString()]);
+
+    const numberWhere = buildWhereClause({
+      nextPlaceholder: createNextPlaceholder(POSTGRES_SPEC),
+      table: scoresTable,
+      where: {
+        score: { between: [10, 20] },
+      },
+    });
+
+    expect(numberWhere.sql).toBe('"score" BETWEEN $1 AND $2');
+    expect(numberWhere.params).toEqual([10, 20]);
+  });
+
+  test("rejects invalid operands for between", () => {
+    expect(() =>
+      buildWhereClause({
+        nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+        table: usersTable,
+        where: {
+          createdAt: {
+            // @ts-expect-error runtime guard
+            between: "2025-01-01",
+          },
+        },
+      }),
+    ).toThrow(
+      "Expected array for where operator: between for field createdAt",
+    );
+
+    const start = new Date("2025-01-01T00:00:00.000Z");
+    const end = new Date("2025-12-31T23:59:59.999Z");
+
+    expect(() =>
+      buildWhereClause({
+        nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+        table: usersTable,
+        where: {
+          createdAt: {
+            // @ts-expect-error runtime guard
+            between: [start],
+          },
+        },
+      }),
+    ).toThrow(
+      "Expected 2-element array for where operator: between for field createdAt",
+    );
+
+    expect(() =>
+      buildWhereClause({
+        nextPlaceholder: createNextPlaceholder(SQLITE_SPEC),
+        table: usersTable,
+        where: {
+          createdAt: {
+            // @ts-expect-error runtime guard
+            between: [start, end, start],
+          },
+        },
+      }),
+    ).toThrow(
+      "Expected 2-element array for where operator: between for field createdAt",
+    );
   });
 
   test("rejects unknown where keys and operators", () => {

--- a/src/lib/orm/dialect/clauses.ts
+++ b/src/lib/orm/dialect/clauses.ts
@@ -188,6 +188,34 @@ const appendOperatorWhereClauses = (input: AppendOperatorWhereClausesInput) => {
       continue;
     }
 
+    if (op === "between") {
+      if (!Array.isArray(operand)) {
+        throw new Error(
+          `Expected array for where operator: ${op} for field ${jsKey}`,
+        );
+      }
+
+      if (operand.length !== 2) {
+        throw new Error(
+          `Expected 2-element array for where operator: ${op} for field ${jsKey}`,
+        );
+      }
+
+      const [min, max] = operand;
+      
+      const ph1 = nextPlaceholder();
+      const ph2 = nextPlaceholder();
+
+      clauses.push(`${sqlName} BETWEEN ${ph1} AND ${ph2}`);
+      
+      params.push(
+        serializeColumnValue(column, min),
+        serializeColumnValue(column, max),
+      );
+
+      continue;
+    }
+
     const operator = OPERATORS[op as keyof typeof OPERATORS];
 
     if (!operator) {

--- a/src/lib/orm/dialect/clauses.ts
+++ b/src/lib/orm/dialect/clauses.ts
@@ -202,12 +202,12 @@ const appendOperatorWhereClauses = (input: AppendOperatorWhereClausesInput) => {
       }
 
       const [min, max] = operand;
-      
+
       const ph1 = nextPlaceholder();
       const ph2 = nextPlaceholder();
 
       clauses.push(`${sqlName} BETWEEN ${ph1} AND ${ph2}`);
-      
+
       params.push(
         serializeColumnValue(column, min),
         serializeColumnValue(column, max),

--- a/src/lib/orm/dialect/postgres.test.ts
+++ b/src/lib/orm/dialect/postgres.test.ts
@@ -44,6 +44,26 @@ describe("postgres dialect", () => {
     expect(query.params).toEqual(["Jo%", createdAfter.toISOString(), 5]);
   });
 
+  test("uses between for date range filters", () => {
+    const builder = new DialectQueryBuilder({
+      spec: POSTGRES_SPEC,
+      table: usersTable,
+      relations: {},
+    });
+    const start = new Date("2025-01-01T00:00:00.000Z");
+    const end = new Date("2025-12-31T23:59:59.999Z");
+    const query = builder.buildFindMany({
+      where: {
+        createdAt: { between: [start, end] },
+      },
+    });
+
+    expect(query.statement).toBe(
+      'SELECT "id" AS "id", "first_name" AS "firstName", "created_at" AS "createdAt", "is_active" AS "isActive" FROM "users" WHERE "created_at" BETWEEN $1 AND $2',
+    );
+    expect(query.params).toEqual([start.toISOString(), end.toISOString()]);
+  });
+
   test("uses unsatisfiable sql for empty $or", () => {
     const builder = new DialectQueryBuilder({
       spec: POSTGRES_SPEC,

--- a/src/lib/orm/orm/index.test.ts
+++ b/src/lib/orm/orm/index.test.ts
@@ -308,6 +308,17 @@ describe("relation helpers", () => {
 
     expect(invalidWhereOperator).toBeDefined();
 
+    const invalidBetweenOnEnum: Parameters<typeof orm.users.findMany>[0] = {
+      where: {
+        status: {
+          // @ts-expect-error enumType does not support between
+          between: ["active", "inactive"],
+        },
+      },
+    };
+
+    expect(invalidBetweenOnEnum).toBeDefined();
+
     acceptCreateOptions<Parameters<typeof orm.users.findMany>[0]>({
       where: {
         status: { in: ["active", "inactive"] },
@@ -789,6 +800,12 @@ describe("relation where filters", () => {
       },
     };
 
+    const validBetween: Parameters<typeof orm.users.findMany>[0] = {
+      where: {
+        posts: { some: { views: { between: [100, 500] } } },
+      },
+    };
+
     const invalidRelation: Parameters<typeof orm.users.findMany>[0] = {
       where: {
         // @ts-expect-error tasks is not a relation on users
@@ -805,9 +822,27 @@ describe("relation where filters", () => {
       },
     };
 
+    const invalidBetweenValue: Parameters<typeof orm.users.findMany>[0] = {
+      where: {
+        posts: {
+          some: {
+            views: {
+              between: [
+                // @ts-expect-error views is a number column
+                "100",
+                500,
+              ],
+            },
+          },
+        },
+      },
+    };
+
     expect(valid).toBeDefined();
+    expect(validBetween).toBeDefined();
     expect(invalidRelation).toBeDefined();
     expect(invalidFilter).toBeDefined();
+    expect(invalidBetweenValue).toBeDefined();
 
     await orm.$raw.close();
   });

--- a/src/lib/orm/orm/types.ts
+++ b/src/lib/orm/orm/types.ts
@@ -146,6 +146,7 @@ type NumberWhereOperators<T extends Column> = InWhereOperators<T> & {
   gte?: NonNullableColumnValue<T>;
   lt?: NonNullableColumnValue<T>;
   lte?: NonNullableColumnValue<T>;
+  between?: [NonNullableColumnValue<T>, NonNullableColumnValue<T>];
 };
 
 type BooleanWhereOperators<T extends Column> = InWhereOperators<T> & {
@@ -158,6 +159,7 @@ type DateWhereOperators<T extends Column> = InWhereOperators<T> & {
   gte?: NonNullableColumnValue<T>;
   lt?: NonNullableColumnValue<T>;
   lte?: NonNullableColumnValue<T>;
+  between?: [NonNullableColumnValue<T>, NonNullableColumnValue<T>];
 };
 
 type EnumWhereOperators<T extends Column> = InWhereOperators<T> & {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `between` operator for WHERE clause filters on numeric and date columns, enabling inclusive range queries with proper validation and SQL generation across database dialects.

* **Tests**
  * Expanded test coverage for the new `between` operator, including operand validation and SQL predicate generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->