### PR TITLE
Add support for ORM hooks

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -123,7 +123,43 @@ Every hook receives:
 
 ### Before-write hooks
 
-`beforeCreate`, `beforeCreateMany`, `beforeUpdate`, `beforeUpdateMany`, `beforeDelete`, and `beforeDeleteMany` may return modified options. Returned fields are merged into the operation options before the query runs.
+`beforeCreate`, `beforeCreateMany`, `beforeUpdate`, `beforeUpdateMany`, `beforeDelete`, and `beforeDeleteMany` may return partial options (for example `{ data: { ... } }`). Returned fields are merged into a copy of the operation options before the query runs. The caller's options object is not mutated.
+
+### Per-table hooks
+
+In addition to global hooks, you can register hooks for a specific table using its config key:
+
+```typescript
+const db = createOrm({
+  adapter: "sqlite",
+  url: ":memory:",
+  tables: { users, posts },
+  hooks: {
+    beforeCreate(ctx) {
+      // runs for every table
+    },
+    users: {
+      beforeCreate(ctx) {
+        // runs only for users, after the global beforeCreate
+        // ctx.options is typed to the users table
+      },
+    },
+  },
+});
+```
+
+Global hooks run first. Table-specific hooks receive options already merged from global before-write hooks.
+
+### Skipping hooks
+
+Pass `$skipHooks: true` on any operation to bypass hooks for that call:
+
+```typescript
+await db.users.create({
+  data: { id: "u1", name: "Alice", email: "alice@example.com" },
+  $skipHooks: true,
+});
+```
 
 ### Aborting operations
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -73,6 +73,66 @@ const db = createOrm({
 
 `$raw` on the returned client is the underlying `Bun.SQL` instance.
 
+## Hooks
+
+Pass an optional `hooks` object to `createOrm` to run lifecycle callbacks around database operations. Hooks are global (one set per ORM client) and receive context identifying the table on each call.
+
+```typescript
+const db = createOrm({
+  adapter: "sqlite",
+  url: ":memory:",
+  tables: { users },
+  hooks: {
+    beforeCreate(ctx) {
+      return {
+        data: { ...ctx.options.data, name: ctx.options.data.name.trim() },
+      };
+    },
+    afterCreate(ctx) {
+      console.log(ctx.tableName, ctx.result);
+    },
+    beforeFindMany(ctx) {
+      console.log(ctx.tableName, ctx.options);
+    },
+  },
+});
+```
+
+### Hook names
+
+Each table operation has `before*` and `after*` hooks:
+
+- `beforeFindMany` / `afterFindMany`
+- `beforeFindFirst` / `afterFindFirst`
+- `beforeFindUnique` / `afterFindUnique`
+- `beforeCreate` / `afterCreate`
+- `beforeCreateMany` / `afterCreateMany`
+- `beforeUpdate` / `afterUpdate`
+- `beforeUpdateMany` / `afterUpdateMany`
+- `beforeDelete` / `afterDelete`
+- `beforeDeleteMany` / `afterDeleteMany`
+
+### Context
+
+Every hook receives:
+
+- `tableName` - the key from the `tables` config (e.g. `"users"`)
+- `table` - the table definition object
+- `options` - the operation options passed to the method
+- `result` - on `after*` hooks, the value returned by the operation
+
+### Before-write hooks
+
+`beforeCreate`, `beforeCreateMany`, `beforeUpdate`, `beforeUpdateMany`, `beforeDelete`, and `beforeDeleteMany` may return modified options. Returned fields are merged into the operation options before the query runs.
+
+### Aborting operations
+
+Throwing from any hook aborts the operation. If the throw happens in an `after*` hook after a write, the write is not rolled back unless the call is inside `$transaction`.
+
+### Transactions
+
+Hooks also run for table clients inside `$transaction`. If a hook throws inside a transaction, the transaction is rolled back.
+
 ---
 
 ## Query API

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -19,6 +19,7 @@ import {
   boolean,
   date,
   uuid,
+  enumType,
   json,
   jsonb,
   one,
@@ -39,7 +40,7 @@ const users = defineTable("users", {
 });
 ```
 
-Column builders support: `.primaryKey()`, `.notNull()`, `.nullable()`, `.unique()`, `.default(fn)`, `.references(fn)`.
+Column builders support: `.primaryKey()`, `.notNull()`, `.nullable()`, `.unique()`, `.default(fn)`, `.references(fn)`. Enum columns use `enumType(name, values)`.
 
 ### JSON columns
 
@@ -75,7 +76,7 @@ const db = createOrm({
 
 ## Hooks
 
-Pass an optional `hooks` object to `createOrm` to run lifecycle callbacks around database operations. Hooks are global (one set per ORM client) and receive context identifying the table on each call.
+Pass an optional `hooks` object to `createOrm` to run lifecycle callbacks around database operations. Register global hooks at the top level of `hooks`. Register per-table hooks under `hooks.tables`, keyed by the table name from the `tables` config. Every hook receives context identifying the table on each call.
 
 ```typescript
 const db = createOrm({
@@ -118,8 +119,12 @@ Every hook receives:
 
 - `tableName` - the key from the `tables` config (e.g. `"users"`)
 - `table` - the table definition object
-- `options` - the operation options passed to the method
-- `result` - on `after*` hooks, the value returned by the operation
+- `options` - the operation options passed to the method (`$skipHooks` is stripped before hooks see it)
+- `result` - on `after*` hooks only, the value returned by the operation
+
+### Before-read hooks
+
+`beforeFindMany`, `beforeFindFirst`, and `beforeFindUnique` are observe-only. They cannot return modified options.
 
 ### Before-write hooks
 
@@ -127,7 +132,7 @@ Every hook receives:
 
 ### Per-table hooks
 
-In addition to global hooks, you can register hooks for a specific table under `tables`:
+In addition to global hooks, register per-table hooks under `hooks.tables` (not the top-level `tables` config):
 
 ```typescript
 const db = createOrm({
@@ -459,6 +464,8 @@ const rows = await db.$raw`SELECT COUNT(*) as count FROM users`;
 
 ## Type exports
 
+Import types with `import type { ... } from "semola/orm"`.
+
 Useful exported types include:
 
 - `TableRow<T>`
@@ -468,9 +475,13 @@ Useful exported types include:
 - `CreateOptions<T, TRelations>`
 - `CreateManyOptions<T>`
 - `UpdateOptions<T, TRelations>`
-- `UpdateManyOptions<T>`
+- `UpdateManyOptions<T, TRelations>`
 - `DeleteOptions<T, TRelations>`
-- `DeleteManyOptions<T>`
+- `DeleteManyOptions<T, TRelations>`
 - `CreateData<T>`
 - `UpdateData<T>`
 - `TransactionClient<T, R>`
+- `OrmHooksConfig<T, R>`
+- `GlobalOrmHooks`
+- `TableHooks<TTable, TRelations>`
+- `OrmHookContext<TOptions, TResult>`

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -123,11 +123,11 @@ Every hook receives:
 
 ### Before-write hooks
 
-`beforeCreate`, `beforeCreateMany`, `beforeUpdate`, `beforeUpdateMany`, `beforeDelete`, and `beforeDeleteMany` may return partial options (for example `{ data: { ... } }`). Returned fields are merged into a copy of the operation options before the query runs. The caller's options object is not mutated.
+`beforeCreate` and `beforeCreateMany` may return `{ data }`. `beforeUpdate` and `beforeUpdateMany` may return `{ where, data }`. `beforeDelete` and `beforeDeleteMany` may return `{ where }`. Returned fields are merged into a copy of the operation options before the query runs. The caller's options object is not mutated.
 
 ### Per-table hooks
 
-In addition to global hooks, you can register hooks for a specific table using its config key:
+In addition to global hooks, you can register hooks for a specific table under `tables`:
 
 ```typescript
 const db = createOrm({
@@ -138,10 +138,12 @@ const db = createOrm({
     beforeCreate(ctx) {
       // runs for every table
     },
-    users: {
-      beforeCreate(ctx) {
-        // runs only for users, after the global beforeCreate
-        // ctx.options is typed to the users table
+    tables: {
+      users: {
+        beforeCreate(ctx) {
+          // runs only for users, after the global beforeCreate
+          // ctx.options is typed to the users table
+        },
       },
     },
   },

--- a/src/lib/orm/index.ts
+++ b/src/lib/orm/index.ts
@@ -2,9 +2,33 @@ export {
   boolean,
   date,
   enumType,
+  json,
+  jsonb,
   number,
   string,
   uuid,
 } from "./column/index.js";
 export { createOrm, many, one } from "./orm/index.js";
+export type {
+  CreateData,
+  CreateManyOptions,
+  CreateOptions,
+  CreateResult,
+  DeleteManyOptions,
+  DeleteOptions,
+  DeleteResult,
+  FindFirstOptions,
+  FindManyOptions,
+  FindUniqueOptions,
+  GlobalOrmHooks,
+  OrmHookContext,
+  OrmHooksConfig,
+  TableHooks,
+  TableRow,
+  TransactionClient,
+  UpdateData,
+  UpdateManyOptions,
+  UpdateOptions,
+  UpdateResult,
+} from "./orm/types.js";
 export { defineTable } from "./table/index.js";

--- a/src/lib/orm/index.ts
+++ b/src/lib/orm/index.ts
@@ -23,6 +23,7 @@ export type {
   GlobalOrmHooks,
   OrmHookContext,
   OrmHooksConfig,
+  OrmReadHookContext,
   TableHooks,
   TableRow,
   TransactionClient,

--- a/src/lib/orm/orm/hooks.types.test.ts
+++ b/src/lib/orm/orm/hooks.types.test.ts
@@ -15,12 +15,16 @@ const examsTable = defineTable("exams", {
 });
 
 const studentsToExamsTable = defineTable("students_to_exams", {
-  studentId: uuid("student_id").notNull(),
-  examId: uuid("exam_id").notNull(),
+  studentId: uuid("student_id")
+    .notNull()
+    .references(() => studentsTable.columns.id),
+  examId: uuid("exam_id")
+    .notNull()
+    .references(() => examsTable.columns.id),
 });
 
 describe("hooks types", () => {
-  test("partial relations keep hooks usable for tables without relations", () => {
+  test("partial relations keep hooks usable for tables without relations", async () => {
     const orm = createOrm({
       adapter: "sqlite",
       url: ":memory:",
@@ -66,7 +70,29 @@ describe("hooks types", () => {
       },
     });
 
+    await orm.$raw`
+      CREATE TABLE students (id TEXT PRIMARY KEY NOT NULL, first_name TEXT NOT NULL);
+      CREATE TABLE exams (id TEXT PRIMARY KEY NOT NULL, name TEXT NOT NULL);
+      CREATE TABLE students_to_exams (
+        student_id TEXT NOT NULL REFERENCES students(id),
+        exam_id TEXT NOT NULL REFERENCES exams(id),
+        PRIMARY KEY (student_id, exam_id)
+      );
+    `;
+
+    await orm.students.createMany({ data: [{ id: "S1", firstName: "John" }] });
+    await orm.exams.createMany({ data: [{ id: "E1", name: "Math" }] });
+    await orm.studentsToExams.createMany({
+      data: [{ studentId: "S1", examId: "E1" }],
+    });
+
+    await orm.exams.findMany({ where: { name: "Math" } });
+    await orm.exams.create({ data: { id: "E2", name: "Physics" } });
+    await orm.studentsToExams.findMany({ include: { exams: true } });
+
     expect(orm.exams).toBeDefined();
+
+    await orm.$raw.close();
   });
 
   test("TableRelationsFor falls back for omitted relation keys", () => {

--- a/src/lib/orm/orm/hooks.types.test.ts
+++ b/src/lib/orm/orm/hooks.types.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { string, uuid } from "../column/index.js";
+import { defineTable } from "../table/index.js";
+import { createOrm, one } from "./index.js";
+import type { TableRelationsFor } from "./types.js";
+
+const studentsTable = defineTable("students", {
+  id: uuid("id").primaryKey().notNull(),
+  firstName: string("first_name").notNull(),
+});
+
+const examsTable = defineTable("exams", {
+  id: uuid("id").primaryKey().notNull(),
+  name: string("name").notNull(),
+});
+
+const studentsToExamsTable = defineTable("students_to_exams", {
+  studentId: uuid("student_id").notNull(),
+  examId: uuid("exam_id").notNull(),
+});
+
+describe("hooks types", () => {
+  test("partial relations keep hooks usable for tables without relations", () => {
+    const orm = createOrm({
+      adapter: "sqlite",
+      url: ":memory:",
+      tables: {
+        students: studentsTable,
+        exams: examsTable,
+        studentsToExams: studentsToExamsTable,
+      },
+      relations: {
+        studentsToExams: {
+          exams: one("examId", () => examsTable),
+        },
+      },
+      hooks: {
+        tables: {
+          exams: {
+            beforeFindMany(ctx) {
+              const where = ctx.options?.where;
+
+              if (where) {
+                expect(where.name).toBeDefined();
+              }
+            },
+            afterCreate(ctx) {
+              const result = ctx.result;
+
+              if (result) {
+                expect(result.name).toBeDefined();
+                expect(result.id).toBeDefined();
+              }
+            },
+          },
+          studentsToExams: {
+            beforeFindMany(ctx) {
+              const include = ctx.options?.include;
+
+              if (include) {
+                expect(include.exams).toBeDefined();
+              }
+            },
+          },
+        },
+      },
+    });
+
+    expect(orm.exams).toBeDefined();
+  });
+
+  test("TableRelationsFor falls back for omitted relation keys", () => {
+    type Relations = {
+      studentsToExams: {
+        exams: ReturnType<typeof one>;
+      };
+    };
+
+    type Omitted = TableRelationsFor<Relations, "exams">;
+    type Present = TableRelationsFor<Relations, "studentsToExams">;
+
+    const omitted: Omitted = {};
+    const present: Present = {
+      exams: one("examId", () => examsTable),
+    };
+
+    expect(omitted).toEqual({});
+    expect(present.exams).toBeDefined();
+  });
+});

--- a/src/lib/orm/orm/index.test.ts
+++ b/src/lib/orm/orm/index.test.ts
@@ -1500,3 +1500,187 @@ describe("many to many relation", () => {
     await orm.$raw.close();
   });
 });
+
+describe("hooks", () => {
+  test("beforeCreate can return modified options", async () => {
+    const orm = createOrm({
+      adapter: "sqlite",
+      url: ":memory:",
+      tables: { users: usersTable },
+      hooks: {
+        beforeCreate(ctx) {
+          return {
+            data: {
+              ...ctx.options.data,
+              name: "Modified",
+            },
+          };
+        },
+      },
+    });
+
+    await createUsersSchema(orm.$raw);
+
+    const created = await orm.users.create({
+      data: { id: "u1", name: "Alice", email: "alice@example.com" },
+    });
+
+    expect(created.name).toBe("Modified");
+
+    await orm.$raw.close();
+  });
+
+  test("afterCreate receives result", async () => {
+    let afterResult: unknown;
+
+    const orm = createOrm({
+      adapter: "sqlite",
+      url: ":memory:",
+      tables: { users: usersTable },
+      hooks: {
+        afterCreate(ctx) {
+          afterResult = ctx.result;
+        },
+      },
+    });
+
+    await createUsersSchema(orm.$raw);
+
+    const created = await orm.users.create({
+      data: { id: "u1", name: "Alice", email: "alice@example.com" },
+    });
+
+    expect(afterResult).toEqual(created);
+
+    await orm.$raw.close();
+  });
+
+  test("beforeFindMany and afterFindMany receive table context", async () => {
+    let beforeTableName: string | undefined;
+    let afterTableName: string | undefined;
+    let afterRowCount: number | undefined;
+
+    const orm = createOrm({
+      adapter: "sqlite",
+      url: ":memory:",
+      tables: { users: usersTable },
+      hooks: {
+        beforeFindMany(ctx) {
+          beforeTableName = ctx.tableName;
+        },
+        afterFindMany(ctx) {
+          afterTableName = ctx.tableName;
+          afterRowCount = ctx.result?.length;
+        },
+      },
+    });
+
+    await createUsersSchema(orm.$raw);
+    await seedTwoUsers(orm.$raw);
+
+    await orm.users.findMany();
+
+    expect(beforeTableName).toBe("users");
+    expect(afterTableName).toBe("users");
+    expect(afterRowCount).toBe(2);
+
+    await orm.$raw.close();
+  });
+
+  test("throwing from a hook aborts the operation", async () => {
+    const orm = createOrm({
+      adapter: "sqlite",
+      url: ":memory:",
+      tables: { users: usersTable },
+      hooks: {
+        beforeCreate() {
+          throw new Error("blocked");
+        },
+      },
+    });
+
+    await createUsersSchema(orm.$raw);
+
+    await expect(
+      orm.users.create({
+        data: { id: "u1", name: "Alice", email: "alice@example.com" },
+      }),
+    ).rejects.toThrow("blocked");
+
+    const rows = await orm.users.findMany();
+    expect(rows).toHaveLength(0);
+
+    await orm.$raw.close();
+  });
+
+  test("hooks run inside $transaction", async () => {
+    let hookCalls = 0;
+
+    const orm = createOrm({
+      adapter: "sqlite",
+      url: ":memory:",
+      tables: { users: usersTable },
+      hooks: {
+        beforeCreate() {
+          hookCalls += 1;
+
+          return undefined;
+        },
+      },
+    });
+
+    await createUsersSchema(orm.$raw);
+
+    await orm.$transaction(async (tx) => {
+      await tx.users.create({
+        data: { id: "u1", name: "Alice", email: "alice@example.com" },
+      });
+    });
+
+    expect(hookCalls).toBe(1);
+
+    await orm.$raw.close();
+  });
+
+  test("throwing from a hook inside $transaction rolls back", async () => {
+    const orm = createOrm({
+      adapter: "sqlite",
+      url: ":memory:",
+      tables: { users: usersTable },
+      hooks: {
+        afterCreate() {
+          throw new Error("rollback");
+        },
+      },
+    });
+
+    await createUsersSchema(orm.$raw);
+
+    await expect(
+      orm.$transaction(async (tx) => {
+        await tx.users.create({
+          data: { id: "u1", name: "Alice", email: "alice@example.com" },
+        });
+      }),
+    ).rejects.toThrow("rollback");
+
+    const rows = await orm.users.findMany();
+    expect(rows).toHaveLength(0);
+
+    await orm.$raw.close();
+  });
+
+  test("works without configured hooks", async () => {
+    const orm = createUsersOrm();
+
+    await createUsersSchema(orm.$raw);
+
+    const created = await orm.users.create({
+      data: { id: "u1", name: "Alice", email: "alice@example.com" },
+    });
+
+    expect(created.name).toBe("Alice");
+
+    await orm.$raw.close();
+  });
+});

--- a/src/lib/orm/orm/index.test.ts
+++ b/src/lib/orm/orm/index.test.ts
@@ -1712,18 +1712,20 @@ describe("hooks", () => {
       url: ":memory:",
       tables: { users: usersTable, posts: postsTable },
       hooks: {
-        users: {
-          beforeCreate() {
-            usersHookCalls += 1;
+        tables: {
+          users: {
+            beforeCreate() {
+              usersHookCalls += 1;
 
-            return undefined;
+              return undefined;
+            },
           },
-        },
-        posts: {
-          beforeCreate() {
-            postsHookCalls += 1;
+          posts: {
+            beforeCreate() {
+              postsHookCalls += 1;
 
-            return undefined;
+              return undefined;
+            },
           },
         },
       },
@@ -1766,11 +1768,13 @@ describe("hooks", () => {
             },
           };
         },
-        users: {
-          beforeCreate(ctx) {
-            callOrder.push(`users:${ctx.options.data.name}`);
+        tables: {
+          users: {
+            beforeCreate(ctx) {
+              callOrder.push(`users:${ctx.options.data.name}`);
 
-            return undefined;
+              return undefined;
+            },
           },
         },
       },

--- a/src/lib/orm/orm/index.test.ts
+++ b/src/lib/orm/orm/index.test.ts
@@ -30,6 +30,23 @@ const createUsersOrm = () =>
     tables: { users: usersTable },
   });
 
+const createUsersOrmWithModifyingBeforeCreate = () =>
+  createOrm({
+    adapter: "sqlite",
+    url: ":memory:",
+    tables: { users: usersTable },
+    hooks: {
+      beforeCreate(ctx) {
+        return {
+          data: {
+            ...ctx.options.data,
+            name: "Modified",
+          },
+        };
+      },
+    },
+  });
+
 const createUsersSchema = async (sql: Bun.SQL) => {
   await sql.unsafe(
     "CREATE TABLE users (id TEXT PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL)",
@@ -1503,21 +1520,7 @@ describe("many to many relation", () => {
 
 describe("hooks", () => {
   test("beforeCreate can return modified options", async () => {
-    const orm = createOrm({
-      adapter: "sqlite",
-      url: ":memory:",
-      tables: { users: usersTable },
-      hooks: {
-        beforeCreate(ctx) {
-          return {
-            data: {
-              ...ctx.options.data,
-              name: "Modified",
-            },
-          };
-        },
-      },
-    });
+    const orm = createUsersOrmWithModifyingBeforeCreate();
 
     await createUsersSchema(orm.$raw);
 
@@ -1679,6 +1682,136 @@ describe("hooks", () => {
       data: { id: "u1", name: "Alice", email: "alice@example.com" },
     });
 
+    expect(created.name).toBe("Alice");
+
+    await orm.$raw.close();
+  });
+
+  test("beforeCreate does not mutate caller options", async () => {
+    const orm = createUsersOrmWithModifyingBeforeCreate();
+
+    await createUsersSchema(orm.$raw);
+
+    const options = {
+      data: { id: "u1", name: "Alice", email: "alice@example.com" },
+    };
+
+    await orm.users.create(options);
+
+    expect(options.data.name).toBe("Alice");
+
+    await orm.$raw.close();
+  });
+
+  test("per-table hooks run only for matching table", async () => {
+    let usersHookCalls = 0;
+    let postsHookCalls = 0;
+
+    const orm = createOrm({
+      adapter: "sqlite",
+      url: ":memory:",
+      tables: { users: usersTable, posts: postsTable },
+      hooks: {
+        users: {
+          beforeCreate() {
+            usersHookCalls += 1;
+
+            return undefined;
+          },
+        },
+        posts: {
+          beforeCreate() {
+            postsHookCalls += 1;
+
+            return undefined;
+          },
+        },
+      },
+    });
+
+    await createUsersSchema(orm.$raw);
+    await orm.$raw.unsafe(
+      "CREATE TABLE posts (id TEXT PRIMARY KEY, title TEXT NOT NULL)",
+    );
+
+    await orm.users.create({
+      data: { id: "u1", name: "Alice", email: "alice@example.com" },
+    });
+
+    await orm.posts.create({
+      data: { id: "p1", title: "Hello" },
+    });
+
+    expect(usersHookCalls).toBe(1);
+    expect(postsHookCalls).toBe(1);
+
+    await orm.$raw.close();
+  });
+
+  test("global and per-table beforeCreate hooks run in order", async () => {
+    const callOrder: string[] = [];
+
+    const orm = createOrm({
+      adapter: "sqlite",
+      url: ":memory:",
+      tables: { users: usersTable },
+      hooks: {
+        beforeCreate(ctx) {
+          callOrder.push("global");
+
+          return {
+            data: {
+              ...ctx.options.data,
+              name: "AfterGlobal",
+            },
+          };
+        },
+        users: {
+          beforeCreate(ctx) {
+            callOrder.push(`users:${ctx.options.data.name}`);
+
+            return undefined;
+          },
+        },
+      },
+    });
+
+    await createUsersSchema(orm.$raw);
+
+    const created = await orm.users.create({
+      data: { id: "u1", name: "Alice", email: "alice@example.com" },
+    });
+
+    expect(callOrder).toEqual(["global", "users:AfterGlobal"]);
+    expect(created.name).toBe("AfterGlobal");
+
+    await orm.$raw.close();
+  });
+
+  test("$skipHooks bypasses hooks for a single call", async () => {
+    let hookCalls = 0;
+
+    const orm = createOrm({
+      adapter: "sqlite",
+      url: ":memory:",
+      tables: { users: usersTable },
+      hooks: {
+        beforeCreate() {
+          hookCalls += 1;
+
+          throw new Error("should not run");
+        },
+      },
+    });
+
+    await createUsersSchema(orm.$raw);
+
+    const created = await orm.users.create({
+      data: { id: "u1", name: "Alice", email: "alice@example.com" },
+      $skipHooks: true,
+    });
+
+    expect(hookCalls).toBe(0);
     expect(created.name).toBe("Alice");
 
     await orm.$raw.close();

--- a/src/lib/orm/orm/index.ts
+++ b/src/lib/orm/orm/index.ts
@@ -19,9 +19,9 @@ import type {
   HasOne,
   ObjectEntries,
   OrmClient,
-  OrmHookContext,
   OrmHooksConfig,
   OrmQueryOptions,
+  OrmReadHookContext,
   OrmTableClients,
   RelationsFor,
   StringKeyOf,
@@ -102,15 +102,17 @@ const withReadHooks = async <TResult, TOptions>(input: {
   tableName: string;
   table: Table;
   hookOptions: TOptions;
-  beforeGlobal?: (ctx: OrmHookContext<TOptions>) => void | Promise<void>;
-  beforeTable?: (ctx: OrmHookContext<TOptions>) => void | Promise<void>;
+  beforeGlobal?: (ctx: OrmReadHookContext<TOptions>) => void | Promise<void>;
+  beforeTable?: (ctx: OrmReadHookContext<TOptions>) => void | Promise<void>;
   afterGlobal?: (
-    ctx: OrmHookContext<TOptions, TResult>,
+    ctx: OrmReadHookContext<TOptions, TResult>,
   ) => void | Promise<void>;
-  afterTable?: (ctx: OrmHookContext<TOptions, TResult>) => void | Promise<void>;
+  afterTable?: (
+    ctx: OrmReadHookContext<TOptions, TResult>,
+  ) => void | Promise<void>;
   query: () => Promise<TResult>;
 }) => {
-  const beforeCtx = {
+  const beforeCtx: OrmReadHookContext<TOptions> = {
     tableName: input.tableName,
     table: input.table,
     options: input.hookOptions,

--- a/src/lib/orm/orm/index.ts
+++ b/src/lib/orm/orm/index.ts
@@ -75,47 +75,9 @@ const pickGlobalHooks = <
 >(
   hooksConfig: OrmHooksConfig<T, R>,
 ): GlobalOrmHooks => {
-  const {
-    beforeFindMany,
-    afterFindMany,
-    beforeFindFirst,
-    afterFindFirst,
-    beforeFindUnique,
-    afterFindUnique,
-    beforeCreate,
-    afterCreate,
-    beforeCreateMany,
-    afterCreateMany,
-    beforeUpdate,
-    afterUpdate,
-    beforeUpdateMany,
-    afterUpdateMany,
-    beforeDelete,
-    afterDelete,
-    beforeDeleteMany,
-    afterDeleteMany,
-  } = hooksConfig;
+  const { tables, ...globalHooks } = hooksConfig;
 
-  return {
-    beforeFindMany,
-    afterFindMany,
-    beforeFindFirst,
-    afterFindFirst,
-    beforeFindUnique,
-    afterFindUnique,
-    beforeCreate,
-    afterCreate,
-    beforeCreateMany,
-    afterCreateMany,
-    beforeUpdate,
-    afterUpdate,
-    beforeUpdateMany,
-    afterUpdateMany,
-    beforeDelete,
-    afterDelete,
-    beforeDeleteMany,
-    afterDeleteMany,
-  };
+  return globalHooks;
 };
 
 const runReadHooks = async <THookContext>(
@@ -543,8 +505,7 @@ const buildTableClients = <
         relations: tableRelations,
         tableRelationsMap,
         globalHooks: hooks ? pickGlobalHooks(hooks) : undefined,
-        // @ts-expect-error table hooks are keyed by table name
-        tableHooks: hooks?.[tableName],
+        tableHooks: hooks?.tables?.[tableName],
       });
     };
 

--- a/src/lib/orm/orm/index.ts
+++ b/src/lib/orm/orm/index.ts
@@ -27,6 +27,7 @@ import type {
   StringKeyOf,
   TableClient,
   TableRelations,
+  TableRelationsFor,
   TransactionClient,
   UpdateManyOptions,
   UpdateOptions,
@@ -80,13 +81,20 @@ const pickGlobalHooks = <
   return globalHooks;
 };
 
+const runHook = async <THookContext>(
+  hook: ((ctx: THookContext) => void | Promise<void>) | undefined,
+  ctx: THookContext,
+) => {
+  await hook?.(ctx);
+};
+
 const runReadHooks = async <THookContext>(
   globalHook: ((ctx: THookContext) => void | Promise<void>) | undefined,
   tableHook: ((ctx: THookContext) => void | Promise<void>) | undefined,
   ctx: THookContext,
 ) => {
-  await globalHook?.(ctx);
-  await tableHook?.(ctx);
+  await runHook(globalHook, ctx);
+  await runHook(tableHook, ctx);
 };
 
 const withReadHooks = async <TResult, TOptions>(input: {
@@ -263,16 +271,15 @@ const createTableClient = <T extends Table, TRelations extends TableRelations>(
       const result = await dialect.createMany(sql, queryOptions);
 
       if (!skipHooks) {
-        await runReadHooks(
-          globalHooks?.afterCreateMany,
-          tableHooks?.afterCreateMany,
-          {
-            tableName,
-            table,
-            options: queryOptions,
-            result,
-          },
-        );
+        const hookCtx = {
+          tableName,
+          table,
+          options: queryOptions,
+          result,
+        };
+
+        await runHook(globalHooks?.afterCreateMany, hookCtx);
+        await runHook(tableHooks?.afterCreateMany, hookCtx);
       }
 
       return result;
@@ -343,16 +350,15 @@ const createTableClient = <T extends Table, TRelations extends TableRelations>(
       const result = await dialect.updateMany(sql, queryOptions);
 
       if (!skipHooks) {
-        await runReadHooks(
-          globalHooks?.afterUpdateMany,
-          tableHooks?.afterUpdateMany,
-          {
-            tableName,
-            table,
-            options: queryOptions,
-            result,
-          },
-        );
+        const hookCtx = {
+          tableName,
+          table,
+          options: queryOptions,
+          result,
+        };
+
+        await runHook(globalHooks?.afterUpdateMany, hookCtx);
+        await runHook(tableHooks?.afterUpdateMany, hookCtx);
       }
 
       return result;
@@ -423,16 +429,15 @@ const createTableClient = <T extends Table, TRelations extends TableRelations>(
       const result = await dialect.deleteMany(sql, queryOptions);
 
       if (!skipHooks) {
-        await runReadHooks(
-          globalHooks?.afterDeleteMany,
-          tableHooks?.afterDeleteMany,
-          {
-            tableName,
-            table,
-            options: queryOptions,
-            result,
-          },
-        );
+        const hookCtx = {
+          tableName,
+          table,
+          options: queryOptions,
+          result,
+        };
+
+        await runHook(globalHooks?.afterDeleteMany, hookCtx);
+        await runHook(tableHooks?.afterDeleteMany, hookCtx);
       }
 
       return result;
@@ -497,11 +502,12 @@ const buildTableClients = <
       const tableRelations = getTableRelations(relations, tableName);
 
       tableRelationsMap.set(table, tableRelations);
-      clients[tableName] = createTableClient<T[K], NonNullable<R[K]>>({
+      clients[tableName] = createTableClient<T[K], TableRelationsFor<R, K>>({
         sql,
         tableName,
         table,
         adapter,
+        // @ts-expect-error TableRelationsFor and NonNullable<R[K]> are equivalent here
         relations: tableRelations,
         tableRelationsMap,
         globalHooks: hooks ? pickGlobalHooks(hooks) : undefined,

--- a/src/lib/orm/orm/index.ts
+++ b/src/lib/orm/orm/index.ts
@@ -16,6 +16,7 @@ import type {
   HasOne,
   ObjectEntries,
   OrmClient,
+  OrmHooks,
   OrmTableClients,
   RelationsFor,
   StringKeyOf,
@@ -47,10 +48,12 @@ export const one = <T extends Table, const TKey extends string>(
 
 const createTableClient = <T extends Table, TRelations extends TableRelations>(
   sql: Bun.SQL,
+  tableName: string,
   table: T,
   adapter: Adapter,
   relations: TRelations,
   tableRelationsMap: Map<Table, TableRelations>,
+  hooks: OrmHooks | undefined,
 ): TableClient<T, TRelations> => {
   const dialect = getDialect({ adapter, table, relations, tableRelationsMap });
 
@@ -58,49 +61,169 @@ const createTableClient = <T extends Table, TRelations extends TableRelations>(
     findMany: async <const TOptions extends FindManyOptions<T, TRelations>>(
       options?: TOptions,
     ) => {
-      return await dialect.findMany<TOptions>(sql, options);
+      await hooks?.beforeFindMany?.({ tableName, table, options });
+
+      const result = await dialect.findMany<TOptions>(sql, options);
+
+      await hooks?.afterFindMany?.({ tableName, table, options, result });
+
+      return result;
     },
 
     findFirst: async <const TOptions extends FindFirstOptions<T, TRelations>>(
       options?: TOptions,
     ) => {
-      return await dialect.findFirst<TOptions>(sql, options);
+      await hooks?.beforeFindFirst?.({ tableName, table, options });
+
+      const result = await dialect.findFirst<TOptions>(sql, options);
+
+      await hooks?.afterFindFirst?.({ tableName, table, options, result });
+
+      return result;
     },
 
     findUnique: async <const TOptions extends FindUniqueOptions<T, TRelations>>(
       options: TOptions,
     ) => {
-      return await dialect.findUnique<TOptions>(sql, options);
+      await hooks?.beforeFindUnique?.({ tableName, table, options });
+
+      const result = await dialect.findUnique<TOptions>(sql, options);
+
+      await hooks?.afterFindUnique?.({ tableName, table, options, result });
+
+      return result;
     },
 
     create: async <const TOptions extends CreateOptions<T, TRelations>>(
       options: TOptions,
     ): Promise<CreateResult<T, TRelations, TOptions>> => {
-      return await dialect.create<TOptions>(sql, options);
+      const createHookResult = await hooks?.beforeCreate?.({
+        tableName,
+        table,
+        options,
+      });
+
+      Object.assign(options, createHookResult);
+
+      const result = await dialect.create<TOptions>(sql, options);
+
+      await hooks?.afterCreate?.({
+        tableName,
+        table,
+        options,
+        result,
+      });
+
+      return result;
     },
 
     createMany: async (options: CreateManyOptions<T>) => {
-      return await dialect.createMany(sql, options);
+      const createManyHookResult = await hooks?.beforeCreateMany?.({
+        tableName,
+        table,
+        options,
+      });
+
+      Object.assign(options, createManyHookResult);
+
+      const result = await dialect.createMany(sql, options);
+
+      await hooks?.afterCreateMany?.({
+        tableName,
+        table,
+        options,
+        result,
+      });
+
+      return result;
     },
 
     update: async <const TOptions extends UpdateOptions<T, TRelations>>(
       options: TOptions,
     ): Promise<UpdateResult<T, TRelations, TOptions>> => {
-      return await dialect.update<TOptions>(sql, options);
+      const updateHookResult = await hooks?.beforeUpdate?.({
+        tableName,
+        table,
+        options,
+      });
+
+      Object.assign(options, updateHookResult);
+
+      const result = await dialect.update<TOptions>(sql, options);
+
+      await hooks?.afterUpdate?.({
+        tableName,
+        table,
+        options,
+        result,
+      });
+
+      return result;
     },
 
     updateMany: async (options: UpdateManyOptions<T, TRelations>) => {
-      return await dialect.updateMany(sql, options);
+      const updateManyHookResult = await hooks?.beforeUpdateMany?.({
+        tableName,
+        table,
+        options,
+      });
+
+      Object.assign(options, updateManyHookResult);
+
+      const result = await dialect.updateMany(sql, options);
+
+      await hooks?.afterUpdateMany?.({
+        tableName,
+        table,
+        options,
+        result,
+      });
+
+      return result;
     },
 
     delete: async <const TOptions extends DeleteOptions<T, TRelations>>(
       options: TOptions,
     ): Promise<DeleteResult<T, TRelations, TOptions>> => {
-      return await dialect.delete<TOptions>(sql, options);
+      const deleteHookResult = await hooks?.beforeDelete?.({
+        tableName,
+        table,
+        options,
+      });
+
+      Object.assign(options, deleteHookResult);
+
+      const result = await dialect.delete<TOptions>(sql, options);
+
+      await hooks?.afterDelete?.({
+        tableName,
+        table,
+        options,
+        result,
+      });
+
+      return result;
     },
 
     deleteMany: async (options: DeleteManyOptions<T, TRelations>) => {
-      return await dialect.deleteMany(sql, options);
+      const deleteManyHookResult = await hooks?.beforeDeleteMany?.({
+        tableName,
+        table,
+        options,
+      });
+
+      Object.assign(options, deleteManyHookResult);
+
+      const result = await dialect.deleteMany(sql, options);
+
+      await hooks?.afterDeleteMany?.({
+        tableName,
+        table,
+        options,
+        result,
+      });
+
+      return result;
     },
   };
 };
@@ -153,6 +276,7 @@ const buildTableClients = <
   sql: Bun.SQL,
   adapter: Adapter,
   tableRelationsMap: Map<Table, TableRelations>,
+  hooks: OrmHooks | undefined,
 ): OrmTableClients<T, R> => {
   const clients = Object.create(null);
 
@@ -166,10 +290,12 @@ const buildTableClients = <
       tableRelationsMap.set(table, tableRelations);
       clients[tableName] = createTableClient(
         sql,
+        tableName,
         table,
         adapter,
         tableRelations,
         tableRelationsMap,
+        hooks,
       );
     };
 
@@ -222,6 +348,7 @@ export const createOrm = <
     sql,
     options.adapter,
     tableRelationsMap,
+    options.hooks,
   );
 
   const orm = buildOrmClient<T, R>(
@@ -237,6 +364,7 @@ export const createOrm = <
           txSql,
           options.adapter,
           tableRelationsMap,
+          options.hooks,
         );
 
         const txClient = buildTransactionClient<T, R>(txTableClients, txSql);

--- a/src/lib/orm/orm/index.ts
+++ b/src/lib/orm/orm/index.ts
@@ -19,6 +19,7 @@ import type {
   HasOne,
   ObjectEntries,
   OrmClient,
+  OrmHookContext,
   OrmHooksConfig,
   OrmQueryOptions,
   OrmTableClients,
@@ -73,26 +74,49 @@ const pickGlobalHooks = <
   R extends RelationsFor<T>,
 >(
   hooksConfig: OrmHooksConfig<T, R>,
-): GlobalOrmHooks => ({
-  beforeFindMany: hooksConfig.beforeFindMany,
-  afterFindMany: hooksConfig.afterFindMany,
-  beforeFindFirst: hooksConfig.beforeFindFirst,
-  afterFindFirst: hooksConfig.afterFindFirst,
-  beforeFindUnique: hooksConfig.beforeFindUnique,
-  afterFindUnique: hooksConfig.afterFindUnique,
-  beforeCreate: hooksConfig.beforeCreate,
-  afterCreate: hooksConfig.afterCreate,
-  beforeCreateMany: hooksConfig.beforeCreateMany,
-  afterCreateMany: hooksConfig.afterCreateMany,
-  beforeUpdate: hooksConfig.beforeUpdate,
-  afterUpdate: hooksConfig.afterUpdate,
-  beforeUpdateMany: hooksConfig.beforeUpdateMany,
-  afterUpdateMany: hooksConfig.afterUpdateMany,
-  beforeDelete: hooksConfig.beforeDelete,
-  afterDelete: hooksConfig.afterDelete,
-  beforeDeleteMany: hooksConfig.beforeDeleteMany,
-  afterDeleteMany: hooksConfig.afterDeleteMany,
-});
+): GlobalOrmHooks => {
+  const {
+    beforeFindMany,
+    afterFindMany,
+    beforeFindFirst,
+    afterFindFirst,
+    beforeFindUnique,
+    afterFindUnique,
+    beforeCreate,
+    afterCreate,
+    beforeCreateMany,
+    afterCreateMany,
+    beforeUpdate,
+    afterUpdate,
+    beforeUpdateMany,
+    afterUpdateMany,
+    beforeDelete,
+    afterDelete,
+    beforeDeleteMany,
+    afterDeleteMany,
+  } = hooksConfig;
+
+  return {
+    beforeFindMany,
+    afterFindMany,
+    beforeFindFirst,
+    afterFindFirst,
+    beforeFindUnique,
+    afterFindUnique,
+    beforeCreate,
+    afterCreate,
+    beforeCreateMany,
+    afterCreateMany,
+    beforeUpdate,
+    afterUpdate,
+    beforeUpdateMany,
+    afterUpdateMany,
+    beforeDelete,
+    afterDelete,
+    beforeDeleteMany,
+    afterDeleteMany,
+  };
+};
 
 const runReadHooks = async <THookContext>(
   globalHook: ((ctx: THookContext) => void | Promise<void>) | undefined,
@@ -101,6 +125,41 @@ const runReadHooks = async <THookContext>(
 ) => {
   await globalHook?.(ctx);
   await tableHook?.(ctx);
+};
+
+const withReadHooks = async <TResult, TOptions>(input: {
+  skipHooks: boolean;
+  tableName: string;
+  table: Table;
+  hookOptions: TOptions;
+  beforeGlobal?: (ctx: OrmHookContext<TOptions>) => void | Promise<void>;
+  beforeTable?: (ctx: OrmHookContext<TOptions>) => void | Promise<void>;
+  afterGlobal?: (
+    ctx: OrmHookContext<TOptions, TResult>,
+  ) => void | Promise<void>;
+  afterTable?: (ctx: OrmHookContext<TOptions, TResult>) => void | Promise<void>;
+  query: () => Promise<TResult>;
+}) => {
+  const beforeCtx = {
+    tableName: input.tableName,
+    table: input.table,
+    options: input.hookOptions,
+  };
+
+  if (!input.skipHooks) {
+    await runReadHooks(input.beforeGlobal, input.beforeTable, beforeCtx);
+  }
+
+  const result = await input.query();
+
+  if (!input.skipHooks) {
+    await runReadHooks(input.afterGlobal, input.afterTable, {
+      ...beforeCtx,
+      result,
+    });
+  }
+
+  return result;
 };
 
 const createTableClient = <T extends Table, TRelations extends TableRelations>(
@@ -126,34 +185,17 @@ const createTableClient = <T extends Table, TRelations extends TableRelations>(
       const skipHooks = shouldSkipHooks(options);
       const hookOptions = toHookOptions(options);
 
-      if (!skipHooks) {
-        await runReadHooks(
-          globalHooks?.beforeFindMany,
-          tableHooks?.beforeFindMany,
-          {
-            tableName,
-            table,
-            options: hookOptions,
-          },
-        );
-      }
-
-      const result = await dialect.findMany(sql, hookOptions);
-
-      if (!skipHooks) {
-        await runReadHooks(
-          globalHooks?.afterFindMany,
-          tableHooks?.afterFindMany,
-          {
-            tableName,
-            table,
-            options: hookOptions,
-            result,
-          },
-        );
-      }
-
-      return result;
+      return withReadHooks({
+        skipHooks,
+        tableName,
+        table,
+        hookOptions,
+        beforeGlobal: globalHooks?.beforeFindMany,
+        beforeTable: tableHooks?.beforeFindMany,
+        afterGlobal: globalHooks?.afterFindMany,
+        afterTable: tableHooks?.afterFindMany,
+        query: () => dialect.findMany(sql, hookOptions),
+      });
     },
 
     findFirst: async <const TOptions extends FindFirstOptions<T, TRelations>>(
@@ -162,34 +204,17 @@ const createTableClient = <T extends Table, TRelations extends TableRelations>(
       const skipHooks = shouldSkipHooks(options);
       const hookOptions = toHookOptions(options);
 
-      if (!skipHooks) {
-        await runReadHooks(
-          globalHooks?.beforeFindFirst,
-          tableHooks?.beforeFindFirst,
-          {
-            tableName,
-            table,
-            options: hookOptions,
-          },
-        );
-      }
-
-      const result = await dialect.findFirst(sql, hookOptions);
-
-      if (!skipHooks) {
-        await runReadHooks(
-          globalHooks?.afterFindFirst,
-          tableHooks?.afterFindFirst,
-          {
-            tableName,
-            table,
-            options: hookOptions,
-            result,
-          },
-        );
-      }
-
-      return result;
+      return withReadHooks({
+        skipHooks,
+        tableName,
+        table,
+        hookOptions,
+        beforeGlobal: globalHooks?.beforeFindFirst,
+        beforeTable: tableHooks?.beforeFindFirst,
+        afterGlobal: globalHooks?.afterFindFirst,
+        afterTable: tableHooks?.afterFindFirst,
+        query: () => dialect.findFirst(sql, hookOptions),
+      });
     },
 
     findUnique: async <const TOptions extends FindUniqueOptions<T, TRelations>>(
@@ -198,34 +223,17 @@ const createTableClient = <T extends Table, TRelations extends TableRelations>(
       const skipHooks = shouldSkipHooks(options);
       const hookOptions = withoutSkipHooks(options);
 
-      if (!skipHooks) {
-        await runReadHooks(
-          globalHooks?.beforeFindUnique,
-          tableHooks?.beforeFindUnique,
-          {
-            tableName,
-            table,
-            options: hookOptions,
-          },
-        );
-      }
-
-      const result = await dialect.findUnique(sql, hookOptions);
-
-      if (!skipHooks) {
-        await runReadHooks(
-          globalHooks?.afterFindUnique,
-          tableHooks?.afterFindUnique,
-          {
-            tableName,
-            table,
-            options: hookOptions,
-            result,
-          },
-        );
-      }
-
-      return result;
+      return withReadHooks({
+        skipHooks,
+        tableName,
+        table,
+        hookOptions,
+        beforeGlobal: globalHooks?.beforeFindUnique,
+        beforeTable: tableHooks?.beforeFindUnique,
+        afterGlobal: globalHooks?.afterFindUnique,
+        afterTable: tableHooks?.afterFindUnique,
+        query: () => dialect.findUnique(sql, hookOptions),
+      });
     },
 
     create: async <const TOptions extends CreateOptions<T, TRelations>>(

--- a/src/lib/orm/orm/index.ts
+++ b/src/lib/orm/orm/index.ts
@@ -14,10 +14,13 @@ import type {
   FindFirstOptions,
   FindManyOptions,
   FindUniqueOptions,
+  GlobalOrmHooks,
   HasMany,
   HasOne,
   ObjectEntries,
   OrmClient,
+  OrmHooksConfig,
+  OrmQueryOptions,
   OrmTableClients,
   RelationsFor,
   StringKeyOf,
@@ -47,6 +50,59 @@ export const one = <T extends Table, const TKey extends string>(
   };
 };
 
+const shouldSkipHooks = (options: OrmQueryOptions | undefined) => {
+  return options?.$skipHooks === true;
+};
+
+const withoutSkipHooks = <T extends OrmQueryOptions>(options: T) => {
+  const { $skipHooks, ...queryOptions } = options;
+
+  return queryOptions;
+};
+
+const toHookOptions = <T extends OrmQueryOptions>(options: T | undefined) => {
+  if (!options) {
+    return undefined;
+  }
+
+  return withoutSkipHooks(options);
+};
+
+const pickGlobalHooks = <
+  T extends Record<string, Table>,
+  R extends RelationsFor<T>,
+>(
+  hooksConfig: OrmHooksConfig<T, R>,
+): GlobalOrmHooks => ({
+  beforeFindMany: hooksConfig.beforeFindMany,
+  afterFindMany: hooksConfig.afterFindMany,
+  beforeFindFirst: hooksConfig.beforeFindFirst,
+  afterFindFirst: hooksConfig.afterFindFirst,
+  beforeFindUnique: hooksConfig.beforeFindUnique,
+  afterFindUnique: hooksConfig.afterFindUnique,
+  beforeCreate: hooksConfig.beforeCreate,
+  afterCreate: hooksConfig.afterCreate,
+  beforeCreateMany: hooksConfig.beforeCreateMany,
+  afterCreateMany: hooksConfig.afterCreateMany,
+  beforeUpdate: hooksConfig.beforeUpdate,
+  afterUpdate: hooksConfig.afterUpdate,
+  beforeUpdateMany: hooksConfig.beforeUpdateMany,
+  afterUpdateMany: hooksConfig.afterUpdateMany,
+  beforeDelete: hooksConfig.beforeDelete,
+  afterDelete: hooksConfig.afterDelete,
+  beforeDeleteMany: hooksConfig.beforeDeleteMany,
+  afterDeleteMany: hooksConfig.afterDeleteMany,
+});
+
+const runReadHooks = async <THookContext>(
+  globalHook: ((ctx: THookContext) => void | Promise<void>) | undefined,
+  tableHook: ((ctx: THookContext) => void | Promise<void>) | undefined,
+  ctx: THookContext,
+) => {
+  await globalHook?.(ctx);
+  await tableHook?.(ctx);
+};
+
 const createTableClient = <T extends Table, TRelations extends TableRelations>(
   input: CreateTableClientInput<T, TRelations>,
 ): TableClient<T, TRelations> => {
@@ -57,7 +113,8 @@ const createTableClient = <T extends Table, TRelations extends TableRelations>(
     adapter,
     relations,
     tableRelationsMap,
-    hooks,
+    globalHooks,
+    tableHooks,
   } = input;
 
   const dialect = getDialect({ adapter, table, relations, tableRelationsMap });
@@ -66,11 +123,35 @@ const createTableClient = <T extends Table, TRelations extends TableRelations>(
     findMany: async <const TOptions extends FindManyOptions<T, TRelations>>(
       options?: TOptions,
     ) => {
-      await hooks?.beforeFindMany?.({ tableName, table, options });
+      const skipHooks = shouldSkipHooks(options);
+      const hookOptions = toHookOptions(options);
 
-      const result = await dialect.findMany<TOptions>(sql, options);
+      if (!skipHooks) {
+        await runReadHooks(
+          globalHooks?.beforeFindMany,
+          tableHooks?.beforeFindMany,
+          {
+            tableName,
+            table,
+            options: hookOptions,
+          },
+        );
+      }
 
-      await hooks?.afterFindMany?.({ tableName, table, options, result });
+      const result = await dialect.findMany(sql, hookOptions);
+
+      if (!skipHooks) {
+        await runReadHooks(
+          globalHooks?.afterFindMany,
+          tableHooks?.afterFindMany,
+          {
+            tableName,
+            table,
+            options: hookOptions,
+            result,
+          },
+        );
+      }
 
       return result;
     },
@@ -78,11 +159,35 @@ const createTableClient = <T extends Table, TRelations extends TableRelations>(
     findFirst: async <const TOptions extends FindFirstOptions<T, TRelations>>(
       options?: TOptions,
     ) => {
-      await hooks?.beforeFindFirst?.({ tableName, table, options });
+      const skipHooks = shouldSkipHooks(options);
+      const hookOptions = toHookOptions(options);
 
-      const result = await dialect.findFirst<TOptions>(sql, options);
+      if (!skipHooks) {
+        await runReadHooks(
+          globalHooks?.beforeFindFirst,
+          tableHooks?.beforeFindFirst,
+          {
+            tableName,
+            table,
+            options: hookOptions,
+          },
+        );
+      }
 
-      await hooks?.afterFindFirst?.({ tableName, table, options, result });
+      const result = await dialect.findFirst(sql, hookOptions);
+
+      if (!skipHooks) {
+        await runReadHooks(
+          globalHooks?.afterFindFirst,
+          tableHooks?.afterFindFirst,
+          {
+            tableName,
+            table,
+            options: hookOptions,
+            result,
+          },
+        );
+      }
 
       return result;
     },
@@ -90,11 +195,35 @@ const createTableClient = <T extends Table, TRelations extends TableRelations>(
     findUnique: async <const TOptions extends FindUniqueOptions<T, TRelations>>(
       options: TOptions,
     ) => {
-      await hooks?.beforeFindUnique?.({ tableName, table, options });
+      const skipHooks = shouldSkipHooks(options);
+      const hookOptions = withoutSkipHooks(options);
 
-      const result = await dialect.findUnique<TOptions>(sql, options);
+      if (!skipHooks) {
+        await runReadHooks(
+          globalHooks?.beforeFindUnique,
+          tableHooks?.beforeFindUnique,
+          {
+            tableName,
+            table,
+            options: hookOptions,
+          },
+        );
+      }
 
-      await hooks?.afterFindUnique?.({ tableName, table, options, result });
+      const result = await dialect.findUnique(sql, hookOptions);
+
+      if (!skipHooks) {
+        await runReadHooks(
+          globalHooks?.afterFindUnique,
+          tableHooks?.afterFindUnique,
+          {
+            tableName,
+            table,
+            options: hookOptions,
+            result,
+          },
+        );
+      }
 
       return result;
     },
@@ -102,43 +231,79 @@ const createTableClient = <T extends Table, TRelations extends TableRelations>(
     create: async <const TOptions extends CreateOptions<T, TRelations>>(
       options: TOptions,
     ): Promise<CreateResult<T, TRelations, TOptions>> => {
-      const createHookResult = await hooks?.beforeCreate?.({
-        tableName,
-        table,
-        options,
-      });
+      const skipHooks = shouldSkipHooks(options);
+      const hookOptions = withoutSkipHooks(options);
+      let queryOptions = hookOptions;
 
-      Object.assign(options, createHookResult);
+      if (!skipHooks) {
+        const createHookResult = await globalHooks?.beforeCreate?.({
+          tableName,
+          table,
+          options: hookOptions,
+        });
 
-      const result = await dialect.create<TOptions>(sql, options);
+        queryOptions = { ...hookOptions, ...createHookResult };
 
-      await hooks?.afterCreate?.({
-        tableName,
-        table,
-        options,
-        result,
-      });
+        const tableCreateHookResult = await tableHooks?.beforeCreate?.({
+          tableName,
+          table,
+          options: queryOptions,
+        });
+
+        queryOptions = { ...queryOptions, ...tableCreateHookResult };
+      }
+
+      const result = await dialect.create(sql, queryOptions);
+
+      if (!skipHooks) {
+        await runReadHooks(globalHooks?.afterCreate, tableHooks?.afterCreate, {
+          tableName,
+          table,
+          options: queryOptions,
+          result,
+        });
+      }
 
       return result;
     },
 
     createMany: async (options: CreateManyOptions<T>) => {
-      const createManyHookResult = await hooks?.beforeCreateMany?.({
-        tableName,
-        table,
-        options,
-      });
+      const skipHooks = shouldSkipHooks(options);
+      const hookOptions = withoutSkipHooks(options);
+      let queryOptions = hookOptions;
 
-      Object.assign(options, createManyHookResult);
+      if (!skipHooks) {
+        const createManyHookResult = await globalHooks?.beforeCreateMany?.({
+          tableName,
+          table,
+          options: hookOptions,
+        });
 
-      const result = await dialect.createMany(sql, options);
+        queryOptions = { ...hookOptions, ...createManyHookResult };
 
-      await hooks?.afterCreateMany?.({
-        tableName,
-        table,
-        options,
-        result,
-      });
+        const tableCreateManyHookResult = await tableHooks?.beforeCreateMany?.({
+          tableName,
+          table,
+          options: queryOptions,
+        });
+
+        queryOptions = { ...queryOptions, ...tableCreateManyHookResult };
+      }
+
+      const result = await dialect.createMany(sql, queryOptions);
+
+      if (!skipHooks) {
+        await runReadHooks(
+          globalHooks?.afterCreateMany,
+          tableHooks?.afterCreateMany,
+          {
+            tableName,
+            table,
+            options: queryOptions,
+            result,
+          },
+        );
+      }
 
       return result;
     },
@@ -146,43 +311,79 @@ const createTableClient = <T extends Table, TRelations extends TableRelations>(
     update: async <const TOptions extends UpdateOptions<T, TRelations>>(
       options: TOptions,
     ): Promise<UpdateResult<T, TRelations, TOptions>> => {
-      const updateHookResult = await hooks?.beforeUpdate?.({
-        tableName,
-        table,
-        options,
-      });
+      const skipHooks = shouldSkipHooks(options);
+      const hookOptions = withoutSkipHooks(options);
+      let queryOptions = hookOptions;
 
-      Object.assign(options, updateHookResult);
+      if (!skipHooks) {
+        const updateHookResult = await globalHooks?.beforeUpdate?.({
+          tableName,
+          table,
+          options: hookOptions,
+        });
 
-      const result = await dialect.update<TOptions>(sql, options);
+        queryOptions = { ...hookOptions, ...updateHookResult };
 
-      await hooks?.afterUpdate?.({
-        tableName,
-        table,
-        options,
-        result,
-      });
+        const tableUpdateHookResult = await tableHooks?.beforeUpdate?.({
+          tableName,
+          table,
+          options: queryOptions,
+        });
+
+        queryOptions = { ...queryOptions, ...tableUpdateHookResult };
+      }
+
+      const result = await dialect.update(sql, queryOptions);
+
+      if (!skipHooks) {
+        await runReadHooks(globalHooks?.afterUpdate, tableHooks?.afterUpdate, {
+          tableName,
+          table,
+          options: queryOptions,
+          result,
+        });
+      }
 
       return result;
     },
 
     updateMany: async (options: UpdateManyOptions<T, TRelations>) => {
-      const updateManyHookResult = await hooks?.beforeUpdateMany?.({
-        tableName,
-        table,
-        options,
-      });
+      const skipHooks = shouldSkipHooks(options);
+      const hookOptions = withoutSkipHooks(options);
+      let queryOptions = hookOptions;
 
-      Object.assign(options, updateManyHookResult);
+      if (!skipHooks) {
+        const updateManyHookResult = await globalHooks?.beforeUpdateMany?.({
+          tableName,
+          table,
+          options: hookOptions,
+        });
 
-      const result = await dialect.updateMany(sql, options);
+        queryOptions = { ...hookOptions, ...updateManyHookResult };
 
-      await hooks?.afterUpdateMany?.({
-        tableName,
-        table,
-        options,
-        result,
-      });
+        const tableUpdateManyHookResult = await tableHooks?.beforeUpdateMany?.({
+          tableName,
+          table,
+          options: queryOptions,
+        });
+
+        queryOptions = { ...queryOptions, ...tableUpdateManyHookResult };
+      }
+
+      const result = await dialect.updateMany(sql, queryOptions);
+
+      if (!skipHooks) {
+        await runReadHooks(
+          globalHooks?.afterUpdateMany,
+          tableHooks?.afterUpdateMany,
+          {
+            tableName,
+            table,
+            options: queryOptions,
+            result,
+          },
+        );
+      }
 
       return result;
     },
@@ -190,43 +391,79 @@ const createTableClient = <T extends Table, TRelations extends TableRelations>(
     delete: async <const TOptions extends DeleteOptions<T, TRelations>>(
       options: TOptions,
     ): Promise<DeleteResult<T, TRelations, TOptions>> => {
-      const deleteHookResult = await hooks?.beforeDelete?.({
-        tableName,
-        table,
-        options,
-      });
+      const skipHooks = shouldSkipHooks(options);
+      const hookOptions = withoutSkipHooks(options);
+      let queryOptions = hookOptions;
 
-      Object.assign(options, deleteHookResult);
+      if (!skipHooks) {
+        const deleteHookResult = await globalHooks?.beforeDelete?.({
+          tableName,
+          table,
+          options: hookOptions,
+        });
 
-      const result = await dialect.delete<TOptions>(sql, options);
+        queryOptions = { ...hookOptions, ...deleteHookResult };
 
-      await hooks?.afterDelete?.({
-        tableName,
-        table,
-        options,
-        result,
-      });
+        const tableDeleteHookResult = await tableHooks?.beforeDelete?.({
+          tableName,
+          table,
+          options: queryOptions,
+        });
+
+        queryOptions = { ...queryOptions, ...tableDeleteHookResult };
+      }
+
+      const result = await dialect.delete(sql, queryOptions);
+
+      if (!skipHooks) {
+        await runReadHooks(globalHooks?.afterDelete, tableHooks?.afterDelete, {
+          tableName,
+          table,
+          options: queryOptions,
+          result,
+        });
+      }
 
       return result;
     },
 
     deleteMany: async (options: DeleteManyOptions<T, TRelations>) => {
-      const deleteManyHookResult = await hooks?.beforeDeleteMany?.({
-        tableName,
-        table,
-        options,
-      });
+      const skipHooks = shouldSkipHooks(options);
+      const hookOptions = withoutSkipHooks(options);
+      let queryOptions = hookOptions;
 
-      Object.assign(options, deleteManyHookResult);
+      if (!skipHooks) {
+        const deleteManyHookResult = await globalHooks?.beforeDeleteMany?.({
+          tableName,
+          table,
+          options: hookOptions,
+        });
 
-      const result = await dialect.deleteMany(sql, options);
+        queryOptions = { ...hookOptions, ...deleteManyHookResult };
 
-      await hooks?.afterDeleteMany?.({
-        tableName,
-        table,
-        options,
-        result,
-      });
+        const tableDeleteManyHookResult = await tableHooks?.beforeDeleteMany?.({
+          tableName,
+          table,
+          options: queryOptions,
+        });
+
+        queryOptions = { ...queryOptions, ...tableDeleteManyHookResult };
+      }
+
+      const result = await dialect.deleteMany(sql, queryOptions);
+
+      if (!skipHooks) {
+        await runReadHooks(
+          globalHooks?.afterDeleteMany,
+          tableHooks?.afterDeleteMany,
+          {
+            tableName,
+            table,
+            options: queryOptions,
+            result,
+          },
+        );
+      }
 
       return result;
     },
@@ -254,19 +491,19 @@ const getTableRelations = <
 >(
   relations: R | undefined,
   tableName: K,
-): TableRelations => {
+): NonNullable<R[K]> => {
   if (!relations) {
-    return {};
+    return Object.create(null);
   }
 
   if (!Object.hasOwn(relations, tableName)) {
-    return {};
+    return Object.create(null);
   }
 
   const tableRelations = relations[tableName];
 
   if (!tableRelations) {
-    return {};
+    return Object.create(null);
   }
 
   return tableRelations;
@@ -290,14 +527,16 @@ const buildTableClients = <
       const tableRelations = getTableRelations(relations, tableName);
 
       tableRelationsMap.set(table, tableRelations);
-      clients[tableName] = createTableClient({
+      clients[tableName] = createTableClient<T[K], NonNullable<R[K]>>({
         sql,
         tableName,
         table,
         adapter,
         relations: tableRelations,
         tableRelationsMap,
-        hooks,
+        globalHooks: hooks ? pickGlobalHooks(hooks) : undefined,
+        // @ts-expect-error table hooks are keyed by table name
+        tableHooks: hooks?.[tableName],
       });
     };
 

--- a/src/lib/orm/orm/index.ts
+++ b/src/lib/orm/orm/index.ts
@@ -1,11 +1,13 @@
-import type { Adapter } from "../dialect/index.js";
 import { getDialect } from "../dialect/index.js";
 import type { Table } from "../table/types.js";
 import type {
+  BuildOrmClientInput,
+  BuildTableClientsInput,
   CreateManyOptions,
   CreateOptions,
   CreateOrmOptions,
   CreateResult,
+  CreateTableClientInput,
   DeleteManyOptions,
   DeleteOptions,
   DeleteResult,
@@ -16,7 +18,6 @@ import type {
   HasOne,
   ObjectEntries,
   OrmClient,
-  OrmHooks,
   OrmTableClients,
   RelationsFor,
   StringKeyOf,
@@ -47,14 +48,18 @@ export const one = <T extends Table, const TKey extends string>(
 };
 
 const createTableClient = <T extends Table, TRelations extends TableRelations>(
-  sql: Bun.SQL,
-  tableName: string,
-  table: T,
-  adapter: Adapter,
-  relations: TRelations,
-  tableRelationsMap: Map<Table, TableRelations>,
-  hooks: OrmHooks | undefined,
+  input: CreateTableClientInput<T, TRelations>,
 ): TableClient<T, TRelations> => {
+  const {
+    sql,
+    tableName,
+    table,
+    adapter,
+    relations,
+    tableRelationsMap,
+    hooks,
+  } = input;
+
   const dialect = getDialect({ adapter, table, relations, tableRelationsMap });
 
   return {
@@ -271,13 +276,10 @@ const buildTableClients = <
   T extends Record<string, Table>,
   R extends RelationsFor<T>,
 >(
-  tables: T,
-  relations: R | undefined,
-  sql: Bun.SQL,
-  adapter: Adapter,
-  tableRelationsMap: Map<Table, TableRelations>,
-  hooks: OrmHooks | undefined,
+  input: BuildTableClientsInput<T, R>,
 ): OrmTableClients<T, R> => {
+  const { tables, relations, sql, adapter, tableRelationsMap, hooks } = input;
+
   const clients = Object.create(null);
 
   for (const entry of toObjectEntries(tables)) {
@@ -288,15 +290,15 @@ const buildTableClients = <
       const tableRelations = getTableRelations(relations, tableName);
 
       tableRelationsMap.set(table, tableRelations);
-      clients[tableName] = createTableClient(
+      clients[tableName] = createTableClient({
         sql,
         tableName,
         table,
         adapter,
-        tableRelations,
+        relations: tableRelations,
         tableRelationsMap,
         hooks,
-      );
+      });
     };
 
     setTableClient(entry[0], entry[1]);
@@ -309,16 +311,16 @@ const buildOrmClient = <
   T extends Record<string, Table>,
   R extends RelationsFor<T>,
 >(
-  tableClients: OrmTableClients<T, R>,
-  sql: Bun.SQL,
-  transaction: <TResult>(
-    callback: (tx: TransactionClient<T, R>) => Promise<TResult>,
-  ) => Promise<TResult>,
-): OrmClient<T, R> => ({
-  ...tableClients,
-  $raw: sql,
-  $transaction: transaction,
-});
+  input: BuildOrmClientInput<T, R>,
+): OrmClient<T, R> => {
+  const { tableClients, sql, transaction } = input;
+
+  return {
+    ...tableClients,
+    $raw: sql,
+    $transaction: transaction,
+  };
+};
 
 const buildTransactionClient = <
   T extends Record<string, Table>,
@@ -342,37 +344,37 @@ export const createOrm = <
   });
 
   const tableRelationsMap = new Map<Table, TableRelations>();
-  const tableClients = buildTableClients(
-    options.tables,
-    options.relations,
+  const tableClients = buildTableClients({
+    tables: options.tables,
+    relations: options.relations,
     sql,
-    options.adapter,
+    adapter: options.adapter,
     tableRelationsMap,
-    options.hooks,
-  );
+    hooks: options.hooks,
+  });
 
-  const orm = buildOrmClient<T, R>(
+  const orm = buildOrmClient<T, R>({
     tableClients,
     sql,
-    async <TResult>(
+    transaction: async <TResult>(
       callback: (tx: TransactionClient<T, R>) => Promise<TResult>,
     ): Promise<TResult> => {
       return await sql.begin(async (txSql) => {
-        const txTableClients = buildTableClients(
-          options.tables,
-          options.relations,
-          txSql,
-          options.adapter,
+        const txTableClients = buildTableClients({
+          tables: options.tables,
+          relations: options.relations,
+          sql: txSql,
+          adapter: options.adapter,
           tableRelationsMap,
-          options.hooks,
-        );
+          hooks: options.hooks,
+        });
 
         const txClient = buildTransactionClient<T, R>(txTableClients, txSql);
 
         return await callback(txClient);
       });
     },
-  );
+  });
 
   return orm;
 };

--- a/src/lib/orm/orm/types.ts
+++ b/src/lib/orm/orm/types.ts
@@ -630,6 +630,13 @@ export type OrmHookContext<TOptions, TResult = undefined> = {
   result?: TResult;
 };
 
+export type OrmReadHookContext<TOptions, TResult = undefined> = {
+  tableName: string;
+  table: Table;
+  readonly options: Readonly<TOptions>;
+  result?: TResult;
+};
+
 type BeforeHookReturn<TResult> =
   | TResult
   | undefined
@@ -698,28 +705,31 @@ export type OrmHookName =
 
 export type GlobalOrmHooks = {
   beforeFindMany?: <T extends Table>(
-    ctx: OrmHookContext<FindManyOptions<T> | undefined>,
+    ctx: OrmReadHookContext<FindManyOptions<T> | undefined>,
   ) => void | Promise<void>;
   afterFindMany?: <T extends Table>(
-    ctx: OrmHookContext<FindManyOptions<T> | undefined, unknown[]>,
+    ctx: OrmReadHookContext<FindManyOptions<T> | undefined, unknown[]>,
   ) => void | Promise<void>;
   beforeFindFirst?: <T extends Table>(
-    ctx: OrmHookContext<FindFirstOptions<T> | undefined>,
+    ctx: OrmReadHookContext<FindFirstOptions<T> | undefined>,
   ) => void | Promise<void>;
   afterFindFirst?: <T extends Table>(
-    ctx: OrmHookContext<FindFirstOptions<T> | undefined, unknown | null>,
+    ctx: OrmReadHookContext<FindFirstOptions<T> | undefined, unknown | null>,
   ) => void | Promise<void>;
   beforeFindUnique?: <
     TTable extends Table,
     TRelations extends TableRelations = TableRelations,
   >(
-    ctx: OrmHookContext<FindUniqueOptions<TTable, TRelations>>,
+    ctx: OrmReadHookContext<FindUniqueOptions<TTable, TRelations>>,
   ) => void | Promise<void>;
   afterFindUnique?: <
     TTable extends Table,
     TRelations extends TableRelations = TableRelations,
   >(
-    ctx: OrmHookContext<FindUniqueOptions<TTable, TRelations>, unknown | null>,
+    ctx: OrmReadHookContext<
+      FindUniqueOptions<TTable, TRelations>,
+      unknown | null
+    >,
   ) => void | Promise<void>;
   beforeCreate?: <
     TTable extends Table,
@@ -794,28 +804,28 @@ export type TableHooks<
   TRelations extends TableRelations = TableRelations,
 > = {
   beforeFindMany?: (
-    ctx: OrmHookContext<FindManyOptions<TTable, TRelations> | undefined>,
+    ctx: OrmReadHookContext<FindManyOptions<TTable, TRelations> | undefined>,
   ) => void | Promise<void>;
   afterFindMany?: (
-    ctx: OrmHookContext<
+    ctx: OrmReadHookContext<
       FindManyOptions<TTable, TRelations> | undefined,
       Array<TableHookResult<TTable>>
     >,
   ) => void | Promise<void>;
   beforeFindFirst?: (
-    ctx: OrmHookContext<FindFirstOptions<TTable, TRelations> | undefined>,
+    ctx: OrmReadHookContext<FindFirstOptions<TTable, TRelations> | undefined>,
   ) => void | Promise<void>;
   afterFindFirst?: (
-    ctx: OrmHookContext<
+    ctx: OrmReadHookContext<
       FindFirstOptions<TTable, TRelations> | undefined,
       TableHookResult<TTable> | null
     >,
   ) => void | Promise<void>;
   beforeFindUnique?: (
-    ctx: OrmHookContext<FindUniqueOptions<TTable, TRelations>>,
+    ctx: OrmReadHookContext<FindUniqueOptions<TTable, TRelations>>,
   ) => void | Promise<void>;
   afterFindUnique?: (
-    ctx: OrmHookContext<
+    ctx: OrmReadHookContext<
       FindUniqueOptions<TTable, TRelations>,
       TableHookResult<TTable> | null
     >,

--- a/src/lib/orm/orm/types.ts
+++ b/src/lib/orm/orm/types.ts
@@ -732,6 +732,42 @@ export type OrmHooks = {
   ) => void | Promise<void>;
 };
 
+export type CreateTableClientInput<
+  T extends Table = Table,
+  TRelations extends TableRelations = TableRelations,
+> = {
+  sql: Bun.SQL;
+  tableName: string;
+  table: T;
+  adapter: Adapter;
+  relations: TRelations;
+  tableRelationsMap: Map<Table, TableRelations>;
+  hooks?: OrmHooks;
+};
+
+export type BuildTableClientsInput<
+  T extends Record<string, Table> = Record<string, Table>,
+  R extends RelationsFor<T> = RelationsFor<T>,
+> = {
+  tables: T;
+  relations?: R;
+  sql: Bun.SQL;
+  adapter: Adapter;
+  tableRelationsMap: Map<Table, TableRelations>;
+  hooks?: OrmHooks;
+};
+
+export type BuildOrmClientInput<
+  T extends Record<string, Table> = Record<string, Table>,
+  R extends RelationsFor<T> = RelationsFor<T>,
+> = {
+  tableClients: OrmTableClients<T, R>;
+  sql: Bun.SQL;
+  transaction: <TResult>(
+    callback: (tx: TransactionClient<T, R>) => Promise<TResult>,
+  ) => Promise<TResult>;
+};
+
 export type TableClient<
   T extends Table,
   TRelations extends TableRelations = TableRelations,

--- a/src/lib/orm/orm/types.ts
+++ b/src/lib/orm/orm/types.ts
@@ -365,6 +365,11 @@ export type TableRow<T extends Table> = Prettify<{
   [TColumnName in keyof T["columns"]]: ColumnValue<T["columns"][TColumnName]>;
 }>;
 
+// After-hook results use a row superset so hooks stay assignable when queries select or include.
+export type TableHookResult<T extends Table> = Prettify<
+  Partial<TableRow<T>> & Record<string, unknown>
+>;
+
 type IsRequiredCreateColumn<TColumn extends Column> =
   TColumn["_meta"]["isNullable"] extends false
     ? TColumn["_meta"]["hasDefault"] extends true
@@ -794,7 +799,7 @@ export type TableHooks<
   afterFindMany?: (
     ctx: OrmHookContext<
       FindManyOptions<TTable, TRelations> | undefined,
-      unknown[]
+      Array<TableHookResult<TTable>>
     >,
   ) => void | Promise<void>;
   beforeFindFirst?: (
@@ -803,50 +808,68 @@ export type TableHooks<
   afterFindFirst?: (
     ctx: OrmHookContext<
       FindFirstOptions<TTable, TRelations> | undefined,
-      unknown | null
+      TableHookResult<TTable> | null
     >,
   ) => void | Promise<void>;
   beforeFindUnique?: (
     ctx: OrmHookContext<FindUniqueOptions<TTable, TRelations>>,
   ) => void | Promise<void>;
   afterFindUnique?: (
-    ctx: OrmHookContext<FindUniqueOptions<TTable, TRelations>, unknown | null>,
+    ctx: OrmHookContext<
+      FindUniqueOptions<TTable, TRelations>,
+      TableHookResult<TTable> | null
+    >,
   ) => void | Promise<void>;
   beforeCreate?: (
     ctx: OrmHookContext<CreateOptions<TTable, TRelations>>,
   ) => BeforeHookReturn<BeforeCreateHookResult<TTable, TRelations>>;
   afterCreate?: (
-    ctx: OrmHookContext<CreateOptions<TTable, TRelations>, unknown>,
+    ctx: OrmHookContext<
+      CreateOptions<TTable, TRelations>,
+      TableHookResult<TTable>
+    >,
   ) => void | Promise<void>;
   beforeCreateMany?: (
     ctx: OrmHookContext<CreateManyOptions<TTable>>,
   ) => BeforeHookReturn<BeforeCreateManyHookResult<TTable>>;
   afterCreateMany?: (
-    ctx: OrmHookContext<CreateManyOptions<TTable>, unknown[]>,
+    ctx: OrmHookContext<CreateManyOptions<TTable>, Array<TableRow<TTable>>>,
   ) => void | Promise<void>;
   beforeUpdate?: (
     ctx: OrmHookContext<UpdateOptions<TTable, TRelations>>,
   ) => BeforeHookReturn<BeforeUpdateHookResult<TTable, TRelations>>;
   afterUpdate?: (
-    ctx: OrmHookContext<UpdateOptions<TTable, TRelations>, unknown>,
+    ctx: OrmHookContext<
+      UpdateOptions<TTable, TRelations>,
+      TableHookResult<TTable>
+    >,
   ) => void | Promise<void>;
   beforeUpdateMany?: (
     ctx: OrmHookContext<UpdateManyOptions<TTable, TRelations>>,
   ) => BeforeHookReturn<BeforeUpdateManyHookResult<TTable, TRelations>>;
   afterUpdateMany?: (
-    ctx: OrmHookContext<UpdateManyOptions<TTable, TRelations>, unknown[]>,
+    ctx: OrmHookContext<
+      UpdateManyOptions<TTable, TRelations>,
+      Array<TableRow<TTable>>
+    >,
   ) => void | Promise<void>;
   beforeDelete?: (
     ctx: OrmHookContext<DeleteOptions<TTable, TRelations>>,
   ) => BeforeHookReturn<BeforeDeleteHookResult<TTable, TRelations>>;
   afterDelete?: (
-    ctx: OrmHookContext<DeleteOptions<TTable, TRelations>, unknown>,
+    ctx: OrmHookContext<
+      DeleteOptions<TTable, TRelations>,
+      TableHookResult<TTable>
+    >,
   ) => void | Promise<void>;
   beforeDeleteMany?: (
     ctx: OrmHookContext<DeleteManyOptions<TTable, TRelations>>,
   ) => BeforeHookReturn<BeforeDeleteManyHookResult<TTable, TRelations>>;
   afterDeleteMany?: (
-    ctx: OrmHookContext<DeleteManyOptions<TTable, TRelations>, unknown[]>,
+    ctx: OrmHookContext<
+      DeleteManyOptions<TTable, TRelations>,
+      Array<TableRow<TTable>>
+    >,
   ) => void | Promise<void>;
 };
 
@@ -855,7 +878,7 @@ export type OrmHooksConfig<
   R extends RelationsFor<T> = RelationsFor<T>,
 > = GlobalOrmHooks & {
   tables?: {
-    [K in keyof T]?: TableHooks<T[K], NonNullable<R[K]>>;
+    [K in keyof T]?: TableHooks<T[K], TableRelationsFor<R, K>>;
   };
 };
 

--- a/src/lib/orm/orm/types.ts
+++ b/src/lib/orm/orm/types.ts
@@ -35,6 +35,10 @@ type ExactlyOne<T extends Record<PropertyKey, unknown>> = {
   };
 }[keyof T];
 
+export type OrmQueryOptions = {
+  $skipHooks?: boolean;
+};
+
 export type CreateOrmOptions<
   T extends Record<string, Table> = Record<string, Table>,
   R extends RelationsFor<T> = RelationsFor<T>,
@@ -43,7 +47,7 @@ export type CreateOrmOptions<
   url: string;
   tables: T;
   relations?: R;
-  hooks?: OrmHooks;
+  hooks?: OrmHooksConfig<T, R>;
 };
 
 // Look up the raw relations for a table by matching its structural type against all tables.
@@ -287,7 +291,7 @@ export type FindManyOptions<
   TRelations extends TableRelations = TableRelations,
   TAllTables extends Record<string, Table> = Record<string, Table>,
   TAllRelations = Record<string, unknown>,
-> = {
+> = OrmQueryOptions & {
   where?: TableWhere<T, TRelations>;
   select?: TableSelect<T>;
   orderBy?: TableOrderBy<T>;
@@ -351,7 +355,7 @@ export type FindUniqueOptions<
   TRelations extends TableRelations = TableRelations,
   TAllTables extends Record<string, Table> = Record<string, Table>,
   TAllRelations = Record<string, unknown>,
-> = {
+> = OrmQueryOptions & {
   where: FindUniqueWhere<T>;
   select?: TableSelect<T>;
   include?: TableInclude<TRelations, TAllTables, TAllRelations>;
@@ -394,7 +398,7 @@ export type CreateOptions<
   TRelations extends TableRelations = TableRelations,
   TAllTables extends Record<string, Table> = Record<string, Table>,
   TAllRelations = Record<string, unknown>,
-> = {
+> = OrmQueryOptions & {
   data: CreateData<T>;
   select?: TableSelect<T>;
   include?: TableInclude<TRelations, TAllTables, TAllRelations>;
@@ -425,7 +429,7 @@ export type UpdateOptions<
   TRelations extends TableRelations = TableRelations,
   TAllTables extends Record<string, Table> = Record<string, Table>,
   TAllRelations = Record<string, unknown>,
-> = {
+> = OrmQueryOptions & {
   where: FindUniqueWhere<T>;
   data: UpdateData<T>;
   select?: TableSelect<T>;
@@ -467,14 +471,14 @@ export type DeleteResult<
   FindUniqueResult<T, TRelations, TOptions, TAllTables, TAllRelations>
 >;
 
-export type CreateManyOptions<T extends Table> = {
+export type CreateManyOptions<T extends Table> = OrmQueryOptions & {
   data: CreateData<T>[];
 };
 
 export type UpdateManyOptions<
   T extends Table,
   TRelations extends TableRelations = TableRelations,
-> = {
+> = OrmQueryOptions & {
   where?: TableWhere<T, TRelations>;
   data: UpdateData<T>;
 };
@@ -482,7 +486,7 @@ export type UpdateManyOptions<
 export type DeleteManyOptions<
   T extends Table,
   TRelations extends TableRelations = TableRelations,
-> = {
+> = OrmQueryOptions & {
   where?: TableWhere<T, TRelations>;
 };
 
@@ -621,7 +625,27 @@ export type OrmHookContext<TOptions, TResult = undefined> = {
   result?: TResult;
 };
 
-export type OrmHooks = {
+export type OrmHookName =
+  | "beforeFindMany"
+  | "afterFindMany"
+  | "beforeFindFirst"
+  | "afterFindFirst"
+  | "beforeFindUnique"
+  | "afterFindUnique"
+  | "beforeCreate"
+  | "afterCreate"
+  | "beforeCreateMany"
+  | "afterCreateMany"
+  | "beforeUpdate"
+  | "afterUpdate"
+  | "beforeUpdateMany"
+  | "afterUpdateMany"
+  | "beforeDelete"
+  | "afterDelete"
+  | "beforeDeleteMany"
+  | "afterDeleteMany";
+
+export type GlobalOrmHooks = {
   beforeFindMany?: <T extends Table>(
     ctx: OrmHookContext<FindManyOptions<T> | undefined>,
   ) => void | Promise<void>;
@@ -652,9 +676,9 @@ export type OrmHooks = {
   >(
     ctx: OrmHookContext<CreateOptions<TTable, TRelations>>,
   ) =>
-    | CreateOptions<TTable, TRelations>
+    | Partial<CreateOptions<TTable, TRelations>>
     | undefined
-    | Promise<CreateOptions<TTable, TRelations> | undefined>;
+    | Promise<Partial<CreateOptions<TTable, TRelations>> | undefined>;
   afterCreate?: <
     TTable extends Table,
     TRelations extends TableRelations = TableRelations,
@@ -664,9 +688,9 @@ export type OrmHooks = {
   beforeCreateMany?: <TTable extends Table>(
     ctx: OrmHookContext<CreateManyOptions<TTable>>,
   ) =>
-    | CreateManyOptions<TTable>
+    | Partial<CreateManyOptions<TTable>>
     | undefined
-    | Promise<CreateManyOptions<TTable> | undefined>;
+    | Promise<Partial<CreateManyOptions<TTable>> | undefined>;
   afterCreateMany?: <TTable extends Table>(
     ctx: OrmHookContext<CreateManyOptions<TTable>, unknown[]>,
   ) => void | Promise<void>;
@@ -676,9 +700,9 @@ export type OrmHooks = {
   >(
     ctx: OrmHookContext<UpdateOptions<TTable, TRelations>>,
   ) =>
-    | UpdateOptions<TTable, TRelations>
+    | Partial<UpdateOptions<TTable, TRelations>>
     | undefined
-    | Promise<UpdateOptions<TTable, TRelations> | undefined>;
+    | Promise<Partial<UpdateOptions<TTable, TRelations>> | undefined>;
   afterUpdate?: <
     TTable extends Table,
     TRelations extends TableRelations = TableRelations,
@@ -691,9 +715,9 @@ export type OrmHooks = {
   >(
     ctx: OrmHookContext<UpdateManyOptions<TTable, TRelations>>,
   ) =>
-    | UpdateManyOptions<TTable, TRelations>
+    | Partial<UpdateManyOptions<TTable, TRelations>>
     | undefined
-    | Promise<UpdateManyOptions<TTable, TRelations> | undefined>;
+    | Promise<Partial<UpdateManyOptions<TTable, TRelations>> | undefined>;
   afterUpdateMany?: <
     TTable extends Table,
     TRelations extends TableRelations = TableRelations,
@@ -706,9 +730,9 @@ export type OrmHooks = {
   >(
     ctx: OrmHookContext<DeleteOptions<TTable, TRelations>>,
   ) =>
-    | DeleteOptions<TTable, TRelations>
+    | Partial<DeleteOptions<TTable, TRelations>>
     | undefined
-    | Promise<DeleteOptions<TTable, TRelations> | undefined>;
+    | Promise<Partial<DeleteOptions<TTable, TRelations>> | undefined>;
   afterDelete?: <
     TTable extends Table,
     TRelations extends TableRelations = TableRelations,
@@ -721,15 +745,109 @@ export type OrmHooks = {
   >(
     ctx: OrmHookContext<DeleteManyOptions<TTable, TRelations>>,
   ) =>
-    | DeleteManyOptions<TTable, TRelations>
+    | Partial<DeleteManyOptions<TTable, TRelations>>
     | undefined
-    | Promise<DeleteManyOptions<TTable, TRelations> | undefined>;
+    | Promise<Partial<DeleteManyOptions<TTable, TRelations>> | undefined>;
   afterDeleteMany?: <
     TTable extends Table,
     TRelations extends TableRelations = TableRelations,
   >(
     ctx: OrmHookContext<DeleteManyOptions<TTable, TRelations>, unknown[]>,
   ) => void | Promise<void>;
+};
+
+export type TableHooks<
+  TTable extends Table,
+  TRelations extends TableRelations = TableRelations,
+> = {
+  beforeFindMany?: (
+    ctx: OrmHookContext<FindManyOptions<TTable, TRelations> | undefined>,
+  ) => void | Promise<void>;
+  afterFindMany?: (
+    ctx: OrmHookContext<
+      FindManyOptions<TTable, TRelations> | undefined,
+      unknown[]
+    >,
+  ) => void | Promise<void>;
+  beforeFindFirst?: (
+    ctx: OrmHookContext<FindFirstOptions<TTable, TRelations> | undefined>,
+  ) => void | Promise<void>;
+  afterFindFirst?: (
+    ctx: OrmHookContext<
+      FindFirstOptions<TTable, TRelations> | undefined,
+      unknown | null
+    >,
+  ) => void | Promise<void>;
+  beforeFindUnique?: (
+    ctx: OrmHookContext<FindUniqueOptions<TTable, TRelations>>,
+  ) => void | Promise<void>;
+  afterFindUnique?: (
+    ctx: OrmHookContext<FindUniqueOptions<TTable, TRelations>, unknown | null>,
+  ) => void | Promise<void>;
+  beforeCreate?: (
+    ctx: OrmHookContext<CreateOptions<TTable, TRelations>>,
+  ) =>
+    | Partial<CreateOptions<TTable, TRelations>>
+    | undefined
+    | Promise<Partial<CreateOptions<TTable, TRelations>> | undefined>;
+  afterCreate?: (
+    ctx: OrmHookContext<CreateOptions<TTable, TRelations>, unknown>,
+  ) => void | Promise<void>;
+  beforeCreateMany?: (
+    ctx: OrmHookContext<CreateManyOptions<TTable>>,
+  ) =>
+    | Partial<CreateManyOptions<TTable>>
+    | undefined
+    | Promise<Partial<CreateManyOptions<TTable>> | undefined>;
+  afterCreateMany?: (
+    ctx: OrmHookContext<CreateManyOptions<TTable>, unknown[]>,
+  ) => void | Promise<void>;
+  beforeUpdate?: (
+    ctx: OrmHookContext<UpdateOptions<TTable, TRelations>>,
+  ) =>
+    | Partial<UpdateOptions<TTable, TRelations>>
+    | undefined
+    | Promise<Partial<UpdateOptions<TTable, TRelations>> | undefined>;
+  afterUpdate?: (
+    ctx: OrmHookContext<UpdateOptions<TTable, TRelations>, unknown>,
+  ) => void | Promise<void>;
+  beforeUpdateMany?: (
+    ctx: OrmHookContext<UpdateManyOptions<TTable, TRelations>>,
+  ) =>
+    | Partial<UpdateManyOptions<TTable, TRelations>>
+    | undefined
+    | Promise<Partial<UpdateManyOptions<TTable, TRelations>> | undefined>;
+  afterUpdateMany?: (
+    ctx: OrmHookContext<UpdateManyOptions<TTable, TRelations>, unknown[]>,
+  ) => void | Promise<void>;
+  beforeDelete?: (
+    ctx: OrmHookContext<DeleteOptions<TTable, TRelations>>,
+  ) =>
+    | Partial<DeleteOptions<TTable, TRelations>>
+    | undefined
+    | Promise<Partial<DeleteOptions<TTable, TRelations>> | undefined>;
+  afterDelete?: (
+    ctx: OrmHookContext<DeleteOptions<TTable, TRelations>, unknown>,
+  ) => void | Promise<void>;
+  beforeDeleteMany?: (
+    ctx: OrmHookContext<DeleteManyOptions<TTable, TRelations>>,
+  ) =>
+    | Partial<DeleteManyOptions<TTable, TRelations>>
+    | undefined
+    | Promise<Partial<DeleteManyOptions<TTable, TRelations>> | undefined>;
+  afterDeleteMany?: (
+    ctx: OrmHookContext<DeleteManyOptions<TTable, TRelations>, unknown[]>,
+  ) => void | Promise<void>;
+};
+
+export type OrmHooksConfig<
+  T extends Record<string, Table>,
+  R extends RelationsFor<T> = RelationsFor<T>,
+> = GlobalOrmHooks & {
+  [K in keyof T as K extends OrmHookName ? never : K]?: TableHooks<
+    T[K],
+    TableRelationsFor<R, K>
+  >;
 };
 
 export type CreateTableClientInput<
@@ -742,7 +860,8 @@ export type CreateTableClientInput<
   adapter: Adapter;
   relations: TRelations;
   tableRelationsMap: Map<Table, TableRelations>;
-  hooks?: OrmHooks;
+  globalHooks?: GlobalOrmHooks;
+  tableHooks?: TableHooks<T, TRelations>;
 };
 
 export type BuildTableClientsInput<
@@ -754,7 +873,7 @@ export type BuildTableClientsInput<
   sql: Bun.SQL;
   adapter: Adapter;
   tableRelationsMap: Map<Table, TableRelations>;
-  hooks?: OrmHooks;
+  hooks?: OrmHooksConfig<T, R>;
 };
 
 export type BuildOrmClientInput<

--- a/src/lib/orm/orm/types.ts
+++ b/src/lib/orm/orm/types.ts
@@ -43,6 +43,7 @@ export type CreateOrmOptions<
   url: string;
   tables: T;
   relations?: R;
+  hooks?: OrmHooks;
 };
 
 // Look up the raw relations for a table by matching its structural type against all tables.
@@ -612,6 +613,124 @@ export type FindUniqueResult<
   SelectResult<T, TOptions> &
     IncludeResult<TRelations, TOptions, TAllTables, TAllRelations>
 > | null;
+
+export type OrmHookContext<TOptions, TResult = undefined> = {
+  tableName: string;
+  table: Table;
+  options: TOptions;
+  result?: TResult;
+};
+
+export type OrmHooks = {
+  beforeFindMany?: <T extends Table>(
+    ctx: OrmHookContext<FindManyOptions<T> | undefined>,
+  ) => void | Promise<void>;
+  afterFindMany?: <T extends Table>(
+    ctx: OrmHookContext<FindManyOptions<T> | undefined, unknown[]>,
+  ) => void | Promise<void>;
+  beforeFindFirst?: <T extends Table>(
+    ctx: OrmHookContext<FindFirstOptions<T> | undefined>,
+  ) => void | Promise<void>;
+  afterFindFirst?: <T extends Table>(
+    ctx: OrmHookContext<FindFirstOptions<T> | undefined, unknown | null>,
+  ) => void | Promise<void>;
+  beforeFindUnique?: <
+    TTable extends Table,
+    TRelations extends TableRelations = TableRelations,
+  >(
+    ctx: OrmHookContext<FindUniqueOptions<TTable, TRelations>>,
+  ) => void | Promise<void>;
+  afterFindUnique?: <
+    TTable extends Table,
+    TRelations extends TableRelations = TableRelations,
+  >(
+    ctx: OrmHookContext<FindUniqueOptions<TTable, TRelations>, unknown | null>,
+  ) => void | Promise<void>;
+  beforeCreate?: <
+    TTable extends Table,
+    TRelations extends TableRelations = TableRelations,
+  >(
+    ctx: OrmHookContext<CreateOptions<TTable, TRelations>>,
+  ) =>
+    | CreateOptions<TTable, TRelations>
+    | undefined
+    | Promise<CreateOptions<TTable, TRelations> | undefined>;
+  afterCreate?: <
+    TTable extends Table,
+    TRelations extends TableRelations = TableRelations,
+  >(
+    ctx: OrmHookContext<CreateOptions<TTable, TRelations>, unknown>,
+  ) => void | Promise<void>;
+  beforeCreateMany?: <TTable extends Table>(
+    ctx: OrmHookContext<CreateManyOptions<TTable>>,
+  ) =>
+    | CreateManyOptions<TTable>
+    | undefined
+    | Promise<CreateManyOptions<TTable> | undefined>;
+  afterCreateMany?: <TTable extends Table>(
+    ctx: OrmHookContext<CreateManyOptions<TTable>, unknown[]>,
+  ) => void | Promise<void>;
+  beforeUpdate?: <
+    TTable extends Table,
+    TRelations extends TableRelations = TableRelations,
+  >(
+    ctx: OrmHookContext<UpdateOptions<TTable, TRelations>>,
+  ) =>
+    | UpdateOptions<TTable, TRelations>
+    | undefined
+    | Promise<UpdateOptions<TTable, TRelations> | undefined>;
+  afterUpdate?: <
+    TTable extends Table,
+    TRelations extends TableRelations = TableRelations,
+  >(
+    ctx: OrmHookContext<UpdateOptions<TTable, TRelations>, unknown>,
+  ) => void | Promise<void>;
+  beforeUpdateMany?: <
+    TTable extends Table,
+    TRelations extends TableRelations = TableRelations,
+  >(
+    ctx: OrmHookContext<UpdateManyOptions<TTable, TRelations>>,
+  ) =>
+    | UpdateManyOptions<TTable, TRelations>
+    | undefined
+    | Promise<UpdateManyOptions<TTable, TRelations> | undefined>;
+  afterUpdateMany?: <
+    TTable extends Table,
+    TRelations extends TableRelations = TableRelations,
+  >(
+    ctx: OrmHookContext<UpdateManyOptions<TTable, TRelations>, unknown[]>,
+  ) => void | Promise<void>;
+  beforeDelete?: <
+    TTable extends Table,
+    TRelations extends TableRelations = TableRelations,
+  >(
+    ctx: OrmHookContext<DeleteOptions<TTable, TRelations>>,
+  ) =>
+    | DeleteOptions<TTable, TRelations>
+    | undefined
+    | Promise<DeleteOptions<TTable, TRelations> | undefined>;
+  afterDelete?: <
+    TTable extends Table,
+    TRelations extends TableRelations = TableRelations,
+  >(
+    ctx: OrmHookContext<DeleteOptions<TTable, TRelations>, unknown>,
+  ) => void | Promise<void>;
+  beforeDeleteMany?: <
+    TTable extends Table,
+    TRelations extends TableRelations = TableRelations,
+  >(
+    ctx: OrmHookContext<DeleteManyOptions<TTable, TRelations>>,
+  ) =>
+    | DeleteManyOptions<TTable, TRelations>
+    | undefined
+    | Promise<DeleteManyOptions<TTable, TRelations> | undefined>;
+  afterDeleteMany?: <
+    TTable extends Table,
+    TRelations extends TableRelations = TableRelations,
+  >(
+    ctx: OrmHookContext<DeleteManyOptions<TTable, TRelations>, unknown[]>,
+  ) => void | Promise<void>;
+};
 
 export type TableClient<
   T extends Table,

--- a/src/lib/orm/orm/types.ts
+++ b/src/lib/orm/orm/types.ts
@@ -625,6 +625,52 @@ export type OrmHookContext<TOptions, TResult = undefined> = {
   result?: TResult;
 };
 
+type BeforeHookReturn<TResult> =
+  | TResult
+  | undefined
+  | Promise<TResult | undefined>;
+
+type BeforeCreateHookResult<
+  TTable extends Table,
+  TRelations extends TableRelations,
+> = {
+  data?: CreateOptions<TTable, TRelations>["data"];
+};
+
+type BeforeCreateManyHookResult<TTable extends Table> = {
+  data?: CreateManyOptions<TTable>["data"];
+};
+
+type BeforeUpdateHookResult<
+  TTable extends Table,
+  TRelations extends TableRelations,
+> = {
+  where?: UpdateOptions<TTable, TRelations>["where"];
+  data?: UpdateOptions<TTable, TRelations>["data"];
+};
+
+type BeforeUpdateManyHookResult<
+  TTable extends Table,
+  TRelations extends TableRelations,
+> = {
+  where?: UpdateManyOptions<TTable, TRelations>["where"];
+  data?: UpdateManyOptions<TTable, TRelations>["data"];
+};
+
+type BeforeDeleteHookResult<
+  TTable extends Table,
+  TRelations extends TableRelations,
+> = {
+  where?: DeleteOptions<TTable, TRelations>["where"];
+};
+
+type BeforeDeleteManyHookResult<
+  TTable extends Table,
+  TRelations extends TableRelations,
+> = {
+  where?: DeleteManyOptions<TTable, TRelations>["where"];
+};
+
 export type OrmHookName =
   | "beforeFindMany"
   | "afterFindMany"
@@ -675,10 +721,7 @@ export type GlobalOrmHooks = {
     TRelations extends TableRelations = TableRelations,
   >(
     ctx: OrmHookContext<CreateOptions<TTable, TRelations>>,
-  ) =>
-    | Partial<CreateOptions<TTable, TRelations>>
-    | undefined
-    | Promise<Partial<CreateOptions<TTable, TRelations>> | undefined>;
+  ) => BeforeHookReturn<BeforeCreateHookResult<TTable, TRelations>>;
   afterCreate?: <
     TTable extends Table,
     TRelations extends TableRelations = TableRelations,
@@ -687,10 +730,7 @@ export type GlobalOrmHooks = {
   ) => void | Promise<void>;
   beforeCreateMany?: <TTable extends Table>(
     ctx: OrmHookContext<CreateManyOptions<TTable>>,
-  ) =>
-    | Partial<CreateManyOptions<TTable>>
-    | undefined
-    | Promise<Partial<CreateManyOptions<TTable>> | undefined>;
+  ) => BeforeHookReturn<BeforeCreateManyHookResult<TTable>>;
   afterCreateMany?: <TTable extends Table>(
     ctx: OrmHookContext<CreateManyOptions<TTable>, unknown[]>,
   ) => void | Promise<void>;
@@ -699,10 +739,7 @@ export type GlobalOrmHooks = {
     TRelations extends TableRelations = TableRelations,
   >(
     ctx: OrmHookContext<UpdateOptions<TTable, TRelations>>,
-  ) =>
-    | Partial<UpdateOptions<TTable, TRelations>>
-    | undefined
-    | Promise<Partial<UpdateOptions<TTable, TRelations>> | undefined>;
+  ) => BeforeHookReturn<BeforeUpdateHookResult<TTable, TRelations>>;
   afterUpdate?: <
     TTable extends Table,
     TRelations extends TableRelations = TableRelations,
@@ -714,10 +751,7 @@ export type GlobalOrmHooks = {
     TRelations extends TableRelations = TableRelations,
   >(
     ctx: OrmHookContext<UpdateManyOptions<TTable, TRelations>>,
-  ) =>
-    | Partial<UpdateManyOptions<TTable, TRelations>>
-    | undefined
-    | Promise<Partial<UpdateManyOptions<TTable, TRelations>> | undefined>;
+  ) => BeforeHookReturn<BeforeUpdateManyHookResult<TTable, TRelations>>;
   afterUpdateMany?: <
     TTable extends Table,
     TRelations extends TableRelations = TableRelations,
@@ -729,10 +763,7 @@ export type GlobalOrmHooks = {
     TRelations extends TableRelations = TableRelations,
   >(
     ctx: OrmHookContext<DeleteOptions<TTable, TRelations>>,
-  ) =>
-    | Partial<DeleteOptions<TTable, TRelations>>
-    | undefined
-    | Promise<Partial<DeleteOptions<TTable, TRelations>> | undefined>;
+  ) => BeforeHookReturn<BeforeDeleteHookResult<TTable, TRelations>>;
   afterDelete?: <
     TTable extends Table,
     TRelations extends TableRelations = TableRelations,
@@ -744,10 +775,7 @@ export type GlobalOrmHooks = {
     TRelations extends TableRelations = TableRelations,
   >(
     ctx: OrmHookContext<DeleteManyOptions<TTable, TRelations>>,
-  ) =>
-    | Partial<DeleteManyOptions<TTable, TRelations>>
-    | undefined
-    | Promise<Partial<DeleteManyOptions<TTable, TRelations>> | undefined>;
+  ) => BeforeHookReturn<BeforeDeleteManyHookResult<TTable, TRelations>>;
   afterDeleteMany?: <
     TTable extends Table,
     TRelations extends TableRelations = TableRelations,
@@ -786,55 +814,37 @@ export type TableHooks<
   ) => void | Promise<void>;
   beforeCreate?: (
     ctx: OrmHookContext<CreateOptions<TTable, TRelations>>,
-  ) =>
-    | Partial<CreateOptions<TTable, TRelations>>
-    | undefined
-    | Promise<Partial<CreateOptions<TTable, TRelations>> | undefined>;
+  ) => BeforeHookReturn<BeforeCreateHookResult<TTable, TRelations>>;
   afterCreate?: (
     ctx: OrmHookContext<CreateOptions<TTable, TRelations>, unknown>,
   ) => void | Promise<void>;
   beforeCreateMany?: (
     ctx: OrmHookContext<CreateManyOptions<TTable>>,
-  ) =>
-    | Partial<CreateManyOptions<TTable>>
-    | undefined
-    | Promise<Partial<CreateManyOptions<TTable>> | undefined>;
+  ) => BeforeHookReturn<BeforeCreateManyHookResult<TTable>>;
   afterCreateMany?: (
     ctx: OrmHookContext<CreateManyOptions<TTable>, unknown[]>,
   ) => void | Promise<void>;
   beforeUpdate?: (
     ctx: OrmHookContext<UpdateOptions<TTable, TRelations>>,
-  ) =>
-    | Partial<UpdateOptions<TTable, TRelations>>
-    | undefined
-    | Promise<Partial<UpdateOptions<TTable, TRelations>> | undefined>;
+  ) => BeforeHookReturn<BeforeUpdateHookResult<TTable, TRelations>>;
   afterUpdate?: (
     ctx: OrmHookContext<UpdateOptions<TTable, TRelations>, unknown>,
   ) => void | Promise<void>;
   beforeUpdateMany?: (
     ctx: OrmHookContext<UpdateManyOptions<TTable, TRelations>>,
-  ) =>
-    | Partial<UpdateManyOptions<TTable, TRelations>>
-    | undefined
-    | Promise<Partial<UpdateManyOptions<TTable, TRelations>> | undefined>;
+  ) => BeforeHookReturn<BeforeUpdateManyHookResult<TTable, TRelations>>;
   afterUpdateMany?: (
     ctx: OrmHookContext<UpdateManyOptions<TTable, TRelations>, unknown[]>,
   ) => void | Promise<void>;
   beforeDelete?: (
     ctx: OrmHookContext<DeleteOptions<TTable, TRelations>>,
-  ) =>
-    | Partial<DeleteOptions<TTable, TRelations>>
-    | undefined
-    | Promise<Partial<DeleteOptions<TTable, TRelations>> | undefined>;
+  ) => BeforeHookReturn<BeforeDeleteHookResult<TTable, TRelations>>;
   afterDelete?: (
     ctx: OrmHookContext<DeleteOptions<TTable, TRelations>, unknown>,
   ) => void | Promise<void>;
   beforeDeleteMany?: (
     ctx: OrmHookContext<DeleteManyOptions<TTable, TRelations>>,
-  ) =>
-    | Partial<DeleteManyOptions<TTable, TRelations>>
-    | undefined
-    | Promise<Partial<DeleteManyOptions<TTable, TRelations>> | undefined>;
+  ) => BeforeHookReturn<BeforeDeleteManyHookResult<TTable, TRelations>>;
   afterDeleteMany?: (
     ctx: OrmHookContext<DeleteManyOptions<TTable, TRelations>, unknown[]>,
   ) => void | Promise<void>;
@@ -844,10 +854,9 @@ export type OrmHooksConfig<
   T extends Record<string, Table>,
   R extends RelationsFor<T> = RelationsFor<T>,
 > = GlobalOrmHooks & {
-  [K in keyof T as K extends OrmHookName ? never : K]?: TableHooks<
-    T[K],
-    TableRelationsFor<R, K>
-  >;
+  tables?: {
+    [K in keyof T]?: TableHooks<T[K], NonNullable<R[K]>>;
+  };
 };
 
 export type CreateTableClientInput<


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ORM lifecycle hooks with global + per-table configuration, typed hook contexts, and `before*`/`after*` support for all CRUD operations.
  * `before*` hooks can return modified options (without mutating the caller’s input); `$skipHooks` bypasses hooks per call.
* **Bug Fixes**
  * Improved ORM relation handling by returning an empty object for missing relations.
* **Documentation**
  * Expanded ORM docs with hook semantics, `$transaction` behavior, and `enumType` builder guidance; updated exported-type documentation.
* **Type Exports & Tests**
  * Exposed hook and query option types (including `$skipHooks`), added `json`/`jsonb` exports, and introduced hook typing/behavior tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->