### PR TITLE
Implement step-level fail command

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -141,6 +141,20 @@ const onboardUser = defineWorkflow<User>({
 
 Failed steps retry automatically with exponential backoff before the workflow is marked `failed`. By default, each step gets 3 retries (4 total attempts). This applies to every workflow unless you override `retries`.
 
+Call `fail(message)` inside a step to skip retries and fail the workflow immediately:
+
+```typescript
+handler: async ({ step }) => {
+  await step("charge", async ({ input, fail }) => {
+    if (!input.cardId) {
+      fail("missing card");
+    }
+  });
+},
+```
+
+Step handlers receive `{ input, signal, fail }`.
+
 Only successful step runs are persisted to Redis. Side effects inside a step may run more than once during retries, so keep step handlers idempotent.
 
 `cancel(executionId)` works during retry backoff as well as between steps.
@@ -203,7 +217,7 @@ const onboardUser = defineWorkflow<User, void>({
 
 - `onStart` runs each time the handler executes, including on `resume()`.
 - `onRetry` runs before each step retry backoff delay.
-- `onError` runs when a step fails after all retries are exhausted.
+- `onError` runs when a step fails after all retries are exhausted, or immediately after `fail()`.
 - `onComplete` runs after a successful execution.
 - `onCancel` runs when execution ends as cancelled.
 

--- a/src/lib/workflow/errors.ts
+++ b/src/lib/workflow/errors.ts
@@ -46,3 +46,10 @@ export class CancelledError extends Error {
     this.name = "CancelledError";
   }
 }
+
+export class StepFailedError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "StepFailedError";
+  }
+}

--- a/src/lib/workflow/index.test.ts
+++ b/src/lib/workflow/index.test.ts
@@ -1478,6 +1478,56 @@ describe("workflow", () => {
       expect(stepAttempts).toBe(3);
     });
 
+    test("fail skips retries and fails the workflow", async () => {
+      const redis = createRedis();
+      let stepAttempts = 0;
+      let onRetryCalls = 0;
+      const errorContexts: Array<{
+        stepName: string;
+        error: string;
+        totalAttempts: number;
+      }> = [];
+
+      const workflow = defineWorkflow<{ id: number }, string>({
+        name: "step-fail",
+        redis,
+        retries: 3,
+        retryBackoff: fastRetryBackoff,
+        hooks: {
+          onRetry: () => {
+            onRetryCalls++;
+          },
+          onError: (context) => {
+            errorContexts.push({
+              stepName: context.stepName,
+              error: context.error,
+              totalAttempts: context.totalAttempts,
+            });
+          },
+        },
+        handler: async ({ step }) => {
+          await step("risky", async ({ fail }) => {
+            stepAttempts++;
+            fail("permanent");
+          });
+
+          return "done";
+        },
+      });
+
+      await workflow.start({ id: 1 }, { executionId: "step-fail-1" });
+      const execution = await waitForExecution(workflow, "step-fail-1");
+
+      expect(execution.status).toBe("failed");
+      expect(execution.error).toBe("permanent");
+      expect(stepAttempts).toBe(1);
+      expect(onRetryCalls).toBe(0);
+      expect(errorContexts.length).toBe(1);
+      expect(errorContexts[0]?.stepName).toBe("risky");
+      expect(errorContexts[0]?.error).toBe("permanent");
+      expect(errorContexts[0]?.totalAttempts).toBe(1);
+    });
+
     test("calls onRetry with correct context", async () => {
       const redis = createRedis();
       const retryContexts: Array<{

--- a/src/lib/workflow/index.ts
+++ b/src/lib/workflow/index.ts
@@ -7,9 +7,11 @@ import {
   NotFoundError,
   SerializationError,
   StateError,
+  StepFailedError,
   WorkflowError,
 } from "./errors.js";
 import type {
+  StepHandler,
   StepSnapshot,
   Workflow,
   WorkflowCancelResult,
@@ -606,10 +608,7 @@ class WorkflowDefinition<TInput, TResult> {
 
     const step = async <TStep>(
       name: string,
-      handler: (
-        inputValue: TInput,
-        signal: AbortSignal,
-      ) => TStep | Promise<TStep>,
+      handler: StepHandler<TInput, TStep>,
     ) => {
       await this.throwIfCancelled(executionId, () => {
         controller.abort();
@@ -749,10 +748,7 @@ class WorkflowDefinition<TInput, TResult> {
     executionId: string,
     input: TInput,
     stepName: string,
-    handler: (
-      inputValue: TInput,
-      signal: AbortSignal,
-    ) => TStep | Promise<TStep>,
+    handler: StepHandler<TInput, TStep>,
     signal: AbortSignal,
     abort: () => void,
   ) {
@@ -760,11 +756,21 @@ class WorkflowDefinition<TInput, TResult> {
 
     const errorHistory: WorkflowStepErrorRecord[] = [];
 
+    const fail = (message: string): never => {
+      throw new StepFailedError(message);
+    };
+
     while (true) {
       await this.throwIfCancelled(executionId, abort);
 
       const stepOutcome = await mightThrow(
-        Promise.resolve(handler(input, signal)),
+        Promise.resolve(
+          handler({
+            input,
+            signal,
+            fail,
+          }),
+        ),
       );
 
       const [stepError, output] = stepOutcome;
@@ -783,7 +789,10 @@ class WorkflowDefinition<TInput, TResult> {
         timestamp: now(),
       });
 
-      if (attempt <= this.retries) {
+      const shouldRetry =
+        !(stepError instanceof StepFailedError) && attempt <= this.retries;
+
+      if (shouldRetry) {
         const nextRetryDelayMs = this.computeBackoffDelay(attempt);
 
         if (this.options.hooks?.onRetry) {
@@ -1462,9 +1471,11 @@ export {
   NotFoundError,
   SerializationError,
   StateError,
+  StepFailedError,
   WorkflowError,
 } from "./errors.js";
 export type {
+  StepContext,
   StepHandler,
   Workflow,
   WorkflowExecution,

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -25,9 +25,14 @@ export type WorkflowExecution<TInput, TResult> = {
   steps: StepSnapshot[];
 };
 
+export type StepContext<TInput> = {
+  input: TInput;
+  signal: AbortSignal;
+  fail: (message: string) => never;
+};
+
 export type StepHandler<TInput, TStep> = (
-  input: TInput,
-  signal: AbortSignal,
+  context: StepContext<TInput>,
 ) => TStep | Promise<TStep>;
 
 export type WorkflowHandlerContext<TInput> = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Step handlers can now immediately fail a workflow with a custom message.
  * Immediate failures skip retries and trigger error handling once.
  * Step handler context now includes input, cancellation signal, and failure controls.

* **Documentation**
  * Added guidance and examples for immediate step failures.
  * Clarified when error hooks are called.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->