### PR TITLE
Fix(semola/cron): Fixed shared retry instances for crons

### DIFF
--- a/docs/cron.md
+++ b/docs/cron.md
@@ -53,7 +53,7 @@ await osJob.stop();
 ## Options
 
 - `Cron` class:
-  - **`name: string`** (required) - Job name
+  - **`name: string`** (required) - Job's name
   - **`schedule: string`** (required) - Cron expression or alias
   - **`handler: () => unknown`** (required) - Function to execute on schedule. Support both sync and async functions
   - **`jobId: string`** (optional) - A unique id assigned for each cron jobs. If not provided, the class will generate a random uuid

--- a/docs/cron.md
+++ b/docs/cron.md
@@ -53,9 +53,10 @@ await osJob.stop();
 ## Options
 
 - `Cron` class:
-  - **`name: string`** (required) - Unique job name
+  - **`name: string`** (required) - Job name
   - **`schedule: string`** (required) - Cron expression or alias
   - **`handler: () => unknown`** (required) - Function to execute on schedule. Support both sync and async functions
+  - **`jobId: string`** (optional) - A unique id assigned for each cron jobs. If not provided, the class will generate a random uuid
   - **`retry: RetryCronJob`** (optional) - Instance of `RetryCronJob` class containing retries' handling logic. You can 
   use the same instance for multiple `Cron` instances. For more information about errors and retries, check 
   the [Error Handling and Retries](#error-handling-and-retries) section 
@@ -215,7 +216,7 @@ Bun invokes the cron callback on each schedule tick. Inside that callback, `Cron
 
 `RetryCronJob.update()` only tracks attempts and backoff. It does not call `handler` itself; Bun re-invokes the callback on the next scheduled run.
 
-Create one `RetryCronJob` per `Cron` job or share the same instance with multiple `Cron` jobs. When sharing one `RetryCronJob` instance, it internally uses the cron job's name to ensure state isolation and, in case it's used for two jobs with the same name, the old job is replaced.
+Create one `RetryCronJob` per `Cron` job or share the same instance with multiple `Cron` jobs. When sharing one `RetryCronJob` instance, it internally uses the cron job's id to ensure state isolation.
 
 `maxAttempts` is validated in the `RetryCronJob` constructor. Invalid values raise `InvalidRetryError` at construction time.
 
@@ -246,14 +247,17 @@ const cleanup = new Cron({
   - `name: string` - The job's name
   - `failedAt: number` - When the job failed, expressed in milliseconds
   - `error: Error` - Which error was fired
+  - `jobId: string` - Job's id
 - **`retryOnError(ctx: RetryOnErrorContextType): boolean`** (optional) - Function called before each attempt. This function return `true` if a job should consume the current retry, otherwise it must return `false`. By default, if not provided, a job will retry on every error raised by the `handler` function. The `RetryOnErrorContextType` type contains the following properties:
     - `error: Error` - Which error was fired in the `handler` function 
     - `jobName: string` - Job's name
+    - `jobId: string` - Job's id
 - **`onFailedAttempt(ctx: OnFailedAttemptContextType): void | Promise<void>`** (optional) - Function called on every attempt. The `OnFailedAttemptContextType` type contains the following properties:
   - `error: Error` - Which error was fired in the `handler` function
   - `jobName: string` - Job's name
   - `attemptNumber: number` - The attempt number. Note that they start at 1
   - `retriesLeft: number` - How many retries remains before stopping the job
+  - `jobId: string` - Job's id
   - `delay: number` - Backoff delay in milliseconds before the next scheduled run. Calculated with exponential backoff and [Full Jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/). The callback returns after this delay; Bun invokes `handler` again on the next schedule tick. Note that the `delay` is capped to 1 minute.
 
 

--- a/src/lib/cron/core/index.test.ts
+++ b/src/lib/cron/core/index.test.ts
@@ -460,7 +460,7 @@ describe("Cron", () => {
     test("should successfully call onError() callback", async () => {
       setSystemTime(new Date("2020-01-10T00:00:00.000Z"));
       const handler = () => Promise.resolve();
-
+      const jobId = "1";
       const retry = new RetryCronJob({
         maxAttempts: 0,
         onError: (err) => {
@@ -476,6 +476,7 @@ describe("Cron", () => {
         schedule: "0 0 * * *",
         handler,
         retry,
+        jobId,
       });
 
       expect(cron).toBeDefined();
@@ -489,6 +490,7 @@ describe("Cron", () => {
         job: cron,
         error: new Error("A generic error"),
         name: cron.getJobName(),
+        jobId,
       };
       await retry.update(ctx);
       expect(cron.getStatus()).toBe("idle");
@@ -498,6 +500,7 @@ describe("Cron", () => {
 
     test("should successfully throw an error when onError() callback is not defined", async () => {
       const handler = () => Promise.resolve();
+      const jobId = "1";
       const retry = new RetryCronJob({
         maxAttempts: 0,
       });
@@ -507,6 +510,7 @@ describe("Cron", () => {
         schedule: "0 0 * * *",
         handler,
         retry,
+        jobId,
       });
 
       expect(cron).toBeDefined();
@@ -520,6 +524,7 @@ describe("Cron", () => {
         job: cron,
         error: new Error("A generic error"),
         name: cron.getJobName(),
+        jobId,
       };
       const [theError] = await mightThrow(retry.update(ctx));
 
@@ -530,6 +535,7 @@ describe("Cron", () => {
 
     test("should successfully call onFailedAttempt() callback", async () => {
       const handler = () => Promise.resolve();
+      const jobId = "1";
 
       const retry = new RetryCronJob({
         maxAttempts: 3,
@@ -557,6 +563,7 @@ describe("Cron", () => {
         schedule: "0 0 * * *",
         handler,
         retry,
+        jobId,
       });
 
       expect(cron).toBeDefined();
@@ -570,6 +577,7 @@ describe("Cron", () => {
         job: cron,
         error: new Error("A generic error"),
         name: cron.getJobName(),
+        jobId,
       };
 
       await retry.update(ctx);
@@ -584,6 +592,7 @@ describe("Cron", () => {
 
     test("should not retry when retryOnError() callback return false", async () => {
       const handler = () => Promise.resolve();
+      const jobId = "1";
 
       const retry = new RetryCronJob({
         maxAttempts: 5,
@@ -595,6 +604,7 @@ describe("Cron", () => {
         schedule: "0 0 * * *",
         handler,
         retry,
+        jobId,
       });
 
       expect(cron).toBeDefined();
@@ -608,6 +618,7 @@ describe("Cron", () => {
         job: cron,
         error: new Error("A generic error"),
         name: cron.getJobName(),
+        jobId,
       };
 
       await retry.update(ctx);
@@ -618,6 +629,7 @@ describe("Cron", () => {
         job: cron,
         error: new UserDefinedError("User defined error"),
         name: cron.getJobName(),
+        jobId,
       };
 
       const [userDefinedError] = await mightThrow(
@@ -631,7 +643,7 @@ describe("Cron", () => {
     test("should not retry when retryOnError() callback return false and also call onError() callback", async () => {
       setSystemTime(new Date("2020-01-10T00:00:00.000Z"));
       const handler = () => Promise.resolve();
-
+      const jobId = "1";
       const retry = new RetryCronJob({
         maxAttempts: 5,
         retryOnError: ({ error: err }) => !(err instanceof UserDefinedError),
@@ -648,6 +660,7 @@ describe("Cron", () => {
         schedule: "0 0 * * *",
         handler,
         retry,
+        jobId,
       });
 
       expect(cron).toBeDefined();
@@ -661,6 +674,7 @@ describe("Cron", () => {
         job: cron,
         error: new Error("A generic error"),
         name: cron.getJobName(),
+        jobId,
       };
 
       await retry.update(ctx);
@@ -671,6 +685,7 @@ describe("Cron", () => {
         job: cron,
         error: new UserDefinedError("User defined error"),
         name: cron.getJobName(),
+        jobId,
       };
 
       await retry.update(ctxWithCustomError);
@@ -680,6 +695,8 @@ describe("Cron", () => {
 
     test("should reset attempts after a success", async () => {
       const handler = () => Promise.resolve();
+      const jobId = "1";
+
       const maxAttempts = 10;
       let shouldFail = true;
       const retry = new RetryCronJob({
@@ -696,6 +713,7 @@ describe("Cron", () => {
         schedule: "0 0 * * *",
         handler,
         retry,
+        jobId,
       });
 
       expect(cron).toBeDefined();
@@ -706,6 +724,7 @@ describe("Cron", () => {
         job: cron,
         error: new Error("A generic error"),
         name: cron.getJobName(),
+        jobId,
       };
 
       const [firstErr] = await mightThrow(retry.update(ctx));
@@ -716,13 +735,16 @@ describe("Cron", () => {
 
       shouldFail = true;
       const [thirdErr] = await mightThrow(
-        retry.update({ type: "success", name: cron.getJobName() }),
+        retry.update({ type: "success", jobId }),
       );
       expect(thirdErr).toBeNull();
     });
 
     test("keeps per-job retry state when a RetryCronJob instance is shared", async () => {
       const perJobFailes: { retriesLeft: number; jobName: string }[] = [];
+      const firstJobId = "1";
+      const secondJobId = "2";
+
       const retry = new RetryCronJob({
         maxAttempts: 2,
         onFailedAttempt: ({ retriesLeft, jobName }) => {
@@ -735,6 +757,7 @@ describe("Cron", () => {
         schedule: "0 0 * * *",
         handler: () => Promise.resolve(),
         retry,
+        jobId: firstJobId,
       });
 
       const cronB = new Cron({
@@ -742,17 +765,20 @@ describe("Cron", () => {
         schedule: "0 0 * * *",
         handler: () => Promise.resolve(),
         retry,
+        jobId: secondJobId,
       });
 
       const ctxA: NotifyContext = {
         type: "error",
         job: cronA,
+        jobId: firstJobId,
         error: new Error("a"),
         name: cronA.getJobName(),
       };
 
       const ctxB: NotifyContext = {
         type: "error",
+        jobId: secondJobId,
         job: cronB,
         error: new Error("b"),
         name: cronB.getJobName(),

--- a/src/lib/cron/core/index.test.ts
+++ b/src/lib/cron/core/index.test.ts
@@ -468,6 +468,7 @@ describe("Cron", () => {
           expect(err.error.message).toBe("A generic error");
           expect(err.failedAt).toBe(Date.now());
           expect(err.name).toBe("retry-job");
+          expect(err.jobId).toBe(jobId);
         },
       });
 
@@ -539,13 +540,20 @@ describe("Cron", () => {
 
       const retry = new RetryCronJob({
         maxAttempts: 3,
-        onFailedAttempt: ({ attemptNumber, delay, error, retriesLeft }) => {
+        onFailedAttempt: ({
+          jobId: onFailedAttemptId,
+          attemptNumber,
+          delay,
+          error,
+          retriesLeft,
+        }) => {
           if (attemptNumber === 1) {
             expect(attemptNumber).toBe(1);
             expect(delay).toBeGreaterThan(0);
             expect(error).toBeInstanceOf(Error);
             expect(error.message).toBe("A generic error");
             expect(retriesLeft).toBe(3);
+            expect(onFailedAttemptId).toBe(jobId);
 
             return;
           }
@@ -652,6 +660,7 @@ describe("Cron", () => {
           expect(err.error.message).toBe("User defined error");
           expect(err.failedAt).toBe(Date.now());
           expect(err.name).toBe("retry-job");
+          expect(err.jobId).toBe(jobId);
         },
       });
 
@@ -701,9 +710,10 @@ describe("Cron", () => {
       let shouldFail = true;
       const retry = new RetryCronJob({
         maxAttempts,
-        onFailedAttempt: ({ retriesLeft }) => {
+        onFailedAttempt: ({ retriesLeft, jobId: onFailedAttemptId }) => {
           if (shouldFail) {
             expect(retriesLeft).toBe(maxAttempts);
+            expect(onFailedAttemptId).toBe(jobId);
           }
         },
       });
@@ -741,14 +751,22 @@ describe("Cron", () => {
     });
 
     test("keeps per-job retry state when a RetryCronJob instance is shared", async () => {
-      const perJobFailes: { retriesLeft: number; jobName: string }[] = [];
+      const perJobFailes: {
+        retriesLeft: number;
+        jobName: string;
+        jobId: string;
+      }[] = [];
       const firstJobId = "1";
       const secondJobId = "2";
 
       const retry = new RetryCronJob({
         maxAttempts: 2,
-        onFailedAttempt: ({ retriesLeft, jobName }) => {
-          perJobFailes.push({ retriesLeft, jobName });
+        onFailedAttempt: ({
+          retriesLeft,
+          jobName,
+          jobId: onFailedAttemptId,
+        }) => {
+          perJobFailes.push({ retriesLeft, jobName, jobId: onFailedAttemptId });
         },
       });
 
@@ -790,11 +808,13 @@ describe("Cron", () => {
       expect(perJobFailes[0]).toMatchObject({
         retriesLeft: 2,
         jobName: "job-a",
+        jobId: firstJobId,
       });
 
       expect(perJobFailes[1]).toMatchObject({
         retriesLeft: 2,
         jobName: "job-b",
+        jobId: secondJobId,
       });
 
       await retry.update(ctxB);
@@ -802,11 +822,13 @@ describe("Cron", () => {
       expect(perJobFailes[0]).toMatchObject({
         retriesLeft: 2,
         jobName: "job-a",
+        jobId: firstJobId,
       });
 
       expect(perJobFailes[2]).toMatchObject({
         retriesLeft: 1,
         jobName: "job-b",
+        jobId: secondJobId,
       });
     });
 

--- a/src/lib/cron/core/index.ts
+++ b/src/lib/cron/core/index.ts
@@ -177,7 +177,7 @@ export class Cron extends JobWithRetry {
   public constructor(options: CronOptions) {
     super();
     this.options = options;
-    this.jobId = crypto.randomUUID();
+    this.jobId = options?.jobId ?? crypto.randomUUID();
     this.status = "idle";
     this.common = new CommonCronUtilities();
 

--- a/src/lib/cron/core/index.ts
+++ b/src/lib/cron/core/index.ts
@@ -102,7 +102,7 @@ export class RetryCronJob implements RetryObserver {
         await this.options.onFailedAttempt(context);
       }
 
-      this.jobs.set(ctx.name, jobAttempts + 1);
+      this.jobs.set(ctx.jobId, jobAttempts + 1);
       await this.runDelay(delay);
 
       return;

--- a/src/lib/cron/core/index.ts
+++ b/src/lib/cron/core/index.ts
@@ -81,9 +81,9 @@ export class RetryCronJob implements RetryObserver {
       return;
     }
 
-    const { job, error, name } = ctx;
+    const { job, error, name, jobId } = ctx;
     const { maxAttempts } = this.options;
-    const onRetryErrorResult = this.runOnRetryError(error, name);
+    const onRetryErrorResult = this.runOnRetryError(error, name, jobId);
     const hasMoreAttempts = jobAttempts < maxAttempts;
     const canRetry = hasMoreAttempts && onRetryErrorResult;
 
@@ -97,6 +97,7 @@ export class RetryCronJob implements RetryObserver {
           error,
           retriesLeft: maxAttempts - jobAttempts,
           jobName: name,
+          jobId,
         };
 
         await this.options.onFailedAttempt(context);
@@ -114,6 +115,7 @@ export class RetryCronJob implements RetryObserver {
     const data: ErrorMetadataType = {
       name,
       error,
+      jobId,
       failedAt: Date.now(),
     };
 
@@ -130,9 +132,9 @@ export class RetryCronJob implements RetryObserver {
     return isNaturalNumber && isValidInteger && !isNegativeZero;
   }
 
-  private runOnRetryError(error: Error, jobName: string) {
+  private runOnRetryError(error: Error, jobName: string, jobId: string) {
     if (!this.options.retryOnError) return true;
-    return this.options.retryOnError({ error, jobName });
+    return this.options.retryOnError({ error, jobName, jobId });
   }
 
   private async runDelay(delay: number) {

--- a/src/lib/cron/core/index.ts
+++ b/src/lib/cron/core/index.ts
@@ -69,15 +69,15 @@ export class RetryCronJob implements RetryObserver {
 
   public async update(ctx: NotifyContext): Promise<void> {
     if (ctx.type === "add") {
-      this.jobs.set(ctx.name, 0);
+      this.jobs.set(ctx.jobId, 0);
       return;
     }
 
-    const jobAttempts = this.jobs.get(ctx.name);
+    const jobAttempts = this.jobs.get(ctx.jobId);
     if (jobAttempts === undefined) return;
 
     if (ctx.type === "success") {
-      this.jobs.set(ctx.name, 0);
+      this.jobs.set(ctx.jobId, 0);
       return;
     }
 
@@ -172,17 +172,19 @@ export class Cron extends JobWithRetry {
   private cron: Bun.CronJob | null = null;
   private manager?: RetryManager;
   private common: CommonCronUtilities;
+  private jobId: string;
 
   public constructor(options: CronOptions) {
     super();
     this.options = options;
+    this.jobId = crypto.randomUUID();
     this.status = "idle";
     this.common = new CommonCronUtilities();
 
     if (this.options.retry) {
       this.manager = new RetryManager();
       this.manager.subscribe(this.options.retry);
-      this.manager.notify({ type: "add", name: this.getJobName() });
+      this.manager.notify({ type: "add", jobId: this.jobId });
     }
   }
 
@@ -210,7 +212,7 @@ export class Cron extends JobWithRetry {
           if (this.manager) {
             await this.manager.notify({
               type: "success",
-              name: this.getJobName(),
+              jobId: this.jobId,
             });
           }
 
@@ -223,6 +225,7 @@ export class Cron extends JobWithRetry {
             error: handlerError,
             job: this,
             name: this.getJobName(),
+            jobId: this.jobId,
           };
 
           await this.manager.notify(errorContext);

--- a/src/lib/cron/core/types.ts
+++ b/src/lib/cron/core/types.ts
@@ -55,10 +55,11 @@ type NotifyErrorContext = {
   job: JobWithRetry;
   error: Error;
   name: string;
+  jobId: string;
 };
 
-type NotifyAddRetryContext = { type: "add"; name: string };
-type NotifySuccessContext = { type: "success"; name: string };
+type NotifyAddRetryContext = { type: "add"; jobId: string };
+type NotifySuccessContext = { type: "success"; jobId: string };
 
 export type NotifyContext =
   | NotifySuccessContext

--- a/src/lib/cron/core/types.ts
+++ b/src/lib/cron/core/types.ts
@@ -34,12 +34,12 @@ export type RetryOptions = {
 export type CronBaseOptions = {
   name: string;
   schedule: ScheduleType;
-  jobId?: string;
 };
 
 export type CronOptions = CronBaseOptions & {
   handler: () => unknown;
   retry?: RetryObserver;
+  jobId?: string;
 };
 
 export type CronOSOptions = CronBaseOptions & {

--- a/src/lib/cron/core/types.ts
+++ b/src/lib/cron/core/types.ts
@@ -31,6 +31,7 @@ export type RetryOptions = {
 export type CronBaseOptions = {
   name: string;
   schedule: ScheduleType;
+  jobId?: string;
 };
 
 export type CronOptions = CronBaseOptions & {

--- a/src/lib/cron/core/types.ts
+++ b/src/lib/cron/core/types.ts
@@ -4,6 +4,7 @@ export type ErrorMetadataType = {
   name: string;
   failedAt: number;
   error: Error;
+  jobId: string;
 };
 
 export type ScheduleType = Bun.CronWithAutocomplete | MinutelyAlias;
@@ -14,11 +15,13 @@ export type OnFailedAttemptContextType = {
   retriesLeft: number;
   delay: number;
   jobName: string;
+  jobId: string;
 };
 
 export type RetryOnErrorContextType = {
   error: Error;
   jobName: string;
+  jobId: string;
 };
 
 export type RetryOptions = {


### PR DESCRIPTION
Improved previous implementation on state isolation between in-process cron jobs. Instead of using the job's name, the `Cron` class will generate a random uuid for ensuring uniqueness between jobs with the same instance of `RetryCronJob` class. 

The implementation took inspiration on how `semola/worflow` handle execution ids.