### PR TITLE
Add workflow hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Type-safe APIs, Redis queues, pub/sub, i18n, caching & auth with tree-shakeable 
 | **🌍 i18n**          | Compile-time validated internationalization            | `semola/i18n`     |
 | **💾 Cache**         | Redis cache wrapper with TTL & automatic serialization | `semola/cache`    |
 | **⏰ Cron**          | In-memory cron scheduler for periodic task execution   | `semola/cron`     |
-| **🔁 Workflow**      | Durable resumable workflows with step persistence      | `semola/workflow` |
+| **🔁 Workflow**      | Durable resumable workflows with retries and hooks   | `semola/workflow` |
 | **⚠️ Errors**        | Result-based error handling without try/catch          | `semola/errors`   |
 | **📃 Logging**       | A simple logging utility                               | `semola/logging`  |
 | **⌨️ Prompts**       | Interactive zero-dependency CLI prompts                | `semola/prompts`  |
@@ -318,7 +318,7 @@ _Higher is better for req/sec, lower is better for latency._
 - [Queue](./docs/queue.md) - Redis-backed job queue with timeouts & concurrency
 - [PubSub](./docs/pubsub.md) - Type-safe Redis pub/sub
 - [Cron](./docs/cron.md) - In-memory cron scheduler for periodic task execution
-- [Workflow](./docs/workflow.md) - Durable and resumable workflows with step persistence
+- [Workflow](./docs/workflow.md) - Durable and resumable workflows with retries and hooks
 - [Policy](./docs/policy.md) - Policy-based authorization
 - [i18n](./docs/i18n.md) - Type-safe internationalization
 - [Cache](./docs/cache.md) - Redis cache wrapper with TTL

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -39,6 +39,26 @@ await queue.stop();
 - **`onRetry`** - Called when a job is retried
 - **`onError`** - Called when a job fails permanently
 
+Callback errors do not fail the job or stop processing. Use callbacks for observability only.
+
+### Custom retry backoff
+
+```typescript
+const queue = new Queue({
+  name: "my-queue",
+  redis: redisClient,
+  retries: 3,
+  retryBackoff: {
+    baseDelay: 500,
+    multiplier: 2,
+    maxDelay: 30000,
+  },
+  handler: async (data) => {
+    await process(data);
+  },
+});
+```
+
 ## Examples
 
 ### With Error Handling

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -32,6 +32,7 @@ await queue.stop();
 - **`redis`** (required) - Bun Redis client instance
 - **`handler`** (required) - Function to process each job
 - **`retries`** - Number of retry attempts (default: 3)
+- **`retryBackoff`** - Optional `{ baseDelay, multiplier, maxDelay }` for retry delays (defaults: 1000ms, 2x, 60000ms cap)
 - **`timeout`** - Job timeout in milliseconds (default: 30000)
 - **`concurrency`** - Number of parallel workers (default: 1)
 - **`onSuccess`** - Called when a job succeeds

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -54,15 +54,34 @@ If a workflow crashes after one or more completed steps:
 - `get(executionId)` returns execution status, timestamps, and completed steps.
 - `cancel(executionId)` marks execution as cancelled.
 
