### PR TITLE
fix(workflow): atomic create for custom execution IDs

### DIFF
--- a/src/lib/workflow/index.test.ts
+++ b/src/lib/workflow/index.test.ts
@@ -1107,7 +1107,7 @@ describe("workflow", () => {
 
     test("fails when hset fails during completed status write", async () => {
       const redis = createRedis() as MockRedisClient & Bun.RedisClient;
-      redis.failHsetAfterNCalls(2);
+      redis.failHsetAfterNCalls(3);
 
       const workflow = defineWorkflow<{ id: number }, string>({
         name: "hset-completed-fail",

--- a/src/lib/workflow/index.test.ts
+++ b/src/lib/workflow/index.test.ts
@@ -39,7 +39,15 @@ class MockRedisClient {
   }
 
   public setCommandFailure(
-    command: "hset" | "hget" | "set" | "get" | "del" | "lpush" | "rpop",
+    command:
+      | "hset"
+      | "hget"
+      | "set"
+      | "get"
+      | "del"
+      | "lpush"
+      | "rpop"
+      | "eval",
   ) {
     this.failCommands.add(command);
   }
@@ -313,6 +321,10 @@ class MockRedisClient {
       throw new Error(`Unsupported command: ${command}`);
     }
 
+    if (this.failCommands.has("eval")) {
+      throw new Error("eval failed");
+    }
+
     const script = args[0];
     const numKeys = parseInt(args[1] ?? "0", 10);
     const keys = args.slice(2, 2 + numKeys);
@@ -571,6 +583,38 @@ describe("workflow", () => {
     ).rejects.toMatchObject({
       name: "StateError",
       message: "Workflow execution exec-1 already exists",
+    });
+  });
+
+  test("rejects concurrent duplicate custom execution ids", async () => {
+    const redis = createRedis();
+
+    const workflow = defineWorkflow<{ id: number }, string>({
+      name: "concurrent-dupe",
+      redis,
+      handler: async () => "ok",
+    });
+
+    const results = await Promise.allSettled([
+      workflow.start({ id: 1 }, { executionId: "exec-race" }),
+      workflow.start({ id: 2 }, { executionId: "exec-race" }),
+    ]);
+
+    const fulfilled = results.filter((result) => result.status === "fulfilled");
+    const rejected = results.filter((result) => result.status === "rejected");
+
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+
+    const failure = rejected[0];
+
+    if (!failure || failure.status !== "rejected") {
+      throw new Error("expected one start to reject");
+    }
+
+    expect(failure.reason).toMatchObject({
+      name: "StateError",
+      message: "Workflow execution exec-race already exists",
     });
   });
 
@@ -1003,7 +1047,7 @@ describe("workflow", () => {
   });
 
   describe("redis write failure matrix", () => {
-    const commands: Array<"hset" | "set"> = ["hset", "set"];
+    const commands: Array<"eval" | "set"> = ["eval", "set"];
 
     for (const command of commands) {
       test(`handles redis ${command} failures during start`, async () => {
@@ -1015,7 +1059,7 @@ describe("workflow", () => {
           redis,
         );
 
-        if (command === "hset") {
+        if (command === "eval") {
           await expect(workflow.start({ id: 1 })).rejects.toMatchObject({
             name: "WorkflowError",
             message: expect.stringContaining(
@@ -1040,20 +1084,30 @@ describe("workflow", () => {
   });
 
   describe("execute hset failure matrix", () => {
-    test("fails when hset fails during running status write", async () => {
+    test("leaves execution pending when running status write fails", async () => {
       const redis = createRedis() as MockRedisClient & Bun.RedisClient;
       redis.failHsetAfterNCalls(0);
 
       const workflow = createWorkflowWithEchoResult("hset-running-fail", redis);
 
-      await expect(workflow.start({ id: 1 })).rejects.toMatchObject({
-        name: "WorkflowError",
-      });
+      const started = await workflow.start(
+        { id: 1 },
+        { executionId: "hset-running-fail-1" },
+      );
+
+      expect(started.status).toBe("pending");
+
+      await sleep(50);
+
+      const execution = await workflow.get(started.executionId);
+
+      expect(execution.status).toBe("pending");
+      expect(redis.hsetFailureCount).toBeGreaterThanOrEqual(1);
     });
 
     test("fails when hset fails during completed status write", async () => {
       const redis = createRedis() as MockRedisClient & Bun.RedisClient;
-      redis.failHsetAfterNCalls(3);
+      redis.failHsetAfterNCalls(2);
 
       const workflow = defineWorkflow<{ id: number }, string>({
         name: "hset-completed-fail",
@@ -1145,7 +1199,7 @@ describe("workflow", () => {
       };
 
       try {
-        redis.failHsetAfterNCalls(1);
+        redis.failHsetAfterNCalls(0);
 
         const workflow = createWorkflowWithEchoResult(
           "background-record-failure",

--- a/src/lib/workflow/index.ts
+++ b/src/lib/workflow/index.ts
@@ -464,12 +464,6 @@ class WorkflowDefinition<TInput, TResult> {
 
     const timestamp = now();
 
-    const existingStatus = await this.getMeta(executionId, "status");
-
-    if (existingStatus) {
-      throw new StateError(`Workflow execution ${executionId} already exists`);
-    }
-
     const metadata: WorkflowMeta = {
       name: this.options.name,
       status: "pending",
@@ -485,14 +479,32 @@ class WorkflowDefinition<TInput, TResult> {
       partitionKey: this.resolvePartitionKey(input, startOptions),
     };
 
-    const [writeError] = await mightThrow(
-      this.options.redis.hset(this.metaKey(executionId), metadata),
+    const script =
+      "if redis.call('EXISTS', KEYS[1]) == 1 then return 0 end return redis.call('HSET', KEYS[1], unpack(ARGV))";
+
+    const argv: string[] = [];
+
+    for (const [field, value] of Object.entries(metadata)) {
+      argv.push(field, value);
+    }
+
+    const [writeError, created] = await mightThrow(
+      this.options.redis.send("EVAL", [
+        script,
+        "1",
+        this.metaKey(executionId),
+        ...argv,
+      ]),
     );
 
     if (writeError) {
       throw new WorkflowError(
         `Unable to persist metadata for execution ${executionId}`,
       );
+    }
+
+    if (created === 0) {
+      throw new StateError(`Workflow execution ${executionId} already exists`);
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes SEM-103: race condition when two callers use `start()` with the same custom `executionId` concurrently.

`createExecution` previously did a non-atomic check-then-`HSET` (read `status`, then write metadata). Two concurrent starts could both pass the existence check and overwrite each other.

This change uses a Redis Lua script to atomically create execution metadata only when the meta key does not exist (`EXISTS` + `HSET` in one `EVAL`). The second caller gets `StateError: Workflow execution {id} already exists`.

## Changes

- Replace check-then-hset in `createExecution` with atomic `EVAL` script
- Add test for concurrent duplicate custom execution IDs
- Update mock Redis and related failure-matrix tests for the new create path

## Test plan

- [x] `bun test src/lib/workflow` (118 tests pass)
- [x] `bun check`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SEM-103](https://linear.app/semola/issue/SEM-103/bugworkflows-possible-race-condition-with-custom-ids)

<div><a href="https://cursor.com/agents/bc-3a26f969-7728-42e5-86ef-02e02e4f54a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a26f969-7728-42e5-86ef-02e02e4f54a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate workflow executions when the same custom execution ID is started concurrently.
  * Duplicate execution attempts now reliably fail with a clear state error, while exactly one attempt succeeds.
  * Improved resilience to Redis write failures during workflow startup and status updates, including handling failures from atomic metadata creation.
  * Workflow executions now remain in a pending state when certain status writes fail, rather than being incorrectly rejected.
* **Tests**
  * Expanded and adjusted workflow start failure coverage, including new concurrency and Redis failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->