### PR TITLE
Add concurrency option to semola/workflow

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -35,7 +35,7 @@ const started = await onboardUser.start({
   email: "leo@example.com",
 });
 
-// start() schedules work in the background, so this is initially pending
+// start() enqueues work for background workers, so this is initially pending
 let execution = await onboardUser.get(started.executionId);
 
 while (execution.status === "pending" || execution.status === "running") {
@@ -79,10 +79,11 @@ for (const item of pending) {
 
 ### Instance methods
 
-- `start(input, options?)` persists and schedules a new execution, then returns its ID with `pending` status.
-- `resume(executionId)` schedules a failed or interrupted execution, then returns its ID with `pending` status.
+- `start(input, options?)` persists and enqueues a new execution on a Redis list, then returns its ID with `pending` status.
+- `resume(executionId)` enqueues a failed or interrupted execution, then returns its ID with `pending` status.
 - `get(executionId)` returns execution status, timestamps, and completed steps.
 - `cancel(executionId)` marks execution as cancelled.
+- `stop()` stops worker loops and waits for in-flight executions to finish.
 - `name` - workflow name used for registration and Redis meta.
 
 ### Top-level helpers
@@ -90,13 +91,17 @@ for (const item of pending) {
 - `listWorkflows(redis, options?)` scans all executions. Options: `name`, `status`, `unlockedOnly`.
 - `resumeWorkflow(redis, executionId)` reads the stored workflow name and resumes via the process registry.
 
-`start()`, `resume()`, and `resumeWorkflow()` run handlers in the background. Use `get(executionId)` to read the eventual result or failure.
+`start()`, `resume()`, and `resumeWorkflow()` enqueue work for background workers. Use `get(executionId)` to read the eventual result or failure.
+
+Workers are per process. With multiple replicas, each process runs up to `concurrency` executions; Redis distributes jobs across them. Total parallelism is roughly the sum of each process's concurrency.
 
 ## Options
 
 - **`name`** (required) - Workflow name stored in Redis meta and used for process registration. Must be unique in the process. Execution IDs must be unique across all workflows sharing a Redis database.
 - **`redis`** (required) - Bun Redis client instance
 - **`handler`** (required) - Workflow function with `step` helper
+- **`concurrency`** - Number of parallel workers in this process (default: 1)
+- **`pollInterval`** - Milliseconds to wait when the job list is empty (default: 100)
 - **`retries`** - Step retry attempts before marking the workflow `failed` (default: 3). Set to `0` to fail on the first error with no retries.
 - **`retryBackoff`** - Optional `{ baseDelay, multiplier, maxDelay }` for retry delays (defaults: 1000ms, 2x, 30000ms cap)
 - **`hooks`** - Optional lifecycle callbacks (see [Hooks](#hooks))
@@ -111,7 +116,26 @@ Executions use flat keys keyed only by execution id:
 - `workflow:execution:{id}:steps`
 - `workflow:execution:{id}:lock`
 
-The workflow `name` is stored as a field on the meta hash (not in the key path).
+Pending work for a workflow name uses a Redis list:
+
+- `workflow:{name}:jobs`
+
+The workflow `name` is also stored as a field on the meta hash (not in the execution key path).
+
+### Concurrency example
+
+```typescript
+const onboardUser = defineWorkflow<User>({
+  name: "onboard-user",
+  redis: redisClient,
+  concurrency: 3,
+  handler: async ({ input, step }) => {
+    await step("send-email", async () => {
+      await emailClient.send(input.email, "Welcome!");
+    });
+  },
+});
+```
 
 ## Retries
 

--- a/src/lib/workflow/index.test.ts
+++ b/src/lib/workflow/index.test.ts
@@ -9,6 +9,7 @@ import {
 class MockRedisClient {
   private hashes = new Map<string, Map<string, string>>();
   private strings = new Map<string, string>();
+  private lists = new Map<string, string[]>();
   private expirations = new Map<string, number>();
   private failCommands = new Set<string>();
   private hsetCallsBeforeFail: number | null = null;
@@ -37,7 +38,9 @@ class MockRedisClient {
     return regex.test(key);
   }
 
-  public setCommandFailure(command: "hset" | "hget" | "set" | "get" | "del") {
+  public setCommandFailure(
+    command: "hset" | "hget" | "set" | "get" | "del" | "lpush" | "rpop",
+  ) {
     this.failCommands.add(command);
   }
 
@@ -270,7 +273,39 @@ class MockRedisClient {
       count++;
     }
 
+    if (this.lists.delete(key)) {
+      count++;
+    }
+
     return count;
+  }
+
+  public async lpush(key: string, value: string) {
+    if (this.failCommands.has("lpush")) {
+      throw new Error("lpush failed");
+    }
+
+    if (!this.lists.has(key)) {
+      this.lists.set(key, []);
+    }
+
+    this.lists.get(key)?.unshift(value);
+
+    return this.lists.get(key)?.length ?? 0;
+  }
+
+  public async rpop(key: string) {
+    if (this.failCommands.has("rpop")) {
+      throw new Error("rpop failed");
+    }
+
+    const list = this.lists.get(key);
+
+    if (!list || list.length === 0) {
+      return null;
+    }
+
+    return list.pop() ?? null;
   }
 
   public async send(command: string, args: string[]) {
@@ -410,6 +445,7 @@ const createWorkflowWithEchoResult = (
   return defineWorkflow<{ id: number }, string>({
     name,
     redis,
+    pollInterval: 1,
     handler: async ({ input, step }) => {
       if (callCounter) {
         callCounter.value++;
@@ -435,6 +471,7 @@ const createTwoStepFailResumeWorkflow = (
     name,
     redis,
     retries: 0,
+    pollInterval: 1,
     handler: async ({ input, step }) => {
       await step("step-1", async () => {
         executedSteps.push(`step-1:${input.id}`);
@@ -458,8 +495,8 @@ const createTwoStepFailResumeWorkflow = (
 };
 
 describe("workflow", () => {
-  beforeEach(() => {
-    clearWorkflowRegistry();
+  beforeEach(async () => {
+    await clearWorkflowRegistry();
   });
 
   test("starts workflow in the background and stores result", async () => {
@@ -1307,6 +1344,7 @@ describe("workflow", () => {
       const workflow = defineWorkflow<{ id: number }, string>({
         name: "step-serializers",
         redis,
+        pollInterval: 1,
         serializeStepOutput: (value) => {
           serializeCalled++;
           return `custom:${JSON.stringify(value)}`;
@@ -1756,6 +1794,7 @@ describe("workflow", () => {
         name: "default-backoff-delay",
         redis,
         retries: 3,
+        pollInterval: 1,
         hooks: {
           onRetry: (context) => {
             retryDelays.push(context.nextRetryDelayMs);
@@ -1775,7 +1814,14 @@ describe("workflow", () => {
         { executionId: "default-backoff-1" },
       );
 
-      await sleep(20);
+      for (let attempt = 0; attempt < 3000; attempt++) {
+        if (retryDelays.length > 0) {
+          break;
+        }
+
+        await sleep(1);
+      }
+
       await workflow.cancel("default-backoff-1");
 
       const execution = await waitForExecution(workflow, "default-backoff-1");
@@ -1947,7 +1993,7 @@ describe("workflow", () => {
       await workflow.start({ id: 1 }, { executionId: "resume-unreg-1" });
       await waitForExecution(workflow, "resume-unreg-1");
 
-      clearWorkflowRegistry();
+      await clearWorkflowRegistry();
 
       await expect(
         resumeWorkflow(redis, "resume-unreg-1"),
@@ -2026,5 +2072,45 @@ describe("workflow", () => {
         message: "Workflow execution owned-by-a not found",
       });
     });
+  });
+
+  test("respects concurrency limits", async () => {
+    const redis = createRedis();
+    let maxConcurrent = 0;
+    let currentConcurrent = 0;
+
+    const workflow = defineWorkflow<{ id: number }, string>({
+      name: "concurrency-cap",
+      redis,
+      concurrency: 2,
+      pollInterval: 1,
+      handler: async ({ input, step }) => {
+        currentConcurrent++;
+        maxConcurrent = Math.max(maxConcurrent, currentConcurrent);
+
+        await step("work", async () => {
+          await sleep(50);
+          return input.id;
+        });
+
+        currentConcurrent--;
+        return "done";
+      },
+    });
+
+    await workflow.start({ id: 1 }, { executionId: "conc-1" });
+    await workflow.start({ id: 2 }, { executionId: "conc-2" });
+    await workflow.start({ id: 3 }, { executionId: "conc-3" });
+    await workflow.start({ id: 4 }, { executionId: "conc-4" });
+
+    await waitForExecution(workflow, "conc-1");
+    await waitForExecution(workflow, "conc-2");
+    await waitForExecution(workflow, "conc-3");
+    await waitForExecution(workflow, "conc-4");
+
+    expect(maxConcurrent).toBeLessThanOrEqual(2);
+    expect(maxConcurrent).toBeGreaterThan(0);
+
+    await workflow.stop();
   });
 });

--- a/src/lib/workflow/index.test.ts
+++ b/src/lib/workflow/index.test.ts
@@ -2098,19 +2098,21 @@ describe("workflow", () => {
       },
     });
 
-    await workflow.start({ id: 1 }, { executionId: "conc-1" });
-    await workflow.start({ id: 2 }, { executionId: "conc-2" });
-    await workflow.start({ id: 3 }, { executionId: "conc-3" });
-    await workflow.start({ id: 4 }, { executionId: "conc-4" });
+    try {
+      await workflow.start({ id: 1 }, { executionId: "conc-1" });
+      await workflow.start({ id: 2 }, { executionId: "conc-2" });
+      await workflow.start({ id: 3 }, { executionId: "conc-3" });
+      await workflow.start({ id: 4 }, { executionId: "conc-4" });
 
-    await waitForExecution(workflow, "conc-1");
-    await waitForExecution(workflow, "conc-2");
-    await waitForExecution(workflow, "conc-3");
-    await waitForExecution(workflow, "conc-4");
+      await waitForExecution(workflow, "conc-1");
+      await waitForExecution(workflow, "conc-2");
+      await waitForExecution(workflow, "conc-3");
+      await waitForExecution(workflow, "conc-4");
 
-    expect(maxConcurrent).toBeLessThanOrEqual(2);
-    expect(maxConcurrent).toBeGreaterThan(0);
-
-    await workflow.stop();
+      expect(maxConcurrent).toBeLessThanOrEqual(2);
+      expect(maxConcurrent).toBeGreaterThan(1);
+    } finally {
+      await workflow.stop();
+    }
   });
 });

--- a/src/lib/workflow/index.ts
+++ b/src/lib/workflow/index.ts
@@ -448,6 +448,10 @@ class WorkflowDefinition<TInput, TResult> {
   }
 
   private async enqueueExecution(executionId: string) {
+    if (!this.running) {
+      throw new StateError(`Workflow ${this.options.name} has been stopped`);
+    }
+
     const [enqueueError] = await mightThrow(
       this.options.redis.lpush(this.jobsKey(), executionId),
     );

--- a/src/lib/workflow/index.ts
+++ b/src/lib/workflow/index.ts
@@ -30,6 +30,9 @@ const DEFAULT_RETRIES = 3;
 const DEFAULT_RETRY_BASE_DELAY = 1000;
 const DEFAULT_RETRY_MULTIPLIER = 2;
 const DEFAULT_RETRY_MAX_DELAY = 30000;
+const DEFAULT_CONCURRENCY = 1;
+const DEFAULT_POLL_INTERVAL = 100;
+const SHUTDOWN_POLL_INTERVAL = 10;
 const META_KEY_PREFIX = "workflow:execution:";
 const META_KEY_SUFFIX = ":meta";
 
@@ -181,6 +184,10 @@ class WorkflowDefinition<TInput, TResult> {
   private retryBaseDelay: number;
   private retryMultiplier: number;
   private retryMaxDelay: number;
+  private concurrency: number;
+  private pollInterval: number;
+  private running = true;
+  private activeWorkers = 0;
 
   public constructor(options: WorkflowOptions<TInput, TResult>) {
     this.options = options;
@@ -192,6 +199,8 @@ class WorkflowDefinition<TInput, TResult> {
       options.retryBackoff?.multiplier ?? DEFAULT_RETRY_MULTIPLIER;
     this.retryMaxDelay =
       options.retryBackoff?.maxDelay ?? DEFAULT_RETRY_MAX_DELAY;
+    this.concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
+    this.pollInterval = options.pollInterval ?? DEFAULT_POLL_INTERVAL;
 
     assert.ok(
       Number.isFinite(this.retries) && this.retries >= 0,
@@ -209,6 +218,16 @@ class WorkflowDefinition<TInput, TResult> {
       Number.isFinite(this.retryMaxDelay) && this.retryMaxDelay > 0,
       "Invalid retryBackoff.maxDelay: must be a positive finite number",
     );
+    assert.ok(
+      Number.isFinite(this.concurrency) && this.concurrency > 0,
+      "Invalid concurrency: must be a positive finite number",
+    );
+    assert.ok(
+      Number.isFinite(this.pollInterval) && this.pollInterval >= 0,
+      "Invalid pollInterval: must be a non-negative finite number",
+    );
+
+    this.startWorkers();
   }
 
   private runHook<T>(hook: () => T | Promise<T>) {
@@ -227,7 +246,7 @@ class WorkflowDefinition<TInput, TResult> {
 
     await this.createExecution(executionId, input);
 
-    this.scheduleExecution(executionId, input);
+    await this.enqueueExecution(executionId);
 
     return { executionId, status: "pending" } satisfies WorkflowStartResult;
   }
@@ -249,9 +268,28 @@ class WorkflowDefinition<TInput, TResult> {
       } satisfies WorkflowStartResult;
     }
 
-    this.scheduleExecution(executionId, execution.input);
+    if (execution.status === "failed") {
+      const timestamp = now();
+
+      await this.setMeta(executionId, "status", "pending");
+      await this.setMeta(executionId, "updatedAt", String(timestamp));
+      await this.setMeta(executionId, "error", "");
+      await this.setMeta(executionId, "failedAt", "");
+    }
+
+    await this.enqueueExecution(executionId);
 
     return { executionId, status: "pending" } satisfies WorkflowStartResult;
+  }
+
+  public async stop() {
+    this.running = false;
+
+    while (this.activeWorkers > 0) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, SHUTDOWN_POLL_INTERVAL),
+      );
+    }
   }
 
   public async get(executionId: string) {
@@ -395,16 +433,93 @@ class WorkflowDefinition<TInput, TResult> {
     }
   }
 
-  private scheduleExecution(executionId: string, input: TInput) {
-    queueMicrotask(() => {
-      void this.executeInBackground(executionId, input);
-    });
+  private jobsKey() {
+    return `workflow:${this.options.name}:jobs`;
+  }
+
+  private waitForPollInterval() {
+    return new Promise((resolve) => setTimeout(resolve, this.pollInterval));
+  }
+
+  private async enqueueExecution(executionId: string) {
+    const [enqueueError] = await mightThrow(
+      this.options.redis.lpush(this.jobsKey(), executionId),
+    );
+
+    if (enqueueError) {
+      throw new WorkflowError(`Unable to enqueue execution ${executionId}`);
+    }
+  }
+
+  private startWorkers() {
+    for (let i = 0; i < this.concurrency; i++) {
+      this.processJobs();
+    }
+  }
+
+  private async processJobs() {
+    while (this.running) {
+      const queueKey = this.jobsKey();
+
+      const [popError, executionId] = await mightThrow(
+        this.options.redis.rpop(queueKey),
+      );
+
+      if (popError) {
+        await this.waitForPollInterval();
+        continue;
+      }
+
+      if (!executionId) {
+        await this.waitForPollInterval();
+        continue;
+      }
+
+      if (!this.running) {
+        await mightThrow(this.options.redis.lpush(queueKey, executionId));
+        break;
+      }
+
+      this.activeWorkers++;
+
+      await mightThrow(this.runQueuedExecution(executionId));
+      this.activeWorkers--;
+    }
+  }
+
+  private async runQueuedExecution(executionId: string) {
+    const [loadError, execution] = await mightThrow(this.get(executionId));
+
+    if (loadError) {
+      return;
+    }
+
+    if (!execution) {
+      return;
+    }
+
+    if (execution.status === "completed") {
+      return;
+    }
+
+    if (execution.status === "cancelled") {
+      return;
+    }
+
+    await this.executeInBackground(executionId, execution.input);
   }
 
   private async executeInBackground(executionId: string, input: TInput) {
     const [executionError] = await mightThrow(this.execute(executionId, input));
 
     if (!executionError) {
+      return;
+    }
+
+    if (
+      executionError instanceof LockError &&
+      executionError.message.includes("already running")
+    ) {
       return;
     }
 
@@ -1115,8 +1230,13 @@ class WorkflowDefinition<TInput, TResult> {
   }
 }
 
-export const clearWorkflowRegistry = () => {
+export const clearWorkflowRegistry = async () => {
+  const workflows = [...workflowRegistry.values()];
   workflowRegistry.clear();
+
+  for (const workflow of workflows) {
+    await workflow.stop();
+  }
 };
 
 const readListItem = async (
@@ -1317,6 +1437,7 @@ export const defineWorkflow = <TInput, TResult = void>(
     resume: (executionId) => workflow.resume(executionId),
     get: (executionId) => workflow.get(executionId),
     cancel: (executionId) => workflow.cancel(executionId),
+    stop: () => workflow.stop(),
   };
 
   workflowRegistry.set(options.name, api as Workflow<unknown, unknown>);

--- a/src/lib/workflow/index.ts
+++ b/src/lib/workflow/index.ts
@@ -285,7 +285,13 @@ class WorkflowDefinition<TInput, TResult> {
   public async stop() {
     this.running = false;
 
+    const deadline = now() + this.lockTTL;
+
     while (this.activeWorkers > 0) {
+      if (now() >= deadline) {
+        return;
+      }
+
       await new Promise((resolve) =>
         setTimeout(resolve, SHUTDOWN_POLL_INTERVAL),
       );

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -102,6 +102,8 @@ export type WorkflowOptions<TInput, TResult> = {
   retryBackoff?: WorkflowRetryBackoff;
   hooks?: WorkflowHooks<TInput, TResult>;
   lockTTL?: number;
+  concurrency?: number;
+  pollInterval?: number;
   serializeInput?: SerializeValue<TInput>;
   deserializeInput?: DeserializeValue<TInput>;
   serializeResult?: SerializeValue<TResult>;
@@ -169,4 +171,5 @@ export type Workflow<TInput, TResult> = {
   resume: (executionId: string) => Promise<WorkflowStartResult>;
   get: (executionId: string) => Promise<WorkflowExecution<TInput, TResult>>;
   cancel: (executionId: string) => Promise<WorkflowCancelResult>;
+  stop: () => Promise<void>;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable workflow concurrency and polling intervals.
  - Added a `stop()` method for gracefully shutting down workflow processing.
  - Workflow jobs are now queued and processed by background workers.
  - Failed executions can be resumed by re-queuing them.

- **Bug Fixes**
  - Improved handling of duplicate or already-running executions.
  - Enhanced shutdown behavior to wait for active work to finish.

- **Documentation**
  - Updated workflow usage, API, queue, and concurrency documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->