+## Options
+
+- **`name`** (required) - Workflow name for Redis keys
+- **`redis`** (required) - Bun Redis client instance
+- **`handler`** (required) - Workflow function with `step` helper
+- **`retries`** - Step retry attempts before marking the workflow `failed` (default: 3). Set to `0` to fail on the first error with no retries.
+- **`retryBackoff`** - Optional `{ baseDelay, multiplier, maxDelay }` for retry delays (defaults: 1000ms, 2x, 30000ms cap)
+- **`hooks`** - Optional lifecycle callbacks (see [Hooks](#hooks))
+- **`lockTTL`** - Execution lock TTL in milliseconds (default: 300000)
+- **`serializeInput`**, **`deserializeInput`**, **`serializeResult`**, **`deserializeResult`**, **`serializeStepOutput`**, **`deserializeStepOutput`** - Custom serializers for Redis persistence
+
 ## Retries
 
-Failed steps retry automatically with exponential backoff before the workflow is marked `failed`. The default is 3 retries (4 total attempts per step).
+Failed steps retry automatically with exponential backoff before the workflow is marked `failed`. By default, each step gets 3 retries (4 total attempts). This applies to every workflow unless you override `retries`.
+
+Only successful step runs are persisted to Redis. Side effects inside a step may run more than once during retries, so keep step handlers idempotent.
+
+`cancel(executionId)` works during retry backoff as well as between steps.
+
+After retries are exhausted, call `resume(executionId)` to re-run the handler from the first unfinished step.
+
+### Disable retries
 
 ```typescript
-const onboardUser = defineWorkflow<User>({
-  name: "onboard-user",
+const strictWorkflow = defineWorkflow<User>({
+  name: "strict",
   redis: redisClient,
-  retries: 3,
+  retries: 0,
   handler: async ({ step }) => {
     await step("send-email", async () => {
       await emailClient.send(...);
@@ -71,13 +90,29 @@ const onboardUser = defineWorkflow<User>({
 });
 ```
 
-Backoff delays start at 1000ms and double each retry, capped at 30000ms. Override with `retryBackoff` when needed. Only successful step runs are persisted to Redis. Side effects inside a step may run more than once during retries, so keep step handlers idempotent.
+### Custom backoff
 
-After retries are exhausted, call `resume(executionId)` to re-run the handler from the first unfinished step.
+```typescript
+const onboardUser = defineWorkflow<User>({
+  name: "onboard-user",
+  redis: redisClient,
+  retries: 3,
+  retryBackoff: {
+    baseDelay: 500,
+    multiplier: 2,
+    maxDelay: 10000,
+  },
+  handler: async ({ step }) => {
+    await step("send-email", async () => {
+      await emailClient.send(...);
+    });
+  },
+});
+```
 
 ## Hooks
 
-Lifecycle hooks are optional callbacks on the workflow definition:
+Lifecycle hooks are optional callbacks on the workflow definition. Use them for logging, metrics, or alerting. Errors thrown inside a hook do not fail the workflow.
 
 ```typescript
 const onboardUser = defineWorkflow<User, void>({
@@ -94,11 +129,11 @@ const onboardUser = defineWorkflow<User, void>({
 });
 ```
 
-- `onStart` runs when execution status becomes `running`.
+- `onStart` runs each time the handler executes, including on `resume()`.
 - `onRetry` runs before each step retry backoff delay.
 - `onError` runs when a step fails after all retries are exhausted.
 - `onComplete` runs after a successful execution.
-- `onCancel` runs when execution is cancelled.
+- `onCancel` runs when execution ends as cancelled.
 
 ## Notes
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -54,6 +54,52 @@ If a workflow crashes after one or more completed steps:
 - `get(executionId)` returns execution status, timestamps, and completed steps.
 - `cancel(executionId)` marks execution as cancelled.
 
+## Retries
+
+Failed steps retry automatically with exponential backoff before the workflow is marked `failed`. The default is 3 retries (4 total attempts per step).
+
+```typescript
+const onboardUser = defineWorkflow<User>({
+  name: "onboard-user",
+  redis: redisClient,
+  retries: 3,
+  handler: async ({ step }) => {
+    await step("send-email", async () => {
+      await emailClient.send(...);
+    });
+  },
+});
+```
+
+Backoff delays start at 1000ms and double each retry, capped at 30000ms. Override with `retryBackoff` when needed. Only successful step runs are persisted to Redis. Side effects inside a step may run more than once during retries, so keep step handlers idempotent.
+
+After retries are exhausted, call `resume(executionId)` to re-run the handler from the first unfinished step.
+
+## Hooks
+
+Lifecycle hooks are optional callbacks on the workflow definition:
+
+```typescript
+const onboardUser = defineWorkflow<User, void>({
+  name: "onboard-user",
+  redis: redisClient,
+  hooks: {
+    onStart: ({ executionId, input }) => { ... },
+    onRetry: ({ stepName, error, attempt, nextRetryDelayMs, retriesRemaining }) => { ... },
+    onError: ({ stepName, error, totalAttempts, errorHistory }) => { ... },
+    onComplete: ({ executionId, input, result }) => { ... },
+    onCancel: ({ executionId, input }) => { ... },
+  },
+  handler: async ({ step }) => { ... },
+});
+```
+
+- `onStart` runs when execution status becomes `running`.
+- `onRetry` runs before each step retry backoff delay.
+- `onError` runs when a step fails after all retries are exhausted.
+- `onComplete` runs after a successful execution.
+- `onCancel` runs when execution is cancelled.
+
 ## Notes
 
 - Step names should be stable and unique inside a workflow handler.

--- a/src/lib/queue/index.test.ts
+++ b/src/lib/queue/index.test.ts
@@ -574,21 +574,23 @@ describe("Queue", () => {
       const secondAttempt = attemptTimestamps[1];
       const thirdAttempt = attemptTimestamps[2];
 
-      if (
-        firstAttempt === undefined ||
-        secondAttempt === undefined ||
-        thirdAttempt === undefined
-      ) {
-        throw new Error("expected three job attempts");
+      if (firstAttempt === undefined) {
+        throw new Error("expected first job attempt timestamp");
+      }
+
+      if (secondAttempt === undefined) {
+        throw new Error("expected second job attempt timestamp");
+      }
+
+      if (thirdAttempt === undefined) {
+        throw new Error("expected third job attempt timestamp");
       }
 
       const firstGap = secondAttempt - firstAttempt;
       const secondGap = thirdAttempt - secondAttempt;
 
       expect(firstGap).toBeGreaterThanOrEqual(1);
-      expect(firstGap).toBeLessThan(50);
       expect(secondGap).toBeGreaterThanOrEqual(2);
-      expect(secondGap).toBeLessThan(50);
     });
   });
 

--- a/src/lib/queue/index.test.ts
+++ b/src/lib/queue/index.test.ts
@@ -53,6 +53,19 @@ const createMockRedis = () => {
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+const fastRetryBackoff = {
+  baseDelay: 1,
+  multiplier: 2,
+  maxDelay: 10,
+};
+
+const fastRetryQueueOptions = {
+  retryBackoff: fastRetryBackoff,
+  pollInterval: 1,
+};
+
+const waitForRetryProcessing = () => sleep(50);
+
 describe("Queue", () => {
   describe("enqueue", () => {
     test.concurrent("should enqueue a job successfully", async () => {
@@ -120,11 +133,17 @@ describe("Queue", () => {
         }
       };
 
-      const queue = new Queue({ name: "test", redis, retries: 3, handler });
+      const queue = new Queue({
+        name: "test",
+        redis,
+        retries: 3,
+        ...fastRetryQueueOptions,
+        handler,
+      });
 
       await queue.enqueue({ message: "test" });
 
-      await sleep(2500);
+      await waitForRetryProcessing();
 
       expect(callCount).toBeGreaterThan(1);
 
@@ -213,19 +232,20 @@ describe("Queue", () => {
         name: "test",
         redis,
         retries: 2,
+        ...fastRetryQueueOptions,
         handler,
         onRetry,
       });
 
       const jobId = await queue.enqueue({ message: "hello" });
 
-      await sleep(2500);
+      await waitForRetryProcessing();
 
       expect(retryContexts.length).toBe(1);
       expect(retryContexts[0]?.id).toBe(jobId);
       expect(retryContexts[0]?.error).toBe("First attempt fails");
       expect(retryContexts[0]?.attempts).toBe(1);
-      expect(retryContexts[0]?.nextRetryDelayMs).toBe(1000);
+      expect(retryContexts[0]?.nextRetryDelayMs).toBe(1);
       expect(retryContexts[0]?.retriesRemaining).toBe(1);
 
       await queue.stop();
@@ -258,20 +278,21 @@ describe("Queue", () => {
         name: "test",
         redis,
         retries: 2,
+        ...fastRetryQueueOptions,
         handler,
         onRetry,
       });
 
       await queue.enqueue({ message: "hello" });
 
-      await sleep(4000);
+      await waitForRetryProcessing();
 
       // Should have called onRetry 2 times (attempts 1, 2)
       expect(retryContexts.length).toBe(2);
       expect(retryContexts[0]?.attempts).toBe(1);
-      expect(retryContexts[0]?.nextRetryDelayMs).toBe(1000);
+      expect(retryContexts[0]?.nextRetryDelayMs).toBe(1);
       expect(retryContexts[1]?.attempts).toBe(2);
-      expect(retryContexts[1]?.nextRetryDelayMs).toBe(2000);
+      expect(retryContexts[1]?.nextRetryDelayMs).toBe(2);
 
       await queue.stop();
     });
@@ -334,6 +355,7 @@ describe("Queue", () => {
         name: "test",
         redis,
         retries: 2,
+        ...fastRetryQueueOptions,
         handler,
         onRetry,
         onError,
@@ -341,7 +363,7 @@ describe("Queue", () => {
 
       const jobId = await queue.enqueue({ message: "hello" });
 
-      await sleep(4000);
+      await waitForRetryProcessing();
 
       expect(retryJobs.length).toBe(2);
       expect(errorJobs.length).toBe(1);
@@ -364,11 +386,17 @@ describe("Queue", () => {
         }
       };
 
-      const queue = new Queue({ name: "test", redis, retries: 2, handler });
+      const queue = new Queue({
+        name: "test",
+        redis,
+        retries: 2,
+        ...fastRetryQueueOptions,
+        handler,
+      });
 
       await queue.enqueue({ message: "hello" });
 
-      await sleep(3000);
+      await waitForRetryProcessing();
 
       expect(attempts).toBe(2);
 
@@ -396,13 +424,14 @@ describe("Queue", () => {
         name: "test",
         redis,
         retries: 2,
+        ...fastRetryQueueOptions,
         handler,
         onError,
       });
 
       const jobId = await queue.enqueue({ message: "hello" });
 
-      await sleep(4000);
+      await waitForRetryProcessing();
 
       expect(attempts).toBe(3);
       expect(errorJobs).toContain(jobId);
@@ -439,13 +468,14 @@ describe("Queue", () => {
         name: "test",
         redis,
         retries: 1,
+        ...fastRetryQueueOptions,
         handler,
         onError,
       });
 
       const jobId = await queue.enqueue({ message: "hello" });
 
-      await sleep(3000);
+      await waitForRetryProcessing();
 
       expect(errorContexts.length).toBe(1);
       expect(errorContexts[0]?.id).toBe(jobId);
@@ -475,17 +505,90 @@ describe("Queue", () => {
         name: "test",
         redis,
         retries: 1,
+        ...fastRetryQueueOptions,
         handler,
         onError,
       });
 
       const jobId = await queue.enqueue({ message: "hello" });
 
-      await sleep(3000);
+      await waitForRetryProcessing();
 
       expect(errorJobs).toContain(jobId);
 
       await queue.stop();
+    });
+
+    test.concurrent("reports default backoff delay in onRetry context", async () => {
+      const redis = createMockRedis();
+      const retryDelays: number[] = [];
+
+      const queue = new Queue({
+        name: "test",
+        redis,
+        retries: 3,
+        pollInterval: 1,
+        handler: () => {
+          throw new Error("fail");
+        },
+        onRetry: (context) => {
+          retryDelays.push(context.nextRetryDelayMs);
+        },
+      });
+
+      await queue.enqueue({ message: "hello" });
+
+      await sleep(20);
+      await queue.stop();
+
+      expect(retryDelays[0]).toBe(1000);
+    });
+
+    test.concurrent("uses exponential backoff between retries", async () => {
+      const redis = createMockRedis();
+      const attemptTimestamps: number[] = [];
+      let attempts = 0;
+
+      const handler = () => {
+        attempts++;
+        attemptTimestamps.push(Date.now());
+        throw new Error(`Attempt ${attempts} failed`);
+      };
+
+      const queue = new Queue({
+        name: "test",
+        redis,
+        retries: 2,
+        ...fastRetryQueueOptions,
+        handler,
+      });
+
+      await queue.enqueue({ message: "hello" });
+
+      await waitForRetryProcessing();
+      await queue.stop();
+
+      expect(attemptTimestamps.length).toBe(3);
+
+      const firstAttempt = attemptTimestamps[0];
+      const secondAttempt = attemptTimestamps[1];
+      const thirdAttempt = attemptTimestamps[2];
+
+      if (
+        firstAttempt === undefined ||
+        secondAttempt === undefined ||
+        thirdAttempt === undefined
+      ) {
+        throw new Error("expected three job attempts");
+      }
+
+      const firstGap = secondAttempt - firstAttempt;
+      const secondGap = thirdAttempt - secondAttempt;
+
+      expect(firstGap).toBeGreaterThanOrEqual(1);
+      expect(firstGap).toBeLessThan(50);
+      expect(secondGap).toBeGreaterThanOrEqual(2);
+      expect(secondGap).toBeLessThan(50);
     });
   });
 
@@ -893,6 +996,7 @@ describe("Queue", () => {
         name: "test",
         redis,
         retries: 1,
+        ...fastRetryQueueOptions,
         handler,
         timeout: 100,
         onError,
@@ -900,7 +1004,7 @@ describe("Queue", () => {
 
       const jobId = await queue.enqueue({ message: "hello" });
 
-      await sleep(3000);
+      await sleep(700);
 
       // Should have retried once due to timeout
       expect(attempts).toBeGreaterThanOrEqual(2);

--- a/src/lib/queue/index.ts
+++ b/src/lib/queue/index.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import { mightThrow, mightThrowSync } from "../errors/index.js";
 import { EnqueueError, SerializationError } from "./errors.js";
 import type { Job, JobState, QueueOptions } from "./types.js";
@@ -43,6 +44,20 @@ export class Queue<T> {
       options.retryBackoff?.multiplier ?? DEFAULT_RETRY_MULTIPLIER;
     this.retryMaxDelay =
       options.retryBackoff?.maxDelay ?? DEFAULT_RETRY_MAX_DELAY;
+
+    assert.ok(
+      Number.isFinite(this.retryBaseDelay) && this.retryBaseDelay > 0,
+      "Invalid retryBackoff.baseDelay: must be a positive finite number",
+    );
+    assert.ok(
+      Number.isFinite(this.retryMultiplier) && this.retryMultiplier > 0,
+      "Invalid retryBackoff.multiplier: must be a positive finite number",
+    );
+    assert.ok(
+      Number.isFinite(this.retryMaxDelay) && this.retryMaxDelay > 0,
+      "Invalid retryBackoff.maxDelay: must be a positive finite number",
+    );
+
     this.startWorkers();
   }
 

--- a/src/lib/queue/index.ts
+++ b/src/lib/queue/index.ts
@@ -14,9 +14,9 @@ const DEFAULT_RETRIES = 3;
 const DEFAULT_TIMEOUT = 30000;
 const DEFAULT_CONCURRENCY = 1;
 const DEFAULT_POLL_INTERVAL = 100;
-const MAX_BACKOFF_DELAY = 60000;
-const BASE_BACKOFF_DELAY = 1000;
-const BACKOFF_MULTIPLIER = 2;
+const DEFAULT_RETRY_MAX_DELAY = 60000;
+const DEFAULT_RETRY_BASE_DELAY = 1000;
+const DEFAULT_RETRY_MULTIPLIER = 2;
 const SHUTDOWN_POLL_INTERVAL = 10;
 
 export class Queue<T> {
@@ -27,6 +27,9 @@ export class Queue<T> {
   private timeout: number;
   private concurrency: number;
   private pollInterval: number;
+  private retryBaseDelay: number;
+  private retryMultiplier: number;
+  private retryMaxDelay: number;
 
   public constructor(options: QueueOptions<T>) {
     this.options = options;
@@ -34,7 +37,20 @@ export class Queue<T> {
     this.timeout = options.timeout ?? DEFAULT_TIMEOUT;
     this.concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
     this.pollInterval = options.pollInterval ?? DEFAULT_POLL_INTERVAL;
+    this.retryBaseDelay =
+      options.retryBackoff?.baseDelay ?? DEFAULT_RETRY_BASE_DELAY;
+    this.retryMultiplier =
+      options.retryBackoff?.multiplier ?? DEFAULT_RETRY_MULTIPLIER;
+    this.retryMaxDelay =
+      options.retryBackoff?.maxDelay ?? DEFAULT_RETRY_MAX_DELAY;
     this.startWorkers();
+  }
+
+  private computeBackoffDelay(attempt: number) {
+    return Math.min(
+      this.retryBaseDelay * this.retryMultiplier ** (attempt - 1),
+      this.retryMaxDelay,
+    );
   }
 
   public async enqueue(data: T) {
@@ -212,10 +228,8 @@ export class Queue<T> {
     // Check if we should retry. Attempt starts at 1, so we retry while attempts <= maxRetries
     if (job.attempts <= job.maxRetries) {
       if (this.options.onRetry) {
-        const delay = Math.min(
-          BASE_BACKOFF_DELAY * BACKOFF_MULTIPLIER ** (job.attempts - 1),
-          MAX_BACKOFF_DELAY,
-        );
+        const delay = this.computeBackoffDelay(job.attempts);
+
         await mightThrow(
           Promise.resolve(
             this.options.onRetry({
@@ -223,7 +237,7 @@ export class Queue<T> {
               error: errorMsg,
               nextRetryDelayMs: delay,
               retriesRemaining: job.maxRetries - job.attempts,
-              backoffMultiplier: BACKOFF_MULTIPLIER,
+              backoffMultiplier: this.retryMultiplier,
             }),
           ),
         );
@@ -269,11 +283,7 @@ export class Queue<T> {
   }
 
   private async retryJob(job: JobState<T>) {
-    // Exponential backoff: 1st retry (attempts=1) -> 1000ms, 2nd (attempts=2) -> 2000ms, etc.
-    const delay = Math.min(
-      BASE_BACKOFF_DELAY * BACKOFF_MULTIPLIER ** (job.attempts - 1),
-      MAX_BACKOFF_DELAY,
-    );
+    const delay = this.computeBackoffDelay(job.attempts);
 
     await new Promise((resolve) => setTimeout(resolve, delay));
 

--- a/src/lib/queue/types.ts
+++ b/src/lib/queue/types.ts
@@ -41,6 +41,12 @@ export type ParseErrorContext = {
   timestamp: number;
 };
 
+export type QueueRetryBackoff = {
+  baseDelay?: number;
+  multiplier?: number;
+  maxDelay?: number;
+};
+
 export type QueueOptions<T> = {
   name: string;
   redis: Bun.RedisClient;
@@ -50,6 +56,7 @@ export type QueueOptions<T> = {
   onError?: (context: ErrorContext<T>) => void | Promise<void>;
   onParseError?: (context: ParseErrorContext) => void | Promise<void>;
   retries?: number;
+  retryBackoff?: QueueRetryBackoff;
   timeout?: number;
   concurrency?: number;
   pollInterval?: number;

--- a/src/lib/workflow/index.test.ts
+++ b/src/lib/workflow/index.test.ts
@@ -1493,9 +1493,7 @@ describe("workflow", () => {
       const secondGap = thirdAttempt - secondAttempt;
 
       expect(firstGap).toBeGreaterThanOrEqual(1);
-      expect(firstGap).toBeLessThan(50);
       expect(secondGap).toBeGreaterThanOrEqual(2);
-      expect(secondGap).toBeLessThan(50);
     });
 
     test("reports default backoff delay in onRetry context", async () => {

--- a/src/lib/workflow/index.test.ts
+++ b/src/lib/workflow/index.test.ts
@@ -262,6 +262,12 @@ const createRedis = () => {
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+const fastRetryBackoff = {
+  baseDelay: 1,
+  multiplier: 2,
+  maxDelay: 10,
+};
+
 const createWorkflowWithEchoResult = (
   name: string,
   redis: Bun.RedisClient,
@@ -280,6 +286,39 @@ const createWorkflowWithEchoResult = (
       });
 
       return value;
+    },
+  });
+};
+
+const createTwoStepFailResumeWorkflow = (
+  name: string,
+  redis: Bun.RedisClient,
+  executedSteps: string[],
+) => {
+  let shouldFail = true;
+
+  return defineWorkflow<{ id: number }, string>({
+    name,
+    redis,
+    retries: 0,
+    handler: async ({ input, step }) => {
+      await step("step-1", async () => {
+        executedSteps.push(`step-1:${input.id}`);
+        return "ok";
+      });
+
+      await step("step-2", async () => {
+        executedSteps.push(`step-2:${input.id}`);
+
+        if (shouldFail) {
+          shouldFail = false;
+          throw new Error("crash");
+        }
+
+        return "ok";
+      });
+
+      return "done";
     },
   });
 };
@@ -352,31 +391,11 @@ describe("workflow", () => {
     const redis = createRedis();
     const executedSteps: string[] = [];
 
-    let shouldFail = true;
-
-    const workflow = defineWorkflow<{ id: number }, string>({
-      name: "resume",
+    const workflow = createTwoStepFailResumeWorkflow(
+      "resume",
       redis,
-      handler: async ({ input, step }) => {
-        await step("step-1", async () => {
-          executedSteps.push(`step-1:${input.id}`);
-          return "ok";
-        });
-
-        await step("step-2", async () => {
-          executedSteps.push(`step-2:${input.id}`);
-
-          if (shouldFail) {
-            shouldFail = false;
-            throw new Error("crash");
-          }
-
-          return "ok";
-        });
-
-        return "done";
-      },
-    });
+      executedSteps,
+    );
 
     await expect(
       workflow.start({ id: 10 }, { executionId: "exec-1" }),
@@ -416,6 +435,7 @@ describe("workflow", () => {
     const workflow = defineWorkflow<{ id: number }, string>({
       name: "cancel",
       redis,
+      retries: 0,
       handler: async ({ step }) => {
         await step("first", async () => "ok");
 
@@ -858,6 +878,7 @@ describe("workflow", () => {
       const workflow = defineWorkflow<{ id: number }, string>({
         name: "cancel-twice",
         redis,
+        retries: 0,
         handler: async ({ step }) => {
           await step("one", async () => {
             if (shouldFail) {
@@ -975,6 +996,7 @@ describe("workflow", () => {
       const workflow = defineWorkflow<{ id: number }, string>({
         name: "get-cancelled",
         redis,
+        retries: 0,
         handler: async ({ step }) => {
           await step("one", async () => {
             if (shouldFail) {
@@ -1148,6 +1170,368 @@ describe("workflow", () => {
       });
 
       expect(signalAborted).toBe(true);
+    });
+  });
+
+  describe("hooks and retries", () => {
+    test("retries step after transient failure", async () => {
+      const redis = createRedis();
+      let stepAttempts = 0;
+
+      const workflow = defineWorkflow<{ id: number }, string>({
+        name: "retry-success",
+        redis,
+        retries: 2,
+        retryBackoff: fastRetryBackoff,
+        handler: async ({ step }) => {
+          await step("flaky", async () => {
+            stepAttempts++;
+
+            if (stepAttempts < 3) {
+              throw new Error("transient");
+            }
+
+            return "ok";
+          });
+
+          return "done";
+        },
+      });
+
+      const result = await workflow.run({ id: 1 });
+
+      expect(result).toBe("done");
+      expect(stepAttempts).toBe(3);
+    });
+
+    test("calls onRetry with correct context", async () => {
+      const redis = createRedis();
+      const retryContexts: Array<{
+        stepName: string;
+        attempt: number;
+        nextRetryDelayMs: number;
+        retriesRemaining: number;
+      }> = [];
+
+      const workflow = defineWorkflow<{ id: number }, string>({
+        name: "on-retry",
+        redis,
+        retries: 2,
+        retryBackoff: fastRetryBackoff,
+        hooks: {
+          onRetry: (context) => {
+            retryContexts.push({
+              stepName: context.stepName,
+              attempt: context.attempt,
+              nextRetryDelayMs: context.nextRetryDelayMs,
+              retriesRemaining: context.retriesRemaining,
+            });
+          },
+        },
+        handler: async ({ step }) => {
+          await step("flaky", async () => {
+            throw new Error("always fail");
+          });
+
+          return "done";
+        },
+      });
+
+      await expect(workflow.start({ id: 1 })).rejects.toMatchObject({
+        name: "ExecutionError",
+      });
+
+      expect(retryContexts.length).toBe(2);
+      expect(retryContexts[0]?.stepName).toBe("flaky");
+      expect(retryContexts[0]?.attempt).toBe(1);
+      expect(retryContexts[0]?.nextRetryDelayMs).toBe(1);
+      expect(retryContexts[0]?.retriesRemaining).toBe(1);
+      expect(retryContexts[1]?.attempt).toBe(2);
+      expect(retryContexts[1]?.nextRetryDelayMs).toBe(2);
+      expect(retryContexts[1]?.retriesRemaining).toBe(0);
+    });
+
+    test("calls onError when retries are exhausted", async () => {
+      const redis = createRedis();
+      const errorContexts: Array<{
+        stepName: string;
+        totalAttempts: number;
+        errorHistoryLength: number;
+      }> = [];
+
+      const workflow = defineWorkflow<{ id: number }, string>({
+        name: "on-error",
+        redis,
+        retries: 1,
+        retryBackoff: fastRetryBackoff,
+        hooks: {
+          onError: (context) => {
+            errorContexts.push({
+              stepName: context.stepName,
+              totalAttempts: context.totalAttempts,
+              errorHistoryLength: context.errorHistory.length,
+            });
+          },
+        },
+        handler: async ({ step }) => {
+          await step("flaky", async () => {
+            throw new Error("permanent fail");
+          });
+
+          return "done";
+        },
+      });
+
+      await expect(
+        workflow.start({ id: 1 }, { executionId: "on-error-1" }),
+      ).rejects.toMatchObject({ name: "ExecutionError" });
+
+      const execution = await workflow.get("on-error-1");
+
+      expect(execution.status).toBe("failed");
+      expect(errorContexts.length).toBe(1);
+      expect(errorContexts[0]?.stepName).toBe("flaky");
+      expect(errorContexts[0]?.totalAttempts).toBe(2);
+      expect(errorContexts[0]?.errorHistoryLength).toBe(2);
+    });
+
+    test("does not call onRetry when step succeeds on first try", async () => {
+      const redis = createRedis();
+      let onRetryCalls = 0;
+
+      const workflow = defineWorkflow<{ id: number }, string>({
+        name: "no-retry",
+        redis,
+        hooks: {
+          onRetry: () => {
+            onRetryCalls++;
+          },
+        },
+        handler: async ({ step }) => {
+          await step("stable", async () => "ok");
+
+          return "done";
+        },
+      });
+
+      await workflow.run({ id: 1 });
+
+      expect(onRetryCalls).toBe(0);
+    });
+
+    test("calls lifecycle hooks on start, complete, and cancel", async () => {
+      const redis = createRedis();
+      const events: string[] = [];
+
+      const workflow = defineWorkflow<{ id: number }, string>({
+        name: "lifecycle-hooks",
+        redis,
+        retries: 0,
+        hooks: {
+          onStart: () => {
+            events.push("start");
+          },
+          onComplete: () => {
+            events.push("complete");
+          },
+          onCancel: () => {
+            events.push("cancel");
+          },
+        },
+        handler: async ({ executionId, step }) => {
+          await step("work", async () => "ok");
+
+          if (events.length === 1) {
+            await workflow.cancel(executionId);
+          }
+
+          return "done";
+        },
+      });
+
+      const startResult = await workflow.start(
+        { id: 1 },
+        { executionId: "lifecycle-1" },
+      );
+
+      expect(startResult.status).toBe("cancelled");
+      expect(events).toEqual(["start", "cancel"]);
+
+      events.length = 0;
+
+      const workflowComplete = defineWorkflow<{ id: number }, string>({
+        name: "lifecycle-complete",
+        redis,
+        hooks: {
+          onStart: () => {
+            events.push("start");
+          },
+          onComplete: () => {
+            events.push("complete");
+          },
+        },
+        handler: async () => "done",
+      });
+
+      await workflowComplete.run({ id: 2 });
+
+      expect(events).toEqual(["start", "complete"]);
+    });
+
+    test("cancels during retry backoff", async () => {
+      const redis = createRedis();
+
+      const workflow = defineWorkflow<{ id: number }, string>({
+        name: "cancel-backoff",
+        redis,
+        retries: 3,
+        retryBackoff: fastRetryBackoff,
+        handler: async ({ step }) => {
+          await step("flaky", async () => {
+            throw new Error("always fail");
+          });
+
+          return "done";
+        },
+      });
+
+      const startPromise = workflow.start(
+        { id: 1 },
+        { executionId: "cancel-backoff-1" },
+      );
+
+      await sleep(5);
+      await workflow.cancel("cancel-backoff-1");
+
+      const startResult = await startPromise;
+
+      expect(startResult.status).toBe("cancelled");
+    });
+
+    test("skips handler for cached step output without retries", async () => {
+      const redis = createRedis();
+      let stepRuns = 0;
+
+      const workflow = defineWorkflow<{ id: number }, string>({
+        name: "cached-no-retry",
+        redis,
+        retries: 3,
+        handler: async ({ step }) => {
+          await step("once", async () => {
+            stepRuns++;
+            return "cached";
+          });
+
+          return "done";
+        },
+      });
+
+      await workflow.start({ id: 1 }, { executionId: "cached-1" });
+      await workflow.resume("cached-1");
+
+      expect(stepRuns).toBe(1);
+    });
+
+    test("resume after exhausted retries re-runs failed step", async () => {
+      const redis = createRedis();
+      const executedSteps: string[] = [];
+
+      const workflow = createTwoStepFailResumeWorkflow(
+        "resume-after-retries",
+        redis,
+        executedSteps,
+      );
+
+      await expect(
+        workflow.start({ id: 10 }, { executionId: "resume-retries-1" }),
+      ).rejects.toMatchObject({ name: "ExecutionError" });
+
+      const resumeData = await workflow.resume("resume-retries-1");
+
+      expect(resumeData.status).toBe("completed");
+      expect(executedSteps).toEqual(["step-1:10", "step-2:10", "step-2:10"]);
+    });
+
+    test("uses exponential backoff between retries", async () => {
+      const redis = createRedis();
+      const attemptTimestamps: number[] = [];
+
+      const workflow = defineWorkflow<{ id: number }, string>({
+        name: "backoff-timing",
+        redis,
+        retries: 2,
+        retryBackoff: fastRetryBackoff,
+        handler: async ({ step }) => {
+          await step("flaky", async () => {
+            attemptTimestamps.push(Date.now());
+            throw new Error("fail");
+          });
+
+          return "done";
+        },
+      });
+
+      await expect(workflow.start({ id: 1 })).rejects.toMatchObject({
+        name: "ExecutionError",
+      });
+
+      expect(attemptTimestamps.length).toBe(3);
+
+      const firstAttempt = attemptTimestamps[0];
+      const secondAttempt = attemptTimestamps[1];
+      const thirdAttempt = attemptTimestamps[2];
+
+      if (
+        firstAttempt === undefined ||
+        secondAttempt === undefined ||
+        thirdAttempt === undefined
+      ) {
+        throw new Error("expected three step attempts");
+      }
+
+      const firstGap = secondAttempt - firstAttempt;
+      const secondGap = thirdAttempt - secondAttempt;
+
+      expect(firstGap).toBeGreaterThanOrEqual(1);
+      expect(firstGap).toBeLessThan(50);
+      expect(secondGap).toBeGreaterThanOrEqual(2);
+      expect(secondGap).toBeLessThan(50);
+    });
+
+    test("reports default backoff delay in onRetry context", async () => {
+      const redis = createRedis();
+      const retryDelays: number[] = [];
+
+      const workflow = defineWorkflow<{ id: number }, string>({
+        name: "default-backoff-delay",
+        redis,
+        retries: 3,
+        hooks: {
+          onRetry: (context) => {
+            retryDelays.push(context.nextRetryDelayMs);
+          },
+        },
+        handler: async ({ step }) => {
+          await step("flaky", async () => {
+            throw new Error("fail");
+          });
+
+          return "done";
+        },
+      });
+
+      const startPromise = workflow.start(
+        { id: 1 },
+        { executionId: "default-backoff-1" },
+      );
+
+      await sleep(20);
+      await workflow.cancel("default-backoff-1");
+
+      const startResult = await startPromise;
+
+      expect(startResult.status).toBe("cancelled");
+      expect(retryDelays[0]).toBe(1000);
     });
   });
 });

--- a/src/lib/workflow/index.ts
+++ b/src/lib/workflow/index.ts
@@ -19,18 +19,54 @@ import type {
   WorkflowStartOptions,
   WorkflowStartResult,
   WorkflowStatus,
+  WorkflowStepErrorRecord,
 } from "./types.js";
 
 const DEFAULT_LOCK_TTL = 5 * 60 * 1000;
+const DEFAULT_RETRIES = 3;
+const DEFAULT_RETRY_BASE_DELAY = 1000;
+const DEFAULT_RETRY_MULTIPLIER = 2;
+const DEFAULT_RETRY_MAX_DELAY = 30000;
 
 const now = () => Date.now();
 
-const toErrorMessage = (error: unknown) => {
-  if (error instanceof Error) {
-    return error.message;
+const delay = async (
+  ms: number,
+  signal: AbortSignal,
+  isCancelled?: () => Promise<boolean>,
+) => {
+  if (signal.aborted) {
+    throw new CancelledError(
+      "Workflow execution was aborted during retry backoff",
+    );
   }
 
-  return String(error);
+  const deadline = now() + ms;
+  const pollInterval = 50;
+
+  while (now() < deadline) {
+    if (signal.aborted) {
+      throw new CancelledError(
+        "Workflow execution was aborted during retry backoff",
+      );
+    }
+
+    if (isCancelled) {
+      const cancelled = await isCancelled();
+
+      if (cancelled) {
+        throw new CancelledError(
+          "Workflow execution was cancelled during retry backoff",
+        );
+      }
+    }
+
+    const remaining = deadline - now();
+
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, Math.min(pollInterval, remaining));
+    });
+  }
 };
 
 const envelopeSerialize = (value: unknown) => {
@@ -70,10 +106,28 @@ const knownStatuses: WorkflowStatus[] = [
 class WorkflowDefinition<TInput, TResult> {
   private options: WorkflowOptions<TInput, TResult>;
   private lockTTL: number;
+  private retries: number;
+  private retryBaseDelay: number;
+  private retryMultiplier: number;
+  private retryMaxDelay: number;
 
   public constructor(options: WorkflowOptions<TInput, TResult>) {
     this.options = options;
     this.lockTTL = options.lockTTL ?? DEFAULT_LOCK_TTL;
+    this.retries = options.retries ?? DEFAULT_RETRIES;
+    this.retryBaseDelay =
+      options.retryBackoff?.baseDelay ?? DEFAULT_RETRY_BASE_DELAY;
+    this.retryMultiplier =
+      options.retryBackoff?.multiplier ?? DEFAULT_RETRY_MULTIPLIER;
+    this.retryMaxDelay =
+      options.retryBackoff?.maxDelay ?? DEFAULT_RETRY_MAX_DELAY;
+  }
+
+  private computeBackoffDelay(attempt: number) {
+    return Math.min(
+      this.retryBaseDelay * this.retryMultiplier ** (attempt - 1),
+      this.retryMaxDelay,
+    );
   }
 
   public async start(input: TInput, options?: WorkflowStartOptions) {
@@ -269,6 +323,17 @@ class WorkflowDefinition<TInput, TResult> {
     await this.setMeta(executionId, "status", "running");
     await this.setMeta(executionId, "updatedAt", String(timestamp));
 
+    if (this.options.hooks?.onStart) {
+      await mightThrow(
+        Promise.resolve(
+          this.options.hooks.onStart({
+            executionId,
+            input,
+          }),
+        ),
+      );
+    }
+
     const controller = new AbortController();
 
     const renewInterval = Math.floor(this.lockTTL / 3);
@@ -294,14 +359,9 @@ class WorkflowDefinition<TInput, TResult> {
         signal: AbortSignal,
       ) => TStep | Promise<TStep>,
     ) => {
-      const cancelled = await this.isCancelled(executionId);
-
-      if (cancelled) {
+      await this.throwIfCancelled(executionId, () => {
         controller.abort();
-        throw new CancelledError(
-          `Workflow execution ${executionId} was cancelled`,
-        );
-      }
+      });
 
       const cachedStep = await this.readStepOutput<TStep>(executionId, name);
 
@@ -309,17 +369,16 @@ class WorkflowDefinition<TInput, TResult> {
         return cachedStep.value as TStep;
       }
 
-      const [stepError, output] = await mightThrow(
-        Promise.resolve(handler(input, controller.signal)),
+      return this.runStepWithRetries(
+        executionId,
+        input,
+        name,
+        handler,
+        controller.signal,
+        () => {
+          controller.abort();
+        },
       );
-
-      if (stepError) {
-        throw stepError;
-      }
-
-      await this.writeStepOutput(executionId, name, output);
-
-      return output as TStep;
     };
 
     const [handlerError, result] = await mightThrow(
@@ -349,6 +408,17 @@ class WorkflowDefinition<TInput, TResult> {
       await this.setMeta(executionId, "updatedAt", String(cancelledAt));
       await this.setMeta(executionId, "cancelledAt", String(cancelledAt));
 
+      if (this.options.hooks?.onCancel) {
+        await mightThrow(
+          Promise.resolve(
+            this.options.hooks.onCancel({
+              executionId,
+              input,
+            }),
+          ),
+        );
+      }
+
       await this.releaseLock(executionId, token);
 
       return { executionId, status: "cancelled" } satisfies WorkflowStartResult;
@@ -358,14 +428,14 @@ class WorkflowDefinition<TInput, TResult> {
       const failedAt = now();
 
       await this.setMeta(executionId, "status", "failed");
-      await this.setMeta(executionId, "error", toErrorMessage(handlerError));
+      await this.setMeta(executionId, "error", handlerError.message);
       await this.setMeta(executionId, "updatedAt", String(failedAt));
       await this.setMeta(executionId, "failedAt", String(failedAt));
 
       await this.releaseLock(executionId, token);
 
       throw new ExecutionError(
-        `Workflow execution ${executionId} failed: ${toErrorMessage(handlerError)}`,
+        `Workflow execution ${executionId} failed: ${handlerError.message}`,
       );
     }
 
@@ -377,11 +447,7 @@ class WorkflowDefinition<TInput, TResult> {
       const failedAt = now();
 
       await this.setMeta(executionId, "status", "failed");
-      await this.setMeta(
-        executionId,
-        "error",
-        toErrorMessage(serializeResultError),
-      );
+      await this.setMeta(executionId, "error", serializeResultError.message);
       await this.setMeta(executionId, "updatedAt", String(failedAt));
       await this.setMeta(executionId, "failedAt", String(failedAt));
 
@@ -401,9 +467,119 @@ class WorkflowDefinition<TInput, TResult> {
     await this.setMeta(executionId, "updatedAt", String(completedAt));
     await this.setMeta(executionId, "completedAt", String(completedAt));
 
+    if (this.options.hooks?.onComplete) {
+      await mightThrow(
+        Promise.resolve(
+          this.options.hooks.onComplete({
+            executionId,
+            input,
+            result: result as TResult,
+          }),
+        ),
+      );
+    }
+
     await this.releaseLock(executionId, token);
 
     return { executionId, status: "completed" } satisfies WorkflowStartResult;
+  }
+
+  private async throwIfCancelled(executionId: string, abort: () => void) {
+    const cancelled = await this.isCancelled(executionId);
+
+    if (cancelled) {
+      abort();
+      throw new CancelledError(
+        `Workflow execution ${executionId} was cancelled`,
+      );
+    }
+  }
+
+  private async runStepWithRetries<TStep>(
+    executionId: string,
+    input: TInput,
+    stepName: string,
+    handler: (
+      inputValue: TInput,
+      signal: AbortSignal,
+    ) => TStep | Promise<TStep>,
+    signal: AbortSignal,
+    abort: () => void,
+  ) {
+    let attempt = 1;
+
+    const errorHistory: WorkflowStepErrorRecord[] = [];
+
+    while (true) {
+      await this.throwIfCancelled(executionId, abort);
+
+      const [stepError, output] = await mightThrow(
+        Promise.resolve(handler(input, signal)),
+      );
+
+      if (!stepError) {
+        await this.writeStepOutput(executionId, stepName, output);
+
+        return output as TStep;
+      }
+
+      const errorMsg = stepError.message;
+
+      errorHistory.push({
+        attempt,
+        error: errorMsg,
+        timestamp: now(),
+      });
+
+      if (attempt <= this.retries) {
+        const nextRetryDelayMs = this.computeBackoffDelay(attempt);
+
+        if (this.options.hooks?.onRetry) {
+          await mightThrow(
+            Promise.resolve(
+              this.options.hooks.onRetry({
+                executionId,
+                input,
+                stepName,
+                error: errorMsg,
+                attempt,
+                nextRetryDelayMs,
+                retriesRemaining: this.retries - attempt,
+              }),
+            ),
+          );
+        }
+
+        const [delayError] = await mightThrow(
+          delay(nextRetryDelayMs, signal, () => this.isCancelled(executionId)),
+        );
+
+        if (delayError) {
+          throw delayError;
+        }
+
+        attempt++;
+
+        continue;
+      }
+
+      if (this.options.hooks?.onError) {
+        await mightThrow(
+          Promise.resolve(
+            this.options.hooks.onError({
+              executionId,
+              input,
+              stepName,
+              error: errorMsg,
+              totalAttempts: attempt,
+              errorHistory,
+            }),
+          ),
+        );
+      }
+
+      throw stepError;
+    }
   }
 
   private async acquireLock(executionId: string, token: string) {
@@ -546,7 +722,7 @@ class WorkflowDefinition<TInput, TResult> {
 
     if (serializeError) {
       throw new SerializationError(
-        `Unable to serialize ${label}: ${toErrorMessage(serializeError)}`,
+        `Unable to serialize ${label}: ${serializeError.message}`,
       );
     }
 
@@ -566,7 +742,7 @@ class WorkflowDefinition<TInput, TResult> {
 
     if (result[0]) {
       throw new SerializationError(
-        `Unable to deserialize ${label}: ${toErrorMessage(result[0])}`,
+        `Unable to deserialize ${label}: ${result[0].message}`,
       );
     }
 
@@ -850,10 +1026,15 @@ export type {
   Workflow,
   WorkflowExecution,
   WorkflowHandlerContext,
+  WorkflowHooks,
   WorkflowMeta,
   WorkflowMetaField,
   WorkflowOptions,
+  WorkflowRetryBackoff,
   WorkflowStartOptions,
   WorkflowStartResult,
   WorkflowStatus,
+  WorkflowStepErrorContext,
+  WorkflowStepErrorRecord,
+  WorkflowStepRetryContext,
 } from "./types.js";

--- a/src/lib/workflow/index.ts
+++ b/src/lib/workflow/index.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import { mightThrow, mightThrowSync } from "../errors/index.js";
 import {
   CancelledError,
@@ -121,6 +122,27 @@ class WorkflowDefinition<TInput, TResult> {
       options.retryBackoff?.multiplier ?? DEFAULT_RETRY_MULTIPLIER;
     this.retryMaxDelay =
       options.retryBackoff?.maxDelay ?? DEFAULT_RETRY_MAX_DELAY;
+
+    assert.ok(
+      Number.isFinite(this.retries) && this.retries >= 0,
+      "Invalid retries: must be a non-negative finite number",
+    );
+    assert.ok(
+      Number.isFinite(this.retryBaseDelay) && this.retryBaseDelay > 0,
+      "Invalid retryBackoff.baseDelay: must be a positive finite number",
+    );
+    assert.ok(
+      Number.isFinite(this.retryMultiplier) && this.retryMultiplier > 0,
+      "Invalid retryBackoff.multiplier: must be a positive finite number",
+    );
+    assert.ok(
+      Number.isFinite(this.retryMaxDelay) && this.retryMaxDelay > 0,
+      "Invalid retryBackoff.maxDelay: must be a positive finite number",
+    );
+  }
+
+  private runHook<T>(hook: () => T | Promise<T>) {
+    return mightThrow(Promise.resolve().then(() => hook()));
   }
 
   private computeBackoffDelay(attempt: number) {
@@ -323,17 +345,6 @@ class WorkflowDefinition<TInput, TResult> {
     await this.setMeta(executionId, "status", "running");
     await this.setMeta(executionId, "updatedAt", String(timestamp));
 
-    if (this.options.hooks?.onStart) {
-      await mightThrow(
-        Promise.resolve(
-          this.options.hooks.onStart({
-            executionId,
-            input,
-          }),
-        ),
-      );
-    }
-
     const controller = new AbortController();
 
     const renewInterval = Math.floor(this.lockTTL / 3);
@@ -351,6 +362,15 @@ class WorkflowDefinition<TInput, TResult> {
         clearInterval(renewTimer);
       }
     }, renewInterval);
+
+    if (this.options.hooks?.onStart) {
+      await this.runHook(() =>
+        this.options.hooks?.onStart?.({
+          executionId,
+          input,
+        }),
+      );
+    }
 
     const step = async <TStep>(
       name: string,
@@ -381,7 +401,7 @@ class WorkflowDefinition<TInput, TResult> {
       );
     };
 
-    const [handlerError, result] = await mightThrow(
+    const handlerOutcome = await mightThrow(
       Promise.resolve(
         this.options.handler({
           input,
@@ -409,13 +429,11 @@ class WorkflowDefinition<TInput, TResult> {
       await this.setMeta(executionId, "cancelledAt", String(cancelledAt));
 
       if (this.options.hooks?.onCancel) {
-        await mightThrow(
-          Promise.resolve(
-            this.options.hooks.onCancel({
-              executionId,
-              input,
-            }),
-          ),
+        await this.runHook(() =>
+          this.options.hooks?.onCancel?.({
+            executionId,
+            input,
+          }),
         );
       }
 
@@ -423,6 +441,8 @@ class WorkflowDefinition<TInput, TResult> {
 
       return { executionId, status: "cancelled" } satisfies WorkflowStartResult;
     }
+
+    const [handlerError, result] = handlerOutcome;
 
     if (handlerError) {
       const failedAt = now();
@@ -468,14 +488,12 @@ class WorkflowDefinition<TInput, TResult> {
     await this.setMeta(executionId, "completedAt", String(completedAt));
 
     if (this.options.hooks?.onComplete) {
-      await mightThrow(
-        Promise.resolve(
-          this.options.hooks.onComplete({
-            executionId,
-            input,
-            result: result as TResult,
-          }),
-        ),
+      await this.runHook(() =>
+        this.options.hooks?.onComplete?.({
+          executionId,
+          input,
+          result,
+        }),
       );
     }
 
@@ -513,14 +531,16 @@ class WorkflowDefinition<TInput, TResult> {
     while (true) {
       await this.throwIfCancelled(executionId, abort);
 
-      const [stepError, output] = await mightThrow(
+      const stepOutcome = await mightThrow(
         Promise.resolve(handler(input, signal)),
       );
+
+      const [stepError, output] = stepOutcome;
 
       if (!stepError) {
         await this.writeStepOutput(executionId, stepName, output);
 
-        return output as TStep;
+        return output;
       }
 
       const errorMsg = stepError.message;
@@ -535,18 +555,16 @@ class WorkflowDefinition<TInput, TResult> {
         const nextRetryDelayMs = this.computeBackoffDelay(attempt);
 
         if (this.options.hooks?.onRetry) {
-          await mightThrow(
-            Promise.resolve(
-              this.options.hooks.onRetry({
-                executionId,
-                input,
-                stepName,
-                error: errorMsg,
-                attempt,
-                nextRetryDelayMs,
-                retriesRemaining: this.retries - attempt,
-              }),
-            ),
+          await this.runHook(() =>
+            this.options.hooks?.onRetry?.({
+              executionId,
+              input,
+              stepName,
+              error: errorMsg,
+              attempt,
+              nextRetryDelayMs,
+              retriesRemaining: this.retries - attempt,
+            }),
           );
         }
 
@@ -564,17 +582,15 @@ class WorkflowDefinition<TInput, TResult> {
       }
 
       if (this.options.hooks?.onError) {
-        await mightThrow(
-          Promise.resolve(
-            this.options.hooks.onError({
-              executionId,
-              input,
-              stepName,
-              error: errorMsg,
-              totalAttempts: attempt,
-              errorHistory,
-            }),
-          ),
+        await this.runHook(() =>
+          this.options.hooks?.onError?.({
+            executionId,
+            input,
+            stepName,
+            error: errorMsg,
+            totalAttempts: attempt,
+            errorHistory,
+          }),
         );
       }
 

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -43,12 +43,64 @@ export type WorkflowHandlerContext<TInput> = {
 export type SerializeValue<T> = (value: T) => string;
 export type DeserializeValue<T> = (raw: string) => T;
 
+export type WorkflowStepErrorRecord = {
+  attempt: number;
+  error: string;
+  timestamp: number;
+};
+
+export type WorkflowStepRetryContext<TInput> = {
+  executionId: string;
+  input: TInput;
+  stepName: string;
+  error: string;
+  attempt: number;
+  nextRetryDelayMs: number;
+  retriesRemaining: number;
+};
+
+export type WorkflowStepErrorContext<TInput> = {
+  executionId: string;
+  input: TInput;
+  stepName: string;
+  error: string;
+  totalAttempts: number;
+  errorHistory: WorkflowStepErrorRecord[];
+};
+
+export type WorkflowHooks<TInput, TResult> = {
+  onStart?: (context: {
+    executionId: string;
+    input: TInput;
+  }) => void | Promise<void>;
+  onRetry?: (context: WorkflowStepRetryContext<TInput>) => void | Promise<void>;
+  onError?: (context: WorkflowStepErrorContext<TInput>) => void | Promise<void>;
+  onComplete?: (context: {
+    executionId: string;
+    input: TInput;
+    result: TResult;
+  }) => void | Promise<void>;
+  onCancel?: (context: {
+    executionId: string;
+    input: TInput;
+  }) => void | Promise<void>;
+};
+
+export type WorkflowRetryBackoff = {
+  baseDelay?: number;
+  multiplier?: number;
+  maxDelay?: number;
+};
+
 export type WorkflowOptions<TInput, TResult> = {
   name: string;
   redis: Bun.RedisClient;
   handler: (
     context: WorkflowHandlerContext<TInput>,
   ) => TResult | Promise<TResult>;
+  retries?: number;
+  retryBackoff?: WorkflowRetryBackoff;
+  hooks?: WorkflowHooks<TInput, TResult>;
   lockTTL?: number;
   serializeInput?: SerializeValue<TInput>;
   deserializeInput?: DeserializeValue<TInput>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queue retry timing is now configurable via `retryBackoff` (base delay, multiplier, max delay).
  * Workflow steps now support configurable retries with exponential backoff and richer lifecycle hooks (`onStart`, `onRetry`, `onError`, `onComplete`, `onCancel`).
* **Documentation**
  * Updated queue and workflow docs with `retryBackoff`, retry behavior, and hook usage; clarified that hook/callback errors don’t fail processing.
* **Bug Fixes**
  * Improved step failure error reporting for handler and serialization scenarios.
* **Tests**
  * Updated and expanded retry/backoff and hook tests with faster, deterministic timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